### PR TITLE
[messenger connector] button template constraints

### DIFF
--- a/bot/connector-messenger/src/main/kotlin/MessengerBuilders.kt
+++ b/bot/connector-messenger/src/main/kotlin/MessengerBuilders.kt
@@ -122,13 +122,22 @@ fun I18nTranslator.buttonsTemplate(text: CharSequence, vararg actions: UserActio
 /**
  * Creates a button template [https://developers.facebook.com/docs/messenger-platform/send-api-reference/button-template]
  */
-fun I18nTranslator.buttonsTemplate(text: CharSequence, actions: List<UserAction> = emptyList()): AttachmentMessage {
+fun I18nTranslator.buttonsTemplate(text: CharSequence, actions: List<UserAction>): AttachmentMessage {
+    val buttons = extractButtons(actions)
+    if (buttons.isEmpty() || buttons.size > 4) {
+        error("buttonsTemplate must have at least 1 button and at most 3")
+    }
+
+    if(text.length > 640) {
+        error("text $text in buttonTemplate should not exceed 640 chars.")
+    }
+
     return AttachmentMessage(
         Attachment(
             AttachmentType.template,
             ButtonPayload(
                 translate(text).toString(),
-                extractButtons(actions)
+                buttons
             )
         ),
         extractQuickReplies(actions.toList())
@@ -288,7 +297,7 @@ fun genericTemplate(vararg elements: Element): AttachmentMessage {
  */
 fun genericTemplate(elements: List<Element>, quickReplies: List<QuickReply>): AttachmentMessage {
     if (elements.isEmpty() || elements.size > 10) {
-        error("must have at least 1 elements and at most 10")
+        error("genericTemplate must have at least 1 elements and at most 10")
     }
 
     return AttachmentMessage(
@@ -434,16 +443,7 @@ fun I18nTranslator.listElement(
     imageUrl: String? = null,
     button: Button? = null
 ): Element {
-    val t = translate(title)
-    val s = translateAndReturnBlankAsNull(subtitle)
-
-    if (t.length > 80) {
-        logger.warn { "title $t has more than 80 chars" }
-    }
-    if (s?.length ?: 0 > 80) {
-        logger.warn { "subtitle $s has more than 80 chars" }
-    }
-    return Element(t, s, imageUrl, listOfNotNull(button))
+    return genericElement(title, subtitle, imageUrl, listOfNotNull(button))
 }
 
 /**

--- a/bot/connector-messenger/src/main/kotlin/model/send/ButtonPayload.kt
+++ b/bot/connector-messenger/src/main/kotlin/model/send/ButtonPayload.kt
@@ -21,9 +21,8 @@ import ai.tock.shared.security.StringObfuscatorMode
 import ai.tock.shared.security.TockObfuscatorService.obfuscate
 
 /**
- *
+ * See [https://developers.facebook.com/docs/messenger-platform/send-messages/template/button]
  */
-//TODO check 640 char text limit
 data class ButtonPayload(val text: String, val buttons: List<Button>) : ModelPayload(PayloadType.button) {
 
     override fun toGenericMessage(): GenericMessage? {

--- a/bot/connector-messenger/src/main/kotlin/model/send/ModelPayload.kt
+++ b/bot/connector-messenger/src/main/kotlin/model/send/ModelPayload.kt
@@ -18,9 +18,6 @@ package ai.tock.bot.connector.messenger.model.send
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-/**
- *
- */
 abstract class ModelPayload(@get:JsonProperty("template_type") val templateType: PayloadType) : Payload() {
 
 }

--- a/bot/connector-messenger/src/main/kotlin/model/send/TextMessage.kt
+++ b/bot/connector-messenger/src/main/kotlin/model/send/TextMessage.kt
@@ -22,10 +22,6 @@ import ai.tock.bot.engine.message.GenericMessage.Companion.TEXT_PARAM
 import ai.tock.shared.security.StringObfuscatorMode
 import ai.tock.shared.security.TockObfuscatorService.obfuscate
 
-/**
- *
- */
-//TODO check 640 char text limit https://developers.facebook.com/docs/messenger-platform/send-api-reference/text-message
 class TextMessage(val text: String, quickReplies: List<QuickReply>? = null) : Message(quickReplies?.run { if (isEmpty()) null else this }) {
 
     override fun toGenericMessage(): GenericMessage? {

--- a/bot/connector-messenger/src/test/kotlin/MessengerBuildersTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/MessengerBuildersTest.kt
@@ -26,6 +26,7 @@ import ai.tock.bot.connector.messenger.model.send.AttachmentType.video
 import ai.tock.bot.connector.messenger.model.send.ListElementStyle
 import ai.tock.bot.connector.messenger.model.send.ListPayload
 import ai.tock.bot.connector.messenger.model.send.UrlPayload
+import ai.tock.bot.definition.Intent
 import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.user.UserPreferences
 import ai.tock.shared.sharedTestModule
@@ -75,6 +76,28 @@ class MessengerBuildersTest {
     }
 
     @Test
+    fun `buttonTemplate throws exception when text exceed 640 chars`() {
+        assertThrows<IllegalStateException> {
+            bus.buttonsTemplate(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                        "Curabitur vitae augue dignissim, ultrices tortor sed, fringilla neque. Maecenas sit amet efficitur enim. " +
+                        "Pellentesque nec dictum tellus. Etiam rhoncus arcu nunc, eget sagittis lacus rutrum ac. Aenean eu ipsum " +
+                        "lorem. Vestibulum condimentum, ligula in euismod auctor, felis ante semper erat, ut laoreet est libero " +
+                        "ut tellus. Duis sollicitudin justo id est lobortis sollicitudin. Fusce gravida sagittis nibh id tempor. " +
+                        "Proin a imperdiet est. In arcu est, imperdiet quis pellentesque vitae, tincidunt sit amet massa. Nunc " +
+                        "laoreet orci eu fringilla auctor. Aliquam interdum odio vel metus.", bus.postbackButton("button", Intent("myIntent"))
+            )
+        }
+    }
+
+    @Test
+    fun `buttonTemplate throws exception when there is no buttons`() {
+        assertThrows<IllegalStateException> {
+            bus.buttonsTemplate("toto", bus.quickReply("quickreply", Intent("myIntent")))
+        }
+    }
+
+    @Test
     fun testImage() {
         assertEquals(
             AttachmentMessage(
@@ -112,7 +135,7 @@ class MessengerBuildersTest {
 
     @Test
     fun testSendToMessenger() {
-        bus.sendToMessenger { buttonsTemplate("Button") }
+        bus.sendToMessenger { buttonsTemplate("Button", postbackButton("button", Intent("myIntent"))) }
 
         verify { bus.withMessage(any()) }
         verify { bus.send(any<Long>()) }
@@ -120,7 +143,7 @@ class MessengerBuildersTest {
 
     @Test
     fun testSendToMessengerWithDelay() {
-        bus.sendToMessenger(10) { buttonsTemplate("Button") }
+        bus.sendToMessenger(10) { buttonsTemplate("Button", postbackButton("button", Intent("myIntent"))) }
 
         verify { bus.withMessage(any()) }
         verify { bus.send(10) }
@@ -128,7 +151,7 @@ class MessengerBuildersTest {
 
     @Test
     fun testEndForMessenger() {
-        bus.endForMessenger { buttonsTemplate("Button") }
+        bus.endForMessenger { buttonsTemplate("Button", postbackButton("button", Intent("myIntent"))) }
 
         verify { bus.withMessage(any()) }
         verify { bus.end(any<Long>()) }


### PR DESCRIPTION
 Button template on messenger connector constraints to text limit (640 characters) and numbers of button (1 to 3)