### PR TITLE
fixes #999: Allow to use named argument in format message label

### DIFF
--- a/translator/core/src/main/kotlin/NamedArgumentNormalizer.kt
+++ b/translator/core/src/main/kotlin/NamedArgumentNormalizer.kt
@@ -1,0 +1,48 @@
+package ai.tock.translator
+
+import mu.KotlinLogging
+
+internal object NamedArgumentNormalizer {
+
+    private val logger = KotlinLogging.logger {}
+    private val enrichedArgPattern = "\\{:([a-zA-Z_]+)\\}".toRegex()
+    private val vanillaArgPattern = "\\{[0-9]+\\}".toRegex()
+
+    /**
+     * @param label e.g: "{:arg_name} {0} {:customName}"
+     * @return messageFormat label and compatible arguments
+     */
+    fun normalize(label: String, args: List<Any?> = emptyList()): NamedArgResult {
+        try {
+            val argNames = enrichedArgPattern.findAll(label)
+                .sortedBy { it.range.first }
+                .map { it.groupValues }
+                .map { it.last() }
+                .toList()
+
+            if (argNames.isEmpty()) {
+                return NamedArgResult(label, args)
+            }
+
+            val enrichedArgs = args.filterIsInstance<Pair<String, Any?>>()
+            val vanillaArgs = args.subtract(enrichedArgs).toList()
+            val newArgsOffset = vanillaArgPattern.findAll(label).count()
+
+            val argsMap = enrichedArgs.toMap()
+
+            return NamedArgResult(
+                argNames.foldIndexed(label) { index, p, arg ->
+                    p.replace(
+                        "{:${arg}}",
+                        "{${index + newArgsOffset}}"
+                    )
+                },
+                vanillaArgs + argNames.map { argsMap[it] ?: ":$it" })
+        } catch (e: Exception) {
+            logger.error("error with $label and $args", e)
+            return NamedArgResult(label, args)
+        }
+    }
+}
+
+internal data class NamedArgResult(val label: String, val args: List<Any?>)

--- a/translator/core/src/main/kotlin/Translator.kt
+++ b/translator/core/src/main/kotlin/Translator.kt
@@ -352,8 +352,11 @@ object Translator {
         if (args.isEmpty()) {
             return label
         }
-        return MessageFormat(escapeQuotes(label), context.userLocale).format(
-            args.map { formatArg(it, context) }.toTypedArray(),
+
+        val (normalizedLabel, normalizedArgs) = NamedArgumentNormalizer.normalize(label, args)
+
+        return MessageFormat(escapeQuotes(normalizedLabel), context.userLocale).format(
+            normalizedArgs.map { formatArg(it, context) }.toTypedArray(),
             StringBuffer(),
             null
         ).toString()
@@ -367,7 +370,7 @@ object Translator {
         if (source == target) {
             return text
         }
-        val t = escapeQuotes(text)
+        val t = escapeQuotes(NamedArgumentNormalizer.normalize(text).label)
         val m = MessageFormat(t, source)
         var pattern = m.toPattern()
         val choicePrefixList: MutableList<String> = mutableListOf()

--- a/translator/core/src/test/kotlin/NamedArgumentNormalizerTest.kt
+++ b/translator/core/src/test/kotlin/NamedArgumentNormalizerTest.kt
@@ -1,0 +1,148 @@
+package ai.tock.translator
+
+import ai.tock.translator.NamedArgumentNormalizer.normalize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.text.MessageFormat
+import java.time.LocalDate
+
+internal class NamedArgumentNormalizerTest {
+
+    @Test
+    fun normalize_shouldHandle_onlyNamedArgs() {
+        val result = normalize(
+            "nom: {:name}, age {:age}",
+            listOf(
+                "name" to "smith",
+                "age" to 10
+            )
+        )
+
+        assertEquals("nom: {0}, age {1}", result.label)
+        assertEquals(listOf("smith", 10), result.args)
+    }
+
+    @Test
+    fun normalize_shouldHandle_namedArgsWithUppercase() {
+        val result = normalize(
+            "nom: {:NaMe}, age {:age}",
+            listOf(
+                "NaMe" to "smith",
+                "age" to 10
+            )
+        )
+
+        assertEquals("nom: {0}, age {1}", result.label)
+        assertEquals(listOf("smith", 10), result.args)
+    }
+
+
+    @Test
+    fun normalize_shouldHandle_namedArgsWithUnderscore() {
+        val result = normalize(
+            "nom: {:first_name}, age {:age}",
+            listOf(
+                "first_name" to "smith",
+                "age" to 10
+            )
+        )
+
+        assertEquals("nom: {0}, age {1}", result.label)
+        assertEquals(listOf("smith", 10), result.args)
+    }
+
+    @Test
+    fun normalize_shouldHandle_onlyVanillaArgs() {
+        val result = normalize(
+            "firstname: {0}, lastname {1}",
+            listOf(
+                "john",
+                "doe"
+            )
+        )
+
+        assertEquals("firstname: {0}, lastname {1}", result.label)
+        assertEquals(listOf("john", "doe"), result.args)
+    }
+
+    @Test
+    fun normalize_shouldHandle_mixArgTypes() {
+        val result = normalize(
+            "nom: {:name}, {0} age {:age_noe} {1}",
+            listOf(
+                "age_noe" to 123,
+                "first parameter",
+                "name" to "smith",
+                "last parameter"
+            )
+        )
+
+        assertEquals("nom: {2}, {0} age {3} {1}", result.label)
+        assertEquals(listOf("first parameter", "last parameter", "smith", 123), result.args)
+    }
+
+    @Test
+    fun normalize_shouldNotCheck_VanillaArgConsistency() {
+        val result = normalize(
+            "nom: {:name}, {0} age {:age_noe} {1}",
+            listOf(
+                "age_noe" to 123,
+                "first parameter",
+                "name" to "smith"
+            )
+        )
+
+        assertEquals("nom: {2}, {0} age {3} {1}", result.label)
+        assertEquals(listOf("first parameter", "smith", 123), result.args)
+        assertEquals("nom: 123, first parameter age {3} smith", MessageFormat.format(result.label, *result.args.toTypedArray()))
+    }
+
+    @Test
+    fun normalize_shouldHandle_complexArgsValue() {
+        val result = normalize(
+            "nom: {:name}, date of birth {:date_of_birth}",
+            listOf(
+                "name" to "smith",
+                "date_of_birth" to LocalDate.of(2000, 12, 25)
+            )
+        )
+
+        assertEquals("nom: {0}, date of birth {1}", result.label)
+        assertEquals(listOf("smith", LocalDate.of(2000, 12, 25)), result.args)
+    }
+
+    @Test
+    fun normalize_shouldFillWithMissingArgWithArgName() {
+        val result = normalize(
+            "nom: {:name}, age {:age} {:address}",
+            listOf("age" to 10)
+        )
+        assertEquals("nom: {0}, age {1} {2}", result.label)
+        assertEquals(listOf(":name", 10, ":address"), result.args)
+        assertEquals("nom: :name, age 10 :address", MessageFormat.format(result.label, *result.args.toTypedArray()))
+    }
+
+    @Test
+    fun normalize_shouldNotRaiseException_IfArgsAreEmpty() {
+        val result = normalize("nom: {:name}, date of birth {:date_of_birth}")
+
+        assertEquals("nom: {0}, date of birth {1}", result.label)
+        assertEquals("nom: {0}, date of birth {1}", MessageFormat.format(result.label))
+    }
+
+    @Test
+    fun normalize_shouldHandle_wrongTags() {
+        val result = normalize(
+            "nom: {:name}, {0} {:} {other} :age: {:age_noe}  {:",
+            listOf(
+                "age_noe" to 10,
+                "first parameter",
+                "name" to "smith"
+            )
+        )
+
+        assertEquals("nom: {1}, {0} {:} {other} :age: {2}  {:", result.label)
+        assertEquals(listOf("first parameter", "smith", 10), result.args)
+    }
+
+}


### PR DESCRIPTION
Allow user to use named arguments in i18n labels.

- allowed characters : a-z, A-Z and underscore
- argument name format {:name}


Signed-off-by: Toki RAOSETA <toki.raoseta@gmail.com>