### PR TITLE
Preserve MDC when launching new thread with the executor

### DIFF
--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -139,6 +139,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-slf4j</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 
         <dependency>
             <groupId>org.jasypt</groupId>


### PR DESCRIPTION
Change to preserve Mapped Diagnostic Context (MDC) when the executor starts a new thread.

_kotlin-logging_ provides support for this.
https://github.com/MicroUtils/kotlin-logging/wiki#mapped-diagnostic-context-mdc-support


Usage :
- Push a contextual information to the MDC in your code :
```
    withLoggingContext("playerId" to this.action.playerId.id) {
        logger.debug { "Hi !" }
    }
```
- Modify the logback pattern to use the contextual information :
`%d{yyyy-MM-dd'T'HH:mm:ss.SSS} [%thread] %-5level %X{playerId} %logger - %msg%n`

