### PR TITLE
fixes #1063 Studio: cannot purge disabled-language labels

### DIFF
--- a/bot/admin/web/src/app/bot/i18n/i18n-label.component.html
+++ b/bot/admin/web/src/app/bot/i18n/i18n-label.component.html
@@ -23,8 +23,9 @@
         <span class="i18n-label__title__label"
               nbTooltip="ns: {{i.namespace}}, key: {{i._id}}">{{i.defaultLocalizedLabel().label.length === 0 ? i._id : i.defaultLocalizedLabel().label}}
         </span>
-        <button class="i18n-label__title__delete" *ngIf="deleteAllowed" nbButton  outline status="danger" size="small" (click)="deleteLabel(i)"
-        nbTooltip="Delete Label" color="warn">
+        <button class="i18n-label__title__delete" nbButton outline status="danger" color="warn" size="small"
+                nbTooltip="Delete Label (including alternative, type, connector and localized configs)"
+                [disabled]="!deleteLabelAllowed" (click)="deleteLabel(i)">
           Delete
         </button>
     </div>
@@ -45,78 +46,16 @@
   </nb-card-header>
 
     <nb-card-body>
-      <div
-        class="i18n-label__entry i18n-label__entry--language-{{l.locale}} i18n-label__entry--mode-{{l.interfaceType}}"
-        *ngFor="let l of i.i18n; let isLast = last; let index = index">
+      <div *ngFor="let l of i.i18n; let isLast = last; let index = index">
 
-        <div class="i18n-label__entry__label_details">
-          <!-- Locale -->
-          <div class="i18n-label__entry__locale" title="{{l.displayStats()}}">{{l.locale}}</div>
-
-          <!-- Interface type -->
-          <div class="i18n-label__entry__mode">
-            <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 0" mat-list-avatar>chat
-            </mat-icon>
-            <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 1" mat-list-avatar>
-              record_voice_over
-            </mat-icon>
-          </div>
-
-          <!-- Connector -->
-          <div class="i18n-label__entry__connector" *ngIf="l.connectorId">
-            <img *ngIf="l.connectorId"
-                 src="{{l.iconUrl()}}"
-                 class="i18n-label__entry__connector__img"
-                 [nbTooltip]="l.connectorId"/>
-          </div>
-        </div>
-
-        <!-- Label -->
-        <div class="i18n-label__entry__input">
-          <textarea class="i18n-label__entry__input__textarea"
-                    nbInput rows="1"
-                    [(ngModel)]="l.label"
-                    (change)="save(i)"
-                    [title]="l.stats && l.stats.length !== 0 ? ('used '+ l.mergedStats().count +' times, last used ' + (l.mergedStats().lastUpdate | amTimeAgo)) : 'No stats'"></textarea>
-        </div>
-
-        <div class="i18n-label__entry__actions">
-          <!-- Add alternative -->
-          <div class="i18n-label__entry__alternative-management">
-            <button class="i18n-label__entry__alternatives__button"
-                    nbButton
-                    ghost
-                    nbTooltip="Add an alternative"
-                    status="info"
-                    (click)="addNewAlternative(l)">
-                    <nb-icon icon="plus-outline"></nb-icon>
-            </button>
-          </div>
-
-          <!-- Delete label -->
-          <div class="i18n-label__entry__delete">
-            <button *ngIf="deleteAllowed"
-                    (click)="removeLocalizedLabel(i, l)"
-                    nbButton
-                    nbTooltip="Delete Label"
-                    status="danger"
-                    ghost>
-              <nb-icon icon="trash-2-outline"></nb-icon>
-            </button>
-          </div>
-
-          <!-- Validate label -->
-          <div class="i18n-label__entry__validation">
-            <nb-checkbox [(ngModel)]="l.validated" (change)="save(i)" nbTooltip="Validate label" status="info"></nb-checkbox>
-          </div>
-        </div>
-
-        <!-- Alternatives -->
-        <div class="i18n-label__entry__alternatives" *ngFor="let a of l.alternatives;let index=index;">
+        <div *ngIf="isLocalizedVisible(l)"
+             class="i18n-label__entry i18n-label__entry--language-{{l.locale}} i18n-label__entry--mode-{{l.interfaceType}}">
 
           <div class="i18n-label__entry__label_details">
-            <div class="i18n-label__entry__locale">{{l.locale}}</div>
+            <!-- Locale -->
+            <div class="i18n-label__entry__locale" title="{{l.displayStats()}}">{{l.locale}}</div>
 
+            <!-- Interface type -->
             <div class="i18n-label__entry__mode">
               <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 0" mat-list-avatar>chat
               </mat-icon>
@@ -125,6 +64,7 @@
               </mat-icon>
             </div>
 
+            <!-- Connector -->
             <div class="i18n-label__entry__connector" *ngIf="l.connectorId">
               <img *ngIf="l.connectorId"
                    src="{{l.iconUrl()}}"
@@ -133,43 +73,113 @@
             </div>
           </div>
 
+          <!-- Label -->
           <div class="i18n-label__entry__input">
-            <textarea class="i18n-label__entry__input__textarea i18n-label__entry__textarea_alternative"
-                      nbInput
-                      [value]="a"
-                      (change)="addAlternative(i, l, index, $event.target.value)"
-                      rows="1"></textarea>
+            <textarea class="i18n-label__entry__input__textarea"
+                      nbInput rows="1"
+                      [(ngModel)]="l.label"
+                      (change)="save(i)"
+                      [nbTooltip]="isSupportedLocale(l)
+                        ? (l.stats && l.stats.length !== 0 ? ('used '+ l.mergedStats().count +' times, last used ' + (l.mergedStats().lastUpdate | amTimeAgo)) : 'No stats')
+                        : 'Delete-only since locale is not supported by current application'"
+                      [disabled]="!isSupportedLocale(l)"></textarea>
           </div>
 
           <div class="i18n-label__entry__actions">
-            <!-- Remove alternative -->
-            <div class="i18n-label__entry__alternative-management remove_alternative">
-              <button class="i18n-label__entry__alternatives__button" nbButton ghost nbTooltip="Remove alternative" status="danger"
-                      (click)="removeAlternative(i, l, index)">
-                <nb-icon icon="minus-outline"></nb-icon>
+            <!-- Add alternative -->
+            <div class="i18n-label__entry__alternative-management">
+              <button class="i18n-label__entry__alternatives__button"
+                      nbButton
+                      ghost
+                      [nbTooltip]="isSupportedLocale(l) ? 'Add an alternative' : 'Delete-only since locale is not supported by current application'"
+                      status="info"
+                      (click)="addNewAlternative(l)"
+                      [disabled]="!isSupportedLocale(l)">
+                      <nb-icon icon="plus-outline"></nb-icon>
               </button>
             </div>
-          </div>
-        </div>
 
-        <!-- Add specific label for connector -->
-        <div class="i18n-label__entry__connectors"
-             *ngIf="isLast || i.i18n[index + 1].interfaceType !== l.interfaceType || i.i18n[index + 1].locale !== l.locale">
-          <div class="i18n-label__entry__connector_container">
-            <span *ngFor="let connector of connectorTypes">
-              <!-- Connectors buttons -->
-              <mat-action-list class="i18n-label__entry__connector-list">
-              <button
-                *ngIf="!i.hasLocaleAndInterfaceAndConnector(l.locale, l.interfaceType, connector.connectorType.id)"
-                (click)="addLocalizedLabelForConnector(i, l, connector.connectorType.id)"
-                nbTooltip="Add specific label for connector {{connector.connectorType.id}}"
-                mat-list-item>
-                 <img src="{{connector.connectorType.iconUrl()}}" class="i18n-label__entry__connector__img"/>
+            <!-- Delete label -->
+            <div class="i18n-label__entry__delete">
+              <button *ngIf="deleteLocalizedAllowed"
+                      (click)="removeLocalizedLabel(i, l)"
+                      nbButton
+                      nbTooltip="Delete Localized Label"
+                      status="danger"
+                      ghost>
+                <nb-icon icon="trash-2-outline"></nb-icon>
               </button>
-              </mat-action-list>
-            </span>
+            </div>
+
+            <!-- Validate label -->
+            <div class="i18n-label__entry__validation">
+              <nb-checkbox [(ngModel)]="l.validated" (change)="save(i)" status="info"
+                           [nbTooltip]="isSupportedLocale(l) ? 'Validate label (for exports/imports)' : 'Delete-only since locale is not supported by current application'"
+                           [disabled]="!isSupportedLocale(l)"></nb-checkbox>
+            </div>
           </div>
-          <mat-divider *ngIf="!isLast"></mat-divider>
+
+          <!-- Alternatives -->
+          <div class="i18n-label__entry__alternatives" *ngFor="let a of l.alternatives;let index=index;">
+
+            <div class="i18n-label__entry__label_details">
+              <div class="i18n-label__entry__locale">{{l.locale}}</div>
+
+              <div class="i18n-label__entry__mode">
+                <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 0" mat-list-avatar>chat
+                </mat-icon>
+                <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 1" mat-list-avatar>
+                  record_voice_over
+                </mat-icon>
+              </div>
+
+              <div class="i18n-label__entry__connector" *ngIf="l.connectorId">
+                <img *ngIf="l.connectorId"
+                     src="{{l.iconUrl()}}"
+                     class="i18n-label__entry__connector__img"
+                     [nbTooltip]="l.connectorId"/>
+              </div>
+            </div>
+
+            <div class="i18n-label__entry__input">
+              <textarea class="i18n-label__entry__input__textarea i18n-label__entry__textarea_alternative"
+                        nbInput
+                        [value]="a"
+                        [disabled]="!isSupportedLocale(l)"
+                        (change)="addAlternative(i, l, index, $event.target.value)"
+                        rows="1"></textarea>
+            </div>
+
+            <div class="i18n-label__entry__actions">
+              <!-- Remove alternative -->
+              <div class="i18n-label__entry__alternative-management remove_alternative">
+                <button class="i18n-label__entry__alternatives__button" nbButton ghost nbTooltip="Remove alternative" status="danger"
+                        (click)="removeAlternative(i, l, index)">
+                  <nb-icon icon="minus-outline"></nb-icon>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Add specific label for connector -->
+          <div class="i18n-label__entry__connectors"
+               *ngIf="isLast || i.i18n[index + 1].interfaceType !== l.interfaceType || i.i18n[index + 1].locale !== l.locale">
+            <div class="i18n-label__entry__connector_container">
+              <span *ngFor="let connector of connectorTypes">
+                <!-- Connectors buttons -->
+                <mat-action-list class="i18n-label__entry__connector-list">
+                <button
+                  *ngIf="isSupportedLocale(l) && !i.hasLocaleAndInterfaceAndConnector(l.locale, l.interfaceType, connector.connectorType.id)"
+                  (click)="addLocalizedLabelForConnector(i, l, connector.connectorType.id)"
+                  nbTooltip="Add specific label for connector {{connector.connectorType.id}}"
+                  mat-list-item>
+                   <img src="{{connector.connectorType.iconUrl()}}" class="i18n-label__entry__connector__img"/>
+                </button>
+                </mat-action-list>
+              </span>
+            </div>
+            <mat-divider *ngIf="!isLast"></mat-divider>
+          </div>
         </div>
       </div>
     </nb-card-body>

--- a/bot/admin/web/src/app/bot/i18n/i18n-label.component.ts
+++ b/bot/admin/web/src/app/bot/i18n/i18n-label.component.ts
@@ -32,10 +32,16 @@ export class I18nLabelComponent implements OnInit {
   localeBase: string = null;
 
   @Input()
+  locales = new Set<string>();
+
+  @Input()
   i: I18nLabel;
 
   @Input()
-  deleteAllowed: boolean = true;
+  deleteLabelAllowed: boolean = true;
+
+  @Input()
+  deleteLocalizedAllowed: boolean = true;
 
   @Input()
   i18nController: I18nController;
@@ -66,8 +72,18 @@ export class I18nLabelComponent implements OnInit {
 
     if (!this.i18nController) {
       this.i18nController = new I18nController(this.state, [this.i], this.localeBase);
-      this.i18nController.fillLabels();
+      this.i18nController.fillLabels(this.locales);
     }
+  }
+
+  isSupportedLocale(i18n: I18nLocalizedLabel) {
+    const supportedLocales = this.state.currentApplication.supportedLocales;
+    return supportedLocales == null || supportedLocales.indexOf(i18n.locale) != -1;
+  }
+
+  isLocalizedVisible(i18n: I18nLocalizedLabel) {
+    const isNew = !i18n.label || i18n.label.length == 0;
+    return this.isSupportedLocale(i18n) || !isNew;
   }
 
   deleteLabel(label: I18nLabel) {
@@ -103,7 +119,7 @@ export class I18nLabelComponent implements OnInit {
   addLocalizedLabelForConnector(i18n: I18nLabel, label: I18nLocalizedLabel, connectorId: string) {
     i18n.i18n.push(new I18nLocalizedLabel(label.locale, label.interfaceType, '', false, connectorId, []));
     this.save(i18n);
-    this.i18nController.fillLabels();
+    this.i18nController.fillLabels(this.locales);
   }
 
   addAlternative(i18n: I18nLabel, label: I18nLocalizedLabel, index: number, value: string) {
@@ -133,8 +149,7 @@ export class I18nController {
     //do nothing
   }
 
-  fillLabels() {
-    const locales = this.state.currentApplication.supportedLocales;
+  fillLabels(locales: Set<string>) {
     this.i18n.forEach(i => {
         //add non present i18n
         locales.forEach(locale => {

--- a/bot/admin/web/src/app/bot/i18n/i18n.component.html
+++ b/bot/admin/web/src/app/bot/i18n/i18n.component.html
@@ -22,8 +22,20 @@
               (keyup)="filter($event.target.value)">
       </nb-form-field>
       <span class="i18n-select nb-form-field-infix">
+        <nb-select placeholder="Filter by locale" [(ngModel)]="filterLocale" class="nb-select" status="primary"
+                   (selectedChange)="filterChanged()">
+          <nb-option value="" title="All locales, including not supported by application">All</nb-option>
+          <nb-option value="current" title="Only current locale">Current locale</nb-option>
+          <nb-option value="supported" title="Only locales, currently supported by application">Supported locales</nb-option>
+          <nb-option value="not_supported" title="Only locales, not supported by application">Not supported locales</nb-option>
+        </nb-select>
+        <span class="nb-form-field-label-wrapper">
+          <label class="label-title">Filter by locale</label>
+        </span>
+      </span>
+      <span class="i18n-select nb-form-field-infix">
         <nb-select placeholder="Filter by category" [(ngModel)]="selectedCategory" class="nb-select" status="primary"
-                   (selectedChange)="onSelectedCategoryChange()">
+                   (selectedChange)="filterChanged()">
           <nb-option *ngFor="let c of allCategories" [value]="c">{{c}}</nb-option>
         </nb-select>
         <span class="nb-form-field-label-wrapper">
@@ -32,7 +44,7 @@
       </span>
       <span class="i18n-select nb-form-field-infix">
         <nb-select placeholder="Filter by state" [(ngModel)]="filterOption" class="nb-select" status="primary"
-                   (selectedChange)="filterValidatedChange()">
+                   (selectedChange)="filterChanged()">
           <nb-option value="">All</nb-option>
           <nb-option value="not_validated">Only not validated</nb-option>
           <nb-option value="validated">Only validated</nb-option>
@@ -43,7 +55,7 @@
       </span>
       <span class="i18n-select nb-form-field-infix">
         <nb-select placeholder="Not used since" [(ngModel)]="notUsedFrom" class="nb-select" status="primary"
-                   (selectedChange)="onNotUsedFromChange()">
+                   (selectedChange)="filterChanged()">
           <nb-select-label>
             {{ notUsedFromLabel(notUsedFrom) }}
           </nb-select-label>
@@ -88,7 +100,9 @@
     <mat-list dense *ngIf="!loading">
       <div *ngFor="let i of pagedItems()">
         <tock-i18n-label [i]="i" [i18nController]="controller()" [intent]="i.category"
-                         [localeBase]="localeBase"></tock-i18n-label>
+                         [localeBase]="localeBase" [locales]="locales"
+                         [deleteLabelAllowed]="isDeleteLabelAllowed()">
+        </tock-i18n-label>
       </div>
     </mat-list>
 

--- a/bot/admin/web/src/app/bot/story/simple-answer.component.html
+++ b/bot/admin/web/src/app/bot/story/simple-answer.component.html
@@ -72,7 +72,7 @@
   <mat-list dense>
     <tock-i18n-label
       *ngFor="let a of answer.answers"
-      [deleteAllowed]="answer.answers.length !== 1"
+      [deleteLabelAllowed]="answer.answers.length !== 1"
       [i]="a.label"
       (delete)="deleteAnswer(a, false)"></tock-i18n-label>
   </mat-list>


### PR DESCRIPTION
It is now possible to check and remove labels from all languages (including disabled languages) in _Answers_ .
The _Filter by locale_ selection enables:

- All labels
- Current locale
- Current application supported locales (remains as default)
- Current application not-supported locales

To prevent mistakes:

- Disabled-language localized labels cannot be edited or added (most fields/buttons are disabled), but they can be removed (one by one).
- Labels labels (incl. all localizations) cannot be deleted when view is filtered by current locale or unsupported locales.

Hth

Signed-off-by: Francois Nollen <francois.nollen@gmail.com>