### PR TITLE
DocumentDB support

### DIFF
--- a/bot/storage-mongo/src/main/kotlin/BotApplicationConfigurationMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/BotApplicationConfigurationMongoDAO.kt
@@ -37,8 +37,8 @@ import org.litote.kmongo.Id
 import org.litote.kmongo.and
 import org.litote.kmongo.deleteOne
 import org.litote.kmongo.deleteOneById
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.findOne

--- a/bot/storage-mongo/src/main/kotlin/DialogFlowMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogFlowMongoDAO.kt
@@ -54,6 +54,7 @@ import ai.tock.bot.mongo.DialogFlowStateTransitionStatCol_.Companion.Application
 import ai.tock.bot.mongo.DialogFlowStateTransitionStatCol_.Companion.Date
 import ai.tock.bot.mongo.DialogFlowStateTransitionStatCol_.Companion.DialogId
 import ai.tock.bot.mongo.DialogFlowStateTransitionStatCol_.Companion.TransitionId
+import ai.tock.shared.ensureIndex
 import ai.tock.shared.error
 import ai.tock.shared.longProperty
 import ai.tock.shared.security.TockObfuscatorService.obfuscate
@@ -66,7 +67,6 @@ import org.litote.kmongo.aggregate
 import org.litote.kmongo.all
 import org.litote.kmongo.and
 import org.litote.kmongo.ascendingSort
-import org.litote.kmongo.ensureIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.findOne

--- a/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
@@ -26,6 +26,8 @@ import ai.tock.bot.mongo.I18nAlternativeIndex_.Companion.Locale
 import ai.tock.bot.mongo.MongoBotConfiguration.asyncDatabase
 import ai.tock.bot.mongo.MongoBotConfiguration.database
 import ai.tock.shared.defaultLocale
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import ai.tock.shared.error
 import ai.tock.shared.longProperty
 import ai.tock.shared.watch
@@ -54,8 +56,6 @@ import org.litote.kmongo.combine
 import org.litote.kmongo.currentDate
 import org.litote.kmongo.deleteOne
 import org.litote.kmongo.elemMatch
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.excludeId
 import org.litote.kmongo.fields

--- a/bot/storage-mongo/src/main/kotlin/MongoUserLock.kt
+++ b/bot/storage-mongo/src/main/kotlin/MongoUserLock.kt
@@ -31,7 +31,7 @@ import org.litote.kmongo.Data
 import org.litote.kmongo.Id
 import org.litote.kmongo.and
 import org.litote.kmongo.deleteOneById
-import org.litote.kmongo.ensureIndex
+import ai.tock.shared.ensureIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOneById
 import org.litote.kmongo.getCollection

--- a/bot/storage-mongo/src/main/kotlin/StoryDefinitionConfigurationMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/StoryDefinitionConfigurationMongoDAO.kt
@@ -46,8 +46,8 @@ import org.litote.kmongo.and
 import org.litote.kmongo.ascending
 import org.litote.kmongo.contains
 import org.litote.kmongo.deleteOneById
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.findOne

--- a/bot/storage-mongo/src/main/kotlin/TestPlanMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/TestPlanMongoDAO.kt
@@ -28,7 +28,7 @@ import org.litote.kmongo.Id
 import org.litote.kmongo.ascendingSort
 import org.litote.kmongo.deleteOneById
 import org.litote.kmongo.descendingSort
-import org.litote.kmongo.ensureIndex
+import ai.tock.shared.ensureIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOneById
 import org.litote.kmongo.getCollection

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -84,8 +84,8 @@ import org.litote.kmongo.contains
 import org.litote.kmongo.deleteOneById
 import org.litote.kmongo.descending
 import org.litote.kmongo.descendingSort
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.findOne

--- a/nlp/front/storage-mongo/src/main/kotlin/ApplicationDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/ApplicationDefinitionMongoDAO.kt
@@ -26,7 +26,7 @@ import ai.tock.nlp.front.storage.mongo.MongoFrontConfiguration.database
 import ai.tock.shared.watch
 import org.litote.kmongo.Id
 import org.litote.kmongo.deleteOneById
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.findOneById

--- a/nlp/front/storage-mongo/src/main/kotlin/ClassifiedSentenceMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/ClassifiedSentenceMongoDAO.kt
@@ -72,8 +72,8 @@ import org.litote.kmongo.and
 import org.litote.kmongo.combine
 import org.litote.kmongo.descendingSort
 import org.litote.kmongo.distinct
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.getCollection

--- a/nlp/front/storage-mongo/src/main/kotlin/EntityTypeDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/EntityTypeDefinitionMongoDAO.kt
@@ -33,7 +33,7 @@ import com.mongodb.client.MongoCollection
 import com.mongodb.client.model.ReplaceOptions
 import mu.KotlinLogging
 import org.litote.kmongo.and
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.getCollection

--- a/nlp/front/storage-mongo/src/main/kotlin/IntentDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/IntentDefinitionMongoDAO.kt
@@ -31,8 +31,8 @@ import org.litote.kmongo.Id
 import org.litote.kmongo.`in`
 import org.litote.kmongo.contains
 import org.litote.kmongo.deleteOneById
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.findOneById

--- a/nlp/front/storage-mongo/src/main/kotlin/ModelBuildTriggerMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/ModelBuildTriggerMongoDAO.kt
@@ -29,7 +29,7 @@ import org.litote.kmongo.Id
 import org.litote.kmongo.and
 import org.litote.kmongo.deleteMany
 import org.litote.kmongo.descendingSort
-import org.litote.kmongo.ensureIndex
+import ai.tock.shared.ensureIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.getCollection
 import org.litote.kmongo.save

--- a/nlp/front/storage-mongo/src/main/kotlin/ParseRequestLogMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/ParseRequestLogMongoDAO.kt
@@ -68,8 +68,8 @@ import org.litote.kmongo.cond
 import org.litote.kmongo.dayOfYear
 import org.litote.kmongo.descendingSort
 import org.litote.kmongo.document
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.excludeId
 import org.litote.kmongo.fields

--- a/nlp/front/storage-mongo/src/main/kotlin/TestModelMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/TestModelMongoDAO.kt
@@ -39,8 +39,8 @@ import ai.tock.shared.namespace
 import org.litote.kmongo.Id
 import org.litote.kmongo.and
 import org.litote.kmongo.descendingSort
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.getCollection

--- a/nlp/model/storage-mongo/src/main/kotlin/NlpApplicationConfigurationMongoDAO.kt
+++ b/nlp/model/storage-mongo/src/main/kotlin/NlpApplicationConfigurationMongoDAO.kt
@@ -27,7 +27,7 @@ import org.litote.kmongo.Data
 import org.litote.jackson.data.JacksonData
 import org.litote.kmongo.descending
 import org.litote.kmongo.descendingSort
-import org.litote.kmongo.ensureIndex
+import ai.tock.shared.ensureIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.find
 import org.litote.kmongo.getCollection

--- a/nlp/model/storage-mongo/src/main/kotlin/NlpEngineModelMongoDAO.kt
+++ b/nlp/model/storage-mongo/src/main/kotlin/NlpEngineModelMongoDAO.kt
@@ -35,7 +35,7 @@ import ai.tock.nlp.model.service.storage.mongo.MongoModelConfiguration.asyncData
 import ai.tock.nlp.model.service.storage.mongo.MongoModelConfiguration.database
 import ai.tock.shared.watch
 import mu.KotlinLogging
-import org.litote.kmongo.ensureIndex
+import ai.tock.shared.ensureIndex
 import java.io.InputStream
 import java.time.Instant
 

--- a/shared/src/main/kotlin/cache/mongo/MongoCache.kt
+++ b/shared/src/main/kotlin/cache/mongo/MongoCache.kt
@@ -28,8 +28,8 @@ import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.and
 import org.litote.kmongo.deleteOne
-import org.litote.kmongo.ensureIndex
-import org.litote.kmongo.ensureUniqueIndex
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
 import org.litote.kmongo.eq
 import org.litote.kmongo.findOne
 import org.litote.kmongo.getCollection


### PR DESCRIPTION
Amazon DocumentDB is a document database service compatible with MongoDB.
https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html

But DocumentDB doesn't support change streams and has a limitation of 32 characters maximum in a compound index.
This pull request allows DocumentDB support in Tock with the environment property _tock_document_db_on_ (false by default).