### PR TITLE
fixes #735 Prevent spaces in path

### DIFF
--- a/bot/admin/web/src/app/configuration/bot/new-bot.component.ts
+++ b/bot/admin/web/src/app/configuration/bot/new-bot.component.ts
@@ -65,7 +65,7 @@ export class NewBotComponent implements OnInit {
   validate() {
     const locale = this.firstFormGroup.value.firstCtrl;
     const channel = this.channel.value;
-    const newApp = new Application("new_assistant", this.state.user.organization, [], [locale], StateService.DEFAULT_ENGINE, true, true, false);
+    const newApp = new Application("new_assistant", "new_assistant", this.state.user.organization, [], [locale], StateService.DEFAULT_ENGINE, true, true, false);
     this.applicationService.saveApplication(newApp)
       .subscribe(app => {
         this.applicationService.refreshCurrentApplication(app);

--- a/bot/admin/web/src/app/core/bot-configuration.service.ts
+++ b/bot/admin/web/src/app/core/bot-configuration.service.ts
@@ -112,7 +112,7 @@ export class BotConfigurationService implements OnInit, OnDestroy {
 
   findValidPath(connectorType: ConnectorType): string {
     const bots = this.bots.getValue();
-    const baseTargetPath = `/io/${this.state.user.organization}/${this.state.currentApplication.name}/${connectorType.id}`;
+    const baseTargetPath = `/io/${this.state.user.organization}/${this.state.currentApplication.name.replace(/\s/g, "_")}/${connectorType.id}`;
     let targetPath = baseTargetPath;
     let index = 1;
     while (bots.findIndex(b => b.configurations && b.configurations.findIndex(c => c.path === targetPath) !== -1) !== -1) {

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
@@ -15,7 +15,7 @@
   -->
 <nb-card class="dialog">
   <nb-card-header>
-    Test the application <i>{{state.currentApplication.name}}</i>
+    Test the application <i>{{state.currentApplication.label}}</i>
   </nb-card-header>
   <nb-card-body *ngIf="testContext" id="test-saving-accordions">
     <nb-accordion>

--- a/bot/admin/web/src/app/theme/components/header/header.component.html
+++ b/bot/admin/web/src/app/theme/components/header/header.component.html
@@ -37,7 +37,7 @@
              [ngModel]="state.currentApplication.name"
              class="app">
     <nb-option *ngFor="let app of state.applications"
-               [value]="app.name">{{ app.name }}
+               [value]="app.name">{{ app.label }}
     </nb-option>
   </nb-select>
 

--- a/bot/connector-rest/src/main/kotlin/RestConnectorBuilder.kt
+++ b/bot/connector-rest/src/main/kotlin/RestConnectorBuilder.kt
@@ -60,7 +60,8 @@ fun addRestConnector(
 /**
  * Generates a default connector path from a base configuration.
  */
-private fun generateRestConnectorPath(botConfiguration: BotApplicationConfiguration): String = "/io/${botConfiguration.namespace}/test/test-${botConfiguration.applicationId}"
+private fun generateRestConnectorPath(botConfiguration: BotApplicationConfiguration): String =
+        "/io/${botConfiguration.namespace}/test/test-${botConfiguration.applicationId.replace("\\s".toRegex(), "_")}"
 
 /**
  * Returns a rest configuration from a base configuration.

--- a/bot/connector-rest/src/test/kotlin/RestConnectorBuilderTest.kt
+++ b/bot/connector-rest/src/test/kotlin/RestConnectorBuilderTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017/2019 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.connector.rest
+
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+
+internal class RestConnectorBuilderTest {
+
+    @Test
+    fun `connector path should include no space char`() {
+
+        val aNameIncludingSpaces = "un nom avec espace"
+        val connectorConfiguration = addRestConnector(BotApplicationConfiguration(applicationId = aNameIncludingSpaces,
+                botId = aNameIncludingSpaces,
+                name = aNameIncludingSpaces,
+                namespace = "aNamespace",
+                connectorType = RestConnectorProvider.connectorType,
+                nlpModel = "aModel"))
+
+        assertFalse { connectorConfiguration.path.contains(' ') }
+    }
+}

--- a/nlp/admin/server/src/main/kotlin/model/ApplicationWithIntents.kt
+++ b/nlp/admin/server/src/main/kotlin/model/ApplicationWithIntents.kt
@@ -32,6 +32,10 @@ data class ApplicationWithIntents(
      */
     val name: String,
     /**
+     * The label of the app.
+     */
+    val label: String = name,
+    /**
      * The namespace of the application.
      */
     val namespace: String,
@@ -68,6 +72,7 @@ data class ApplicationWithIntents(
     constructor(application: ApplicationDefinition, intents: List<IntentDefinition>) :
             this(
                 application.name,
+                application.label,
                 application.namespace,
                 intents.sortedWith(compareBy({ it.label }, { it.name })),
                 application.supportedLocales,
@@ -81,6 +86,7 @@ data class ApplicationWithIntents(
     fun toApplication(): ApplicationDefinition {
         return ApplicationDefinition(
             name,
+            label,
             namespace,
             intents.map { it._id }.toSet(),
             supportedLocales,

--- a/nlp/admin/web/src/app/applications/application/application.component.html
+++ b/nlp/admin/web/src/app/applications/application/application.component.html
@@ -42,19 +42,33 @@
   <nb-card-body *ngIf="application">
     <nb-card>
       <nb-card-body>
-          <input #appName name="appName" nbInput placeholder="New Application Name" [(ngModel)]="application.name"
-                 (keyup.enter)="saveApplication()" class="application-name">
-        <nb-checkbox class="separator" [(ngModel)]="application.mergeEngineTypes"
-                     nbTooltip="If selected, this option uses built-in entity models (like dates) in conjunction with standard NER">
-          Use entity models
-        </nb-checkbox>
-        <nb-checkbox class="separator" *ngIf="!application.mergeEngineTypes" [(ngModel)]="application.useEntityModels"
-                     nbTooltip="If selected, built-in entity models results are provided only for info and potential entity disambiguation">
-          Entity disambiguation only
-        </nb-checkbox>
-        <nb-checkbox class="separator" [(ngModel)]="application.supportSubEntities"
-                     nbTooltip="If selected, you can use subentities in your nlp models">Allow subentities
-        </nb-checkbox>
+        <p>
+          <mat-form-field>
+            <input matInput name="appLabel" placeholder="New Application Label" [(ngModel)]="application.label"
+                   (keyup)="format()" (keyup.enter)="saveApplication()"
+                   matTooltip="Displayed label" #appLabel required autocomplete="off">
+          </mat-form-field>
+        </p>
+        <p>
+          <mat-form-field>
+            <input matInput name="appName" placeholder="New Application Name" [(ngModel)]="application.name"
+                   (keyup.enter)="saveApplication()"
+                   matTooltip="Technical name (without special chars)" #appName required autocomplete="off">
+          </mat-form-field>
+        </p>
+        <p>
+          <nb-checkbox class="separator" [(ngModel)]="application.mergeEngineTypes"
+                       nbTooltip="If selected, this option uses built-in entity models (like dates) in conjunction with standard NER">
+            Use entity models
+          </nb-checkbox>
+          <nb-checkbox class="separator" *ngIf="!application.mergeEngineTypes" [(ngModel)]="application.useEntityModels"
+                       nbTooltip="If selected, built-in entity models results are provided only for info and potential entity disambiguation">
+            Entity disambiguation only
+          </nb-checkbox>
+          <nb-checkbox class="separator" [(ngModel)]="application.supportSubEntities"
+                       nbTooltip="If selected, you can use subentities in your nlp models">Allow subentities
+          </nb-checkbox>
+        </p>
       </nb-card-body>
     </nb-card>
     <nb-card *ngIf="state.locales">

--- a/nlp/admin/web/src/app/applications/application/application.component.ts
+++ b/nlp/admin/web/src/app/applications/application/application.component.ts
@@ -38,7 +38,7 @@ export class ApplicationComponent implements OnInit {
   nlpEngineType: string;
   nlpEngineTypeChange: Subject<NlpEngineType> = new Subject();
 
-  @ViewChild('appName', {static: false}) appName: ElementRef;
+  @ViewChild('appLabel', {static: false}) appLabel: ElementRef;
 
   constructor(private route: ActivatedRoute,
               private snackBar: MatSnackBar,
@@ -59,19 +59,30 @@ export class ApplicationComponent implements OnInit {
           }
         } else {
           this.newApplication = true;
-          this.application = new Application("", this.state.user.organization, [], [], StateService.DEFAULT_ENGINE, true, true, false);
+          this.application = new Application("", "", this.state.user.organization, [], [], StateService.DEFAULT_ENGINE, true, true, false);
         }
         this.nlpEngineType = this.application.nlpEngineType.name;
         if (this.application) {
           setTimeout(_ => {
-            this.appName.nativeElement.focus();
+            this.appLabel.nativeElement.focus();
           });
         }
       }
     );
   }
 
+  format() {
+    this.formatName(this.application.label);
+  }
+
+  private formatName(label: string) {
+    if (label) {
+      this.application.name = label.replace(/[^A-Za-z_-]*/g, '').toLowerCase().trim();
+    }
+  }
+
   saveApplication() {
+    this.format();
     if (this.application.name.trim().length === 0) {
       this.snackBar.open(`Please choose an application name`, "ERROR", {duration: 5000});
     } else if (this.application.supportedLocales.length === 0) {

--- a/nlp/admin/web/src/app/applications/applications/applications.component.html
+++ b/nlp/admin/web/src/app/applications/applications/applications.component.html
@@ -48,7 +48,7 @@
         <mat-icon></mat-icon>
       </button>
 
-      <span class="applications-applications__app-name">{{app.name}}</span>
+      <span class="applications-applications__app-name">{{app.label}}</span>
 
       <div class="applications-applications__datas">
         <span *ngFor="let locale of app.supportedLocales">

--- a/nlp/admin/web/src/app/model/application.ts
+++ b/nlp/admin/web/src/app/model/application.ts
@@ -20,6 +20,7 @@ import {flatMap, JsonUtils} from "./commons";
 export class Application {
 
   constructor(public name: string,
+              public label: string,
               public namespace: string,
               public intents: Intent[],
               public supportedLocales: string[],
@@ -33,6 +34,7 @@ export class Application {
   clone(): Application {
     return new Application(
       this.name,
+      this.label,
       this.namespace,
       this.intents.slice(0),
       this.supportedLocales.slice(0),
@@ -102,7 +104,8 @@ export class Application {
     const value = Object.create(Application.prototype);
     const result = Object.assign(value, json, {
       intents: Intent.fromJSONArray(json.intents),
-      nlpEngineType: NlpEngineType.fromJSON(json.nlpEngineType)
+      nlpEngineType: NlpEngineType.fromJSON(json.nlpEngineType),
+      label: json.label || json.name
     });
 
     return result;

--- a/nlp/admin/web/src/app/theme/components/header/header.component.html
+++ b/nlp/admin/web/src/app/theme/components/header/header.component.html
@@ -35,7 +35,7 @@
              [ngModel]="state.currentApplication.name"
              class="app">
     <nb-option *ngFor="let app of state.applications"
-               [value]="app.name">{{ app.name }}
+               [value]="app.name">{{ app.label }}
     </nb-option>
   </nb-select>
 

--- a/nlp/api/client/src/main/kotlin/TockNlpClient.kt
+++ b/nlp/api/client/src/main/kotlin/TockNlpClient.kt
@@ -110,7 +110,7 @@ class TockNlpClient(baseUrl: String = System.getenv("tock_nlp_service_url") ?: "
     }
 
     override fun createApplication(namespace: String, name: String, locale: Locale): ApplicationDefinition? {
-        return nlpService.createApplication(CreateApplicationQuery(name, namespace, locale)).execute().body()
+        return nlpService.createApplication(CreateApplicationQuery(name, namespace = namespace, locale = locale)).execute().body()
     }
 
     private fun createMultipart(stream: InputStream): MultipartBody.Part {

--- a/nlp/api/client/src/main/kotlin/model/dump/ApplicationDump.kt
+++ b/nlp/api/client/src/main/kotlin/model/dump/ApplicationDump.kt
@@ -35,6 +35,7 @@ data class ApplicationDump(
 
 data class ApplicationDefinition(
     val name: String,
+    val label: String = name,
     val namespace: String,
     val intents: Set<String> = emptySet(),
     val supportedLocales: Set<Locale> = emptySet(),

--- a/nlp/api/client/src/main/kotlin/model/dump/CreateApplicationQuery.kt
+++ b/nlp/api/client/src/main/kotlin/model/dump/CreateApplicationQuery.kt
@@ -23,6 +23,7 @@ import java.util.Locale
  */
 data class CreateApplicationQuery(
     val name: String,
+    val label: String = name,
     val namespace: String,
     val locale: Locale
 )

--- a/nlp/api/service/src/main/kotlin/NlpVerticle.kt
+++ b/nlp/api/service/src/main/kotlin/NlpVerticle.kt
@@ -141,6 +141,7 @@ class NlpVerticle : WebVerticle() {
                     front.save(
                         ApplicationDefinition(
                             query.name,
+                            query.label ?: query.name,
                             query.namespace,
                             supportedLocales = setOf(query.locale)
                         )

--- a/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
+++ b/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
@@ -296,7 +296,7 @@ internal object ApplicationCodecService : ApplicationCodec {
             var app = config.getApplicationByNamespaceAndName(namespace, appName)
                 .let { app ->
                     if (app == null) {
-                        val appToSave = ApplicationDefinition(appName, namespace)
+                        val appToSave = ApplicationDefinition(appName, appName, namespace)
                         report.add(appToSave)
                         logger.debug { "Import application $appToSave" }
                         config.save(appToSave)

--- a/nlp/front/service/src/test/kotlin/AbstractTest.kt
+++ b/nlp/front/service/src/test/kotlin/AbstractTest.kt
@@ -114,7 +114,7 @@ abstract class AbstractTest {
     val appName = "test"
     val app = ApplicationDefinition(
         appName,
-        namespace,
+        namespace = namespace,
         _id = "id".toId(),
         supportedLocales = setOf(defaultLocale)
     )

--- a/nlp/front/service/src/test/kotlin/ApplicationCodecServiceTest.kt
+++ b/nlp/front/service/src/test/kotlin/ApplicationCodecServiceTest.kt
@@ -66,7 +66,7 @@ class ApplicationCodecServiceTest : AbstractTest() {
     @Test
     fun `export sentence fails WHEN sentence intent is unknown`() {
         val appId = "id".toId<ApplicationDefinition>()
-        val app = ApplicationDefinition("test", "test", _id = appId)
+        val app = ApplicationDefinition("test", namespace = "test", _id = appId)
         val sentences = listOf(
             ClassifiedSentence(
                 "text",

--- a/nlp/front/service/src/test/kotlin/ParserServiceTest.kt
+++ b/nlp/front/service/src/test/kotlin/ParserServiceTest.kt
@@ -57,7 +57,7 @@ class ParserServiceTest : AbstractTest() {
     @Test
     fun findLanguage_shouldReturnDefault_WhenLocaleParameterIsNotSupportedAndDefaultIsSupported() {
         val locale = ParserService.findLanguage(
-            ApplicationDefinition("test", "test", supportedLocales = setOf(defaultLocale)),
+            ApplicationDefinition("test", namespace = "test", supportedLocales = setOf(defaultLocale)),
             Locale.JAPANESE
         )
 
@@ -67,7 +67,7 @@ class ParserServiceTest : AbstractTest() {
     @Test
     fun findLanguage_shouldReturnFirstFound_WhenLocaleParameterIsNotSupportedAndDefaultIsNotSupported() {
         val locale = ParserService.findLanguage(
-            ApplicationDefinition("test", "test", supportedLocales = setOf(Locale.ITALIAN)),
+            ApplicationDefinition("test", namespace = "test", supportedLocales = setOf(Locale.ITALIAN)),
             Locale.JAPANESE
         )
 

--- a/nlp/front/shared/src/main/kotlin/codec/CreateApplicationQuery.kt
+++ b/nlp/front/shared/src/main/kotlin/codec/CreateApplicationQuery.kt
@@ -23,6 +23,7 @@ import java.util.Locale
  */
 data class CreateApplicationQuery(
     val name: String,
+    val label: String?,
     val namespace: String,
     val locale: Locale
 )

--- a/nlp/front/shared/src/main/kotlin/config/ApplicationDefinition.kt
+++ b/nlp/front/shared/src/main/kotlin/config/ApplicationDefinition.kt
@@ -31,6 +31,10 @@ data class ApplicationDefinition(
      */
     val name: String,
     /**
+     * The label of the app.
+     */
+    val label: String = name,
+    /**
      * The namespace of the app.
      */
     val namespace: String,

--- a/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_.kt
+++ b/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_.kt
@@ -18,6 +18,8 @@ import org.litote.kmongo.property.KPropertyPath
 
 private val __Name: KProperty1<ApplicationDefinition, String?>
     get() = ApplicationDefinition::name
+private val __Label: KProperty1<ApplicationDefinition, String?>
+    get() = ApplicationDefinition::label
 private val __Namespace: KProperty1<ApplicationDefinition, String?>
     get() = ApplicationDefinition::namespace
 private val __Intents: KProperty1<ApplicationDefinition, Set<Id<IntentDefinition>>?>
@@ -41,6 +43,9 @@ class ApplicationDefinition_<T>(previous: KPropertyPath<T, *>?, property: KPrope
         ApplicationDefinition?>) : KPropertyPath<T, ApplicationDefinition?>(previous,property) {
     val name_: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Name)
+
+    val label: KPropertyPath<T, String?>
+        get() = KPropertyPath(this,__Label)
 
     val namespace: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Namespace)
@@ -72,6 +77,8 @@ class ApplicationDefinition_<T>(previous: KPropertyPath<T, *>?, property: KPrope
     companion object {
         val Name: KProperty1<ApplicationDefinition, String?>
             get() = __Name
+        val Label: KProperty1<ApplicationDefinition, String?>
+            get() = __Label
         val Namespace: KProperty1<ApplicationDefinition, String?>
             get() = __Namespace
         val Intents: KCollectionSimplePropertyPath<ApplicationDefinition, Id<IntentDefinition>?>
@@ -98,6 +105,9 @@ class ApplicationDefinition_Col<T>(previous: KPropertyPath<T, *>?, property: KPr
         ApplicationDefinition_<T>>(previous,property) {
     val name_: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Name)
+
+    val label: KPropertyPath<T, String?>
+        get() = KPropertyPath(this,__Label)
 
     val namespace: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Namespace)
@@ -135,6 +145,9 @@ class ApplicationDefinition_Map<T, K>(previous: KPropertyPath<T, *>?, property: 
         ApplicationDefinition_<T>>(previous,property) {
     val name_: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Name)
+
+    val label: KPropertyPath<T, String?>
+        get() = KPropertyPath(this,__Label)
 
     val namespace: KPropertyPath<T, String?>
         get() = KPropertyPath(this,__Namespace)

--- a/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_Deserializer.kt
+++ b/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_Deserializer.kt
@@ -29,6 +29,8 @@ internal class ApplicationDefinition_Deserializer : JsonDeserializer<Application
         with(p) {
             var _name_: String? = null
             var _name_set : Boolean = false
+            var _label_: String? = null
+            var _label_set : Boolean = false
             var _namespace_: String? = null
             var _namespace_set : Boolean = false
             var _intents_: MutableSet<Id<IntentDefinition>>? = null
@@ -61,6 +63,11 @@ internal class ApplicationDefinition_Deserializer : JsonDeserializer<Application
                             _name_ = if(_token_ == JsonToken.VALUE_NULL) null
                              else p.text;
                             _name_set = true
+                            }
+                    "label" -> {
+                            _label_ = if(_token_ == JsonToken.VALUE_NULL) null
+                             else p.text;
+                            _label_set = true
                             }
                     "namespace" -> {
                             _namespace_ = if(_token_ == JsonToken.VALUE_NULL) null
@@ -115,18 +122,22 @@ internal class ApplicationDefinition_Deserializer : JsonDeserializer<Application
                     } 
                 _token_ = currentToken
                         } 
-            return if(_name_set && _namespace_set && _intents_set && _supportedLocales_set &&
-                    _intentStatesMap_set && _nlpEngineType_set && _mergeEngineTypes_set &&
-                    _useEntityModels_set && _supportSubEntities_set && __id_set)
-                    ApplicationDefinition(name = _name_!!, namespace = _namespace_!!, intents =
-                            _intents_!!, supportedLocales = _supportedLocales_!!, intentStatesMap =
-                            _intentStatesMap_!!, nlpEngineType = _nlpEngineType_!!, mergeEngineTypes
-                            = _mergeEngineTypes_!!, useEntityModels = _useEntityModels_!!,
+            return if(_name_set && _label_set && _namespace_set && _intents_set &&
+                    _supportedLocales_set && _intentStatesMap_set && _nlpEngineType_set &&
+                    _mergeEngineTypes_set && _useEntityModels_set && _supportSubEntities_set &&
+                    __id_set)
+                    ApplicationDefinition(name = _name_!!, label = _label_!!, namespace =
+                            _namespace_!!, intents = _intents_!!, supportedLocales =
+                            _supportedLocales_!!, intentStatesMap = _intentStatesMap_!!,
+                            nlpEngineType = _nlpEngineType_!!, mergeEngineTypes =
+                            _mergeEngineTypes_!!, useEntityModels = _useEntityModels_!!,
                             supportSubEntities = _supportSubEntities_!!, _id = __id_!!)
                     else {
                     val map = mutableMapOf<KParameter, Any?>()
                     if(_name_set)
                     map[parameters.getValue("name")] = _name_
+                    if(_label_set)
+                    map[parameters.getValue("label")] = _label_
                     if(_namespace_set)
                     map[parameters.getValue("namespace")] = _namespace_
                     if(_intents_set)
@@ -157,7 +168,8 @@ internal class ApplicationDefinition_Deserializer : JsonDeserializer<Application
 
         private val parameters: Map<String, KParameter> by lazy(LazyThreadSafetyMode.PUBLICATION) {
                 kotlin.collections.mapOf("name" to primaryConstructor.findParameterByName("name")!!,
-                "namespace" to primaryConstructor.findParameterByName("namespace")!!, "intents" to
+                "label" to primaryConstructor.findParameterByName("label")!!, "namespace" to
+                primaryConstructor.findParameterByName("namespace")!!, "intents" to
                 primaryConstructor.findParameterByName("intents")!!, "supportedLocales" to
                 primaryConstructor.findParameterByName("supportedLocales")!!, "intentStatesMap" to
                 primaryConstructor.findParameterByName("intentStatesMap")!!, "nlpEngineType" to

--- a/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_Serializer.kt
+++ b/nlp/front/storage-mongo/target/generated-sources/kapt/compile/ai/tock/nlp/front/shared/config/ApplicationDefinition_Serializer.kt
@@ -20,6 +20,9 @@ internal class ApplicationDefinition_Serializer :
         gen.writeFieldName("name")
         val _name_ = value.name
         gen.writeString(_name_)
+        gen.writeFieldName("label")
+        val _label_ = value.label
+        gen.writeString(_label_)
         gen.writeFieldName("namespace")
         val _namespace_ = value.namespace
         gen.writeString(_namespace_)


### PR DESCRIPTION
I replaced spaces by underscores '_' where applicationId is used in : 
- Connector path
- REST connector "test" path

Did not replace other special chars.
Did not replace spaces, where namespace is used for path (but namespace cannot include space right?).