### PR TITLE
[docs] fix sidebar link for connectors doc

### DIFF
--- a/docs/fr/utilisateur/studio/configuration/index.html
+++ b/docs/fr/utilisateur/studio/configuration/index.html
@@ -455,7 +455,7 @@
 
 
   <li class="md-nav__item">
-    <a href="../../../dev/connectors.md" title="Connecteurs" class="md-nav__link">
+    <a href="../../../dev/connecteurs/" title="Connecteurs" class="md-nav__link">
       Connecteurs
     </a>
   </li>


### PR DESCRIPTION
Hi, here's a small fix to the doc.

Steps to reproduce:

1. Go to http://doc.tock.ai/tock/fr/dev/modes/
2. Click on "Connecteurs"
3. You'll get a 404 page
