### PR TITLE
Add a MongoDB credentials provider

### DIFF
--- a/shared/src/main/kotlin/IOCs.kt
+++ b/shared/src/main/kotlin/IOCs.kt
@@ -20,6 +20,8 @@ import ai.tock.shared.cache.TockCache
 import ai.tock.shared.cache.mongo.MongoCache
 import ai.tock.shared.security.NoOpTockUserListener
 import ai.tock.shared.security.TockUserListener
+import ai.tock.shared.security.mongo.DefaultMongoCredentialsProvider
+import ai.tock.shared.security.mongo.MongoCredentialsProvider
 import ai.tock.shared.vertx.TockVertxProvider
 import ai.tock.shared.vertx.VertxProvider
 import ai.tock.shared.vertx.vertxExecutor
@@ -70,6 +72,7 @@ val sharedModule = Kodein.Module {
     bind<TockCache>() with provider { MongoCache }
     bind<VertxProvider>() with provider { TockVertxProvider }
     bind<TockUserListener>() with provider { NoOpTockUserListener }
+    bind<MongoCredentialsProvider>() with provider { DefaultMongoCredentialsProvider }
     try {
         bind<MongoClient>() with singleton { mongoClient }
     } catch (e: Exception) {

--- a/shared/src/main/kotlin/security/mongo/DefaultMongoCredentialsProvider.kt
+++ b/shared/src/main/kotlin/security/mongo/DefaultMongoCredentialsProvider.kt
@@ -1,0 +1,12 @@
+package ai.tock.shared.security.mongo
+
+import com.mongodb.MongoCredential
+
+/**
+ * Default Mongo credential provider with no authentication
+ */
+internal object DefaultMongoCredentialsProvider: MongoCredentialsProvider {
+    override fun getCredentials(): MongoCredential? {
+        return null
+    }
+}

--- a/shared/src/main/kotlin/security/mongo/MongoCredentialsProvider.kt
+++ b/shared/src/main/kotlin/security/mongo/MongoCredentialsProvider.kt
@@ -1,0 +1,10 @@
+package ai.tock.shared.security.mongo
+
+import com.mongodb.MongoCredential
+
+/**
+ * Mongo credential provider
+ */
+interface MongoCredentialsProvider {
+    fun getCredentials(): MongoCredential?
+}

--- a/shared/src/test/kotlin/MongoTest.kt
+++ b/shared/src/test/kotlin/MongoTest.kt
@@ -16,7 +16,15 @@
 
 package ai.tock.shared
 
+import ai.tock.shared.security.mongo.DefaultMongoCredentialsProvider
+import ai.tock.shared.security.mongo.MongoCredentialsProvider
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.salomonbrys.kodein.Kodein
+import com.github.salomonbrys.kodein.KodeinInjector
+import com.github.salomonbrys.kodein.bind
+import com.github.salomonbrys.kodein.provider
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.litote.kmongo.util.KMongoConfiguration
 import java.time.Period
@@ -28,6 +36,19 @@ import kotlin.test.assertEquals
 class MongoTest {
 
     class ThisIsACollection
+
+    @BeforeEach
+    fun before() {
+        tockInternalInjector = KodeinInjector()
+        tockInternalInjector.inject(Kodein.invoke {
+            bind<MongoCredentialsProvider>() with provider { DefaultMongoCredentialsProvider }
+        })
+    }
+
+    @AfterEach
+    fun after() {
+        tockInternalInjector = KodeinInjector()
+    }
 
     @Test
     fun collectionBuilder_shouldAddUnderscore_forEachUpperCase() {

--- a/shared/src/test/kotlin/SharedTestModule.kt
+++ b/shared/src/test/kotlin/SharedTestModule.kt
@@ -19,6 +19,8 @@ package ai.tock.shared
 import ai.tock.shared.cache.TockCache
 import ai.tock.shared.security.NoOpTockUserListener
 import ai.tock.shared.security.TockUserListener
+import ai.tock.shared.security.mongo.DefaultMongoCredentialsProvider
+import ai.tock.shared.security.mongo.MongoCredentialsProvider
 import ai.tock.shared.vertx.VertxProvider
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.bind
@@ -51,6 +53,7 @@ val sharedTestModule = Kodein.Module {
     bind<Executor>() with provider { TestExecutor }
     bind<TockCache>() with provider { NoOpCache }
     bind<TockUserListener>() with provider { NoOpTockUserListener }
+    bind<MongoCredentialsProvider>() with provider { DefaultMongoCredentialsProvider }
 
     try {
         clearMocks(mockedVertx)


### PR DESCRIPTION
Add a MongoDB credentials provider to provide credentials from another source than the MongoDB connection url.
The provider is called only if there is no credentials in the Mongo connection url.

By default, the provider provides no credentials.