### PR TITLE
785 fixes search filter disabled after story update

### DIFF
--- a/bot/admin/web/src/app/bot/story/search-story.component.ts
+++ b/bot/admin/web/src/app/bot/story/search-story.component.ts
@@ -84,7 +84,6 @@ export class SearchStoryComponent implements OnInit, OnDestroy {
           s2.selected = true;
         }
       }
-      this.stories = s.filter(story => !story.isBuiltIn());
       this.loadedStories = s;
       s.forEach(story => {
         story.hideDetails = true;
@@ -93,6 +92,7 @@ export class SearchStoryComponent implements OnInit, OnDestroy {
         }
       });
       this.categories.sort();
+      this.search();
       this.loading = false;
     });
   }


### PR DESCRIPTION
Fixes issue #785 (moved from former repository).

I suppose it is not necessary to reset state after a story update, considering intent modifications (eg. modifying the intent or its category) are performed in an additional dialog with its own Update button resetting state.