### PR TITLE
resolves #698 Add test saving to Xray

### DIFF
--- a/bot/admin/test/xray/src/main/kotlin/XrayApi.kt
+++ b/bot/admin/test/xray/src/main/kotlin/XrayApi.kt
@@ -20,10 +20,12 @@ import ai.tock.bot.admin.test.xray.model.JiraAttachment
 import ai.tock.bot.admin.test.xray.model.JiraIssue
 import ai.tock.bot.admin.test.xray.model.JiraIssueLink
 import ai.tock.bot.admin.test.xray.model.JiraTest
+import ai.tock.bot.admin.test.xray.model.SearchResult
 import ai.tock.bot.admin.test.xray.model.XrayBuildTestStep
 import ai.tock.bot.admin.test.xray.model.XrayTest
 import ai.tock.bot.admin.test.xray.model.XrayTestExecution
 import ai.tock.bot.admin.test.xray.model.XrayTestExecutionCreation
+import ai.tock.bot.admin.test.xray.model.XrayTestPlan
 import ai.tock.bot.admin.test.xray.model.XrayTestStep
 import ai.tock.bot.admin.test.xray.model.XrayUpdateTest
 import okhttp3.MultipartBody
@@ -93,4 +95,7 @@ interface XrayApi {
 
     @GET("/rest/api/2/search")
     fun searchIssue(@Query("jql") jql: String): Call<ResponseBody>
+
+    @GET("/rest/api/2/search")
+    fun searchTestPlans(@Query("jql") jql: String, @Query("fields") fields: List<String>): Call<SearchResult>
 }

--- a/bot/admin/test/xray/src/main/kotlin/XrayService.kt
+++ b/bot/admin/test/xray/src/main/kotlin/XrayService.kt
@@ -26,6 +26,7 @@ import ai.tock.bot.admin.test.TestPlanExecutionStatus
 import ai.tock.bot.admin.test.TestPlanService.saveTestPlanExecution
 import ai.tock.bot.admin.test.findTestClient
 import ai.tock.bot.admin.test.xray.XrayClient.getProjectFromIssue
+import ai.tock.bot.admin.test.xray.XrayClient.getProjectTestPlans
 import ai.tock.bot.admin.test.xray.model.JiraIssueType
 import ai.tock.bot.admin.test.xray.model.JiraTest
 import ai.tock.bot.admin.test.xray.model.XrayAttachment
@@ -42,6 +43,7 @@ import ai.tock.bot.admin.test.xray.model.XrayTestExecutionCreation
 import ai.tock.bot.admin.test.xray.model.XrayTestExecutionInfo
 import ai.tock.bot.admin.test.xray.model.XrayTestExecutionReport
 import ai.tock.bot.admin.test.xray.model.XrayTestExecutionStepReport
+import ai.tock.bot.admin.test.xray.model.XrayTestPlan
 import ai.tock.bot.admin.test.xray.model.XrayTextExecutionFields
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.engine.message.parser.MessageParser
@@ -102,6 +104,8 @@ class XrayService(
     init {
         XrayConfiguration.configure()
     }
+
+    fun getTestPlans(): List<XrayTestPlan> = getProjectTestPlans(jiraProject)
 
     fun execute(namespace: String): XRayPlanExecutionResult {
         return when {

--- a/bot/admin/test/xray/src/main/kotlin/XrayTestService.kt
+++ b/bot/admin/test/xray/src/main/kotlin/XrayTestService.kt
@@ -39,6 +39,10 @@ class XrayTestService : TestService by testCoreService {
                     configuration.testedBotId
             ).execute(context.organization)
         }
+
+        blockingJsonGet("/xray/test/plans", botUser) { context ->
+            XrayService().getTestPlans()
+        }
     }
 
     override fun priority(): Int = 1

--- a/bot/admin/test/xray/src/main/kotlin/model/SearchResult.kt
+++ b/bot/admin/test/xray/src/main/kotlin/model/SearchResult.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2017/2019 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.test.xray.model
+
+data class SearchResult (
+        val total: Int,
+        val issues: List<XrayTestPlan>
+)

--- a/bot/admin/test/xray/src/main/kotlin/model/XrayTestPlan.kt
+++ b/bot/admin/test/xray/src/main/kotlin/model/XrayTestPlan.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2017/2019 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.test.xray.model
+
+data class XrayTestPlan (
+    val key: String,
+    val fields: XrayTestPlanField
+)

--- a/bot/admin/test/xray/src/main/kotlin/model/XrayTestPlanField.kt
+++ b/bot/admin/test/xray/src/main/kotlin/model/XrayTestPlanField.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017/2019 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.test.xray.model
+
+data class XrayTestPlanField (
+        val summary: String
+)

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.css
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.css
@@ -33,3 +33,44 @@
 .messages {
   margin-bottom: 15px;
 }
+
+.dialog-handler {
+  float: right;
+}
+
+.dialog-handler button {
+  margin: 0 5px 0 5px;
+}
+
+.dialog-handler input {
+  margin: 0 10px 0 10px;
+}
+
+.test-plans-select {
+  margin: 0 5px 0 5px;
+  width: 10rem;
+  max-width: 10rem;
+}
+
+.test-plans-select {
+  margin: 0 5px 0 5px;
+  width: 10rem;
+  max-width: 10rem;
+}
+
+.dialog-manager-button {
+  margin: 0 5px 0 5px;
+}
+
+#test-saving-accordions nb-accordion {
+  float: left;
+  widht: 30%;
+}
+
+#test-saving-accordions button {
+  margin: 0 5px 0 5px;
+}
+
+#test-saving-accordions input {
+  margin: 0 10px 0 10px;
+}

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
@@ -17,12 +17,77 @@
   <nb-card-header>
     Test the application <i>{{state.currentApplication.name}}</i>
   </nb-card-header>
+  <nb-card-body *ngIf="testContext" id="test-saving-accordions">
+    <nb-accordion>
+      <nb-accordion-item>
+        <nb-accordion-item-header (click)="removeXrayTestName()">Save dialog in Xray</nb-accordion-item-header>
+        <nb-accordion-item-body>
+          <input *ngIf="testContext" nbInput [status]="isXrayTestNameFilled ? 'basic' : 'danger'"
+                 placeholder="Xray test name" id="test-name"
+                 [(ngModel)]="xrayTestName" (ngModelChange)="updateSaveButtonStatus($event)">
+
+          <input *ngIf="testContext" nbInput status="default" placeholder="US identifier in Jira" id="jira-name"
+                 [(ngModel)]="jiraIdentifier">
+
+          <nb-select *ngIf="testContext" multiple placeholder="Xray test plans" class="test-plans-select"
+                     name="testplans" [(selected)]="selectTestPlans" (selectedChange)="printSelectedTestPlans($event)">
+            <nb-option *ngFor="let e of xrayTestPlans" [value]="e.key" [nbTooltip]="e.fields.summary">
+              {{e.key}}
+            </nb-option>
+          </nb-select>
+
+          <button *ngIf="testContext" nbTooltip="Send dialog to Xray" nbTooltipStatus="info"
+                  [disabled]="!isXrayTestNameFilled"
+                  id="save-button" nbButton outline status="primary" size="small" (click)="saveDialogToXray()">
+            <nb-icon icon="save-outline"></nb-icon>
+          </button>
+        </nb-accordion-item-body>
+      </nb-accordion-item>
+
+      <nb-accordion-item>
+        <nb-accordion-item-header (click)="removeXrayTestIdentifier()">Update dialog in Xray</nb-accordion-item-header>
+        <nb-accordion-item-body>
+          <input *ngIf="testContext" nbInput [status]="isXrayTestIdentifierFilled?'basic':'danger'"
+                 placeholder="Xray test identifier" id="test-identifier"
+                 [(ngModel)]="xrayTestIdentifier" (ngModelChange)="updateUpdateButtonStatus($event)">
+
+          <button *ngIf="testContext" nbTooltip="Update Xray test" nbTooltipStatus="info"
+                  [disabled]="!isXrayTestIdentifierFilled"
+                  id="update-button" nbButton outline status="primary" size="small" (click)="updateDialogXray()">
+            <nb-icon icon="save-outline"></nb-icon>
+          </button>
+        </nb-accordion-item-body>
+      </nb-accordion-item>
+
+      <nb-accordion-item disabled>
+        <nb-accordion-item-header>Save dialog in Tock</nb-accordion-item-header>
+        <nb-accordion-item-body>
+          coming soon...
+        </nb-accordion-item-body>
+      </nb-accordion-item>
+    </nb-accordion>
+  </nb-card-body>
+
   <nb-card-body>
     <br>
     <div>
       <tock-select-bot [(configurationId)]="currentConfigurationId" [returnsRestConfiguration]="true"
                        (selectionChange)="changeConfiguration($event)">
-        <button *ngIf="messages.length !== 0" mat-icon-button matTooltip="Clear conversation" (click)="clear()" color="primary"><mat-icon>clear_all</mat-icon></button>
+        <button *ngIf="messages.length !== 0"
+                nbTooltip="Clear conversation" nbTooltipStatus="info"
+                nbButton outline status="danger" size="small" (click)="clear()">
+          <nb-icon icon="trash-2-outline"></nb-icon>
+        </button>
+        <button *ngIf="xrayAvailable"
+                class="dialog-manager-button"
+                [nbTooltip]="testContext ? 'Disable test context' : 'Enable test context'"
+                nbTooltipStatus="info"
+                nbButton outline status="warning"
+                size="small"
+                (click)="enableTestContext()">
+          <nb-icon icon="cube-outline"></nb-icon>
+        </button>
+
         <br><br><br>
         <table *ngIf="messages.length !== 0" class="messages">
           <tr *ngFor="let m of messages">
@@ -32,7 +97,8 @@
             <td *ngIf="!m.bot" style="min-width: 200px">
               <span *ngIf="m.locale" class="stats">
                 [{{m.locale}}]
-                <button *ngIf="m.hasNlpStats" mat-icon-button (click)="displayNlpStats(m)" matTooltip="View Nlp Stats" color="primary"><mat-icon>visibility</mat-icon></button>
+                <button *ngIf="m.hasNlpStats" mat-icon-button (click)="displayNlpStats(m)" matTooltip="View Nlp Stats"
+                        color="primary"><mat-icon>visibility</mat-icon></button>
               </span>
               <tock-bot-message [message]="m.message" (user)="true"></tock-bot-message>
             </td>
@@ -53,8 +119,15 @@
                  [(ngModel)]="userMessage"
                  (keyup.enter)="submit()">
         </span>
-        <button nbButton outline status="primary" size="small" (click)="submit()">GO</button>
+        <button nbButton outline status="primary" size="medium" (click)="submit()">GO</button>
       </tock-select-bot>
     </div>
   </nb-card-body>
 </nb-card>
+
+<script>
+  angular.module('ngRequiredExample', [])
+    .controller('ExampleController', ['$scope', function ($scope) {
+      $scope.required = true;
+    }]);
+</script>

--- a/bot/admin/web/src/app/test/model/test.ts
+++ b/bot/admin/web/src/app/test/model/test.ts
@@ -255,3 +255,32 @@ export class XRayPlanExecutionResult {
   }
 
 }
+
+export class XRayTestPlan {
+  constructor(public key: string,
+              public fields: XRayField) {
+  }
+  static fromJSON(json?: any): XRayTestPlan {
+    const value = Object.create(XRayTestPlan.prototype);
+
+    const result = Object.assign(value, json, {});
+
+    return result;
+  }
+
+  static fromJSONArray(json?: Array<any>): XRayTestPlan[] {
+    return json ? json.map(XRayTestPlan.fromJSON) : [];
+  }
+}
+
+export class XRayField {
+  constructor(public summary: string) {
+  }
+  static fromJSON(json?: any): XRayField {
+    const value = Object.create(XRayField.prototype);
+
+    const result = Object.assign(value, json, {});
+
+    return result;
+  }
+}

--- a/bot/admin/web/src/app/test/test.module.ts
+++ b/bot/admin/web/src/app/test/test.module.ts
@@ -36,6 +36,7 @@ import {
   NbTooltipModule,
   NbInputModule
 } from "@nebular/theme";
+import {ReactiveFormsModule} from "@angular/forms";
 
 const routes: Routes = [
   {
@@ -82,7 +83,8 @@ export class BotTestRoutingModule {
     NbSelectModule,
     NbTooltipModule,
     NbAccordionModule,
-    NbInputModule
+    NbInputModule,
+    ReactiveFormsModule
   ],
   declarations: [
     TestTabsComponent,

--- a/bot/admin/web/src/app/test/test.service.ts
+++ b/bot/admin/web/src/app/test/test.service.ts
@@ -23,7 +23,7 @@ import {
   TestPlan,
   TestPlanExecution,
   XRayPlanExecutionConfiguration,
-  XRayPlanExecutionResult
+  XRayPlanExecutionResult, XRayTestPlan
 } from "./model/test";
 import {Observable} from "rxjs";
 
@@ -73,6 +73,10 @@ export class TestService {
 
   executeXRay(conf: XRayPlanExecutionConfiguration): Observable<XRayPlanExecutionResult> {
     return this.rest.post(`/xray/execute`, conf, XRayPlanExecutionResult.fromJSON);
+  }
+
+  getXrayTestPlans(): Observable<XRayTestPlan[]> {
+    return this.rest.get(`/xray/test/plans`, XRayTestPlan.fromJSONArray);
   }
 
 }


### PR DESCRIPTION
Remove created tab and add div at the end of 'test the bot' page
Add web page components for xray saving.
Add web page components for Tock saving
Add autocomplete on Tock test plans field
Enable test saving in Xray through Tock test webpage.
Add API in Tock to retrieve all test plans in Xray project.
Add selection of test plan during test creation.
Add method to retrieve test plans.
Change test dialog handler display into accordion.
Add test tab and rename 'test the bot' to 'live-testing'
Remove created tab and add div at the end of 'test the bot' page
Remove created tab and add div at the end of 'test the bot' page
Add web page components for xray saving.
Add web page components for Tock saving
Add autocomplete on Tock test plans field
Enable test saving in Xray through Tock test webpage.
Add API in Tock to retrieve all test plans in Xray project.
Add selection of test plan during test creation.
Enable xray test update.
Make "update dialog in Xray" part dynamic (Angular-friendly)
Make "Send dialog to Xray" part dynamic (Angular-friendly)
Disable accordion item : add test to Tock test plan.
Remove text from inputs when accordion items collapse.
Modify tooltip text according test context.