### PR TITLE
Make SendAttachment inheritable

### DIFF
--- a/bot/engine/src/main/kotlin/engine/action/SendAttachment.kt
+++ b/bot/engine/src/main/kotlin/engine/action/SendAttachment.kt
@@ -29,7 +29,7 @@ import java.time.Instant
 /**
  * A simple attachment file sent.
  */
-class SendAttachment(playerId: PlayerId,
+open class SendAttachment(playerId: PlayerId,
                      applicationId: String,
                      recipientId: PlayerId,
                      val url: String,


### PR DESCRIPTION
`SendAttachment` action has restricted properties. Making it inheritable allows the connector to include project's specific data (or behavior) in it.