### PR TITLE
Update messenger message tags

### DIFF
--- a/bot/connector-messenger/src/main/kotlin/model/send/MessageTag.kt
+++ b/bot/connector-messenger/src/main/kotlin/model/send/MessageTag.kt
@@ -21,17 +21,31 @@ import ai.tock.bot.engine.action.ActionNotificationType
 
 
 enum class MessageTag {
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new POST_PURCHASE_UPDATE")
     SHIPPING_UPDATE,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag POST_PURCHASE_UPDATE")
     RESERVATION_UPDATE,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag HUMAN_AGENT")
     ISSUE_RESOLUTION,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag CONFIRMED_EVENT_UPDATE")
     APPOINTMENT_UPDATE,
+    @Deprecated("No longer supported after January 15, 2020")
     GAME_EVENT,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag CONFIRMED_EVENT_UPDATE")
     TRANSPORTATION_UPDATE,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag HUMAN_AGENT")
     FEATURE_FUNCTIONALITY_UPDATE,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag CONFIRMED_EVENT_UPDATE")
     TICKET_UPDATE,
-    ACCOUNT_UPDATE,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag POST_PURCHASE_UPDATE")
     PAYMENT_UPDATE,
-    PERSONAL_FINANCE_UPDATE;
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new tag ACCOUNT_UPDATE")
+    PERSONAL_FINANCE_UPDATE,
+
+    CONFIRMED_EVENT_UPDATE,
+    POST_PURCHASE_UPDATE,
+    ACCOUNT_UPDATE,
+    HUMAN_AGENT;
 
     companion object {
         fun toMessageTag(action: Action): MessageTag? {
@@ -40,9 +54,12 @@ enum class MessageTag {
                 ActionNotificationType.issueResolution -> ISSUE_RESOLUTION
                 ActionNotificationType.newFeatureFunctionality -> FEATURE_FUNCTIONALITY_UPDATE
                 ActionNotificationType.reservationUpdate -> RESERVATION_UPDATE
-                ActionNotificationType.accountUpdate -> ACCOUNT_UPDATE
                 ActionNotificationType.paymentUpdate -> PAYMENT_UPDATE
                 ActionNotificationType.personalFinanceUpdate -> PERSONAL_FINANCE_UPDATE
+                ActionNotificationType.confirmedEventUpdate -> CONFIRMED_EVENT_UPDATE
+                ActionNotificationType.humanAgent -> HUMAN_AGENT
+                ActionNotificationType.postPurchaseUpdate -> POST_PURCHASE_UPDATE
+                ActionNotificationType.accountUpdate -> ACCOUNT_UPDATE
                 else -> null
             }
         }

--- a/bot/connector-messenger/src/test/kotlin/json/send/MessageRequestDeserializationTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/json/send/MessageRequestDeserializationTest.kt
@@ -31,6 +31,7 @@ import ai.tock.bot.connector.messenger.model.send.MediaPayload
 import ai.tock.bot.connector.messenger.model.send.MediaType
 import ai.tock.bot.connector.messenger.model.send.MessageRequest
 import ai.tock.bot.connector.messenger.model.send.MessageTag
+import ai.tock.bot.connector.messenger.model.send.MessageTag.HUMAN_AGENT
 import ai.tock.bot.connector.messenger.model.send.PostbackButton
 import ai.tock.bot.connector.messenger.model.send.QuickReply
 import ai.tock.bot.connector.messenger.model.send.TextMessage
@@ -67,7 +68,7 @@ class MessageRequestDeserializationTest {
                     )
                 )
             )
-            , tag = MessageTag.FEATURE_FUNCTIONALITY_UPDATE
+            , tag = HUMAN_AGENT
         )
         val s = mapper.writeValueAsString(m)
         assertEquals(m, mapper.readValue(s))
@@ -98,7 +99,7 @@ class MessageRequestDeserializationTest {
                     )
                 )
             )
-            , tag = MessageTag.FEATURE_FUNCTIONALITY_UPDATE
+            , tag = HUMAN_AGENT
         )
         val s = mapper.writeValueAsString(m)
         assertEquals(m, mapper.readValue(s))

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -35,7 +35,7 @@ import ai.tock.bot.definition.StoryHandlerDefinition
 import ai.tock.bot.definition.StoryHandlerListener
 import ai.tock.bot.definition.StoryStep
 import ai.tock.bot.engine.action.ActionNotificationType
-import ai.tock.bot.engine.action.ActionNotificationType.newFeatureFunctionality
+import ai.tock.bot.engine.action.ActionNotificationType.humanAgent
 import ai.tock.bot.engine.config.StoryConfigurationMonitor
 import ai.tock.bot.engine.monitoring.RequestTimer
 import ai.tock.bot.engine.nlp.BuiltInKeywordListener
@@ -170,7 +170,7 @@ object BotRepository {
         step: StoryStep<out StoryHandlerDefinition>? = null,
         parameters: Map<String, String> = emptyMap(),
         stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
-        notificationType: ActionNotificationType = newFeatureFunctionality
+        notificationType: ActionNotificationType = humanAgent
     ) {
         val conf = getConfigurationByApplicationId(applicationId) ?: error("unknown application $applicationId")
         connectorControllerMap.getValue(conf).notifyAndCheckState(recipientId, intent, step, parameters, stateModifier, notificationType)

--- a/bot/engine/src/main/kotlin/engine/action/ActionNotificationType.kt
+++ b/bot/engine/src/main/kotlin/engine/action/ActionNotificationType.kt
@@ -20,12 +20,22 @@ package ai.tock.bot.engine.action
  * ActionTag deals with type of message notification.
  */
 enum class ActionNotificationType {
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action postPurchaseUpdate")
     reservationUpdate,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action humanAgent")
     issueResolution,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action confirmedEventUpdate")
     transportationUpdate,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action humanAgent")
     newFeatureFunctionality,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action confirmedEventUpdate")
     ticketUpdate,
-    accountUpdate,
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action postPurchaseUpdate")
     paymentUpdate,
-    personalFinanceUpdate
+    @Deprecated("Available until January 15th, 2020 Partially covered as the new action accountUpdate")
+    personalFinanceUpdate,
+    accountUpdate,
+    confirmedEventUpdate,
+    humanAgent,
+    postPurchaseUpdate,
 }


### PR DESCRIPTION
Mise à jour des tags messenger qui seront déprécié à partir du 15/01/2020.
Les tags qui ne sont plus supporté sont :

- RESERVATION_UPDATE
- ISSUE_RESOLUTION
- TRANSPORTATION_UPDATE
- TICKET_UPDATE
- PAYMENT_UPDATE

Les nouveaux tags sont : 

- CONFIRMED_EVENT_UPDATE
- POST_PURCHASE_UPDATE
- HUMAN_AGENT
- ACCOUNT_UPDATE

Plus d'informations sur la page de l'API : https://developers.facebook.com/docs/messenger-platform/send-messages/message-tags

