### PR TITLE
Change property name of attachment type to avoid property collision with action type

### DIFF
--- a/bot/storage-mongo/src/main/kotlin/DialogCol.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogCol.kt
@@ -39,6 +39,8 @@ import ai.tock.shared.checkMaxLengthAllowed
 import ai.tock.shared.jackson.AnyValueWrapper
 import ai.tock.shared.security.TockObfuscatorService.obfuscate
 import ai.tock.translator.UserInterfaceType.textChat
+import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
@@ -320,6 +322,8 @@ internal data class DialogCol(
     @JsonTypeName(value = "attachment")
     class SendAttachmentMongoWrapper(
         val url: String,
+        @JsonProperty("attachment_type")
+        @JsonAlias("type")
         val type: SendAttachment.AttachmentType
     ) : ActionMongoWrapper() {
 


### PR DESCRIPTION
There is a potential collision between two properties named "type" in ActionMongoWrapper when serialized in database.
The first property represents the action type, the second the attachment type.

To illustrate, here is an extract of a dialog document with the two properties named "type" :
```
{
    "_id" : "5dca8fabee03972ced763344",
    ...
    "stories" : [ 
        {
            "storyDefinitionId" : "attachment_intent",
            "currentIntent" : {
                "name" : "attachment_intent"
            },
            "currentStep" : null,
            "actions" : [ 
                {
                    "type" : "attachment",
                    "url" : "",
                    "type" : "file",
                    "id" : "5dca8fa5ee03972ced763343",
                    "date" : ISODate("2019-11-12T10:55:33.853Z"),
                    ...
                }
            ]
        }
    ],
    ...
}
```

Two fields with the same name is allowed in MongoDB but is not supported by all drivers.  

> BSON documents may have more than one field with the same name. Most MongoDB interfaces, however, represent MongoDB with a structure (e.g. a hash table) that does not support duplicate field names. If you need to manipulate documents that have more than one field with the same name, see the driver documentation for your driver.
https://docs.mongodb.com/manual/core/document/#document-structure

My PR deals with that by changing the property name of the attachment type.   
To preserve compatibility with old documents, I’ve added an alias on the previous name "type".