### PR TITLE
fixes #1137 compiler compile phase fails

### DIFF
--- a/bot/admin/kotlin-compiler/core/pom.xml
+++ b/bot/admin/kotlin-compiler/core/pom.xml
@@ -68,22 +68,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/bot/admin/kotlin-compiler/core/src/test/kotlin/KotlinCompilerTest.kt
+++ b/bot/admin/kotlin-compiler/core/src/test/kotlin/KotlinCompilerTest.kt
@@ -31,7 +31,7 @@ class KotlinCompilerTest {
         @BeforeAll
         @JvmStatic
         fun beforeClass() {
-            KotlinCompiler.init(listOf("target/dependency/", "target/test-classes/"))
+            KotlinCompiler.init(listOf("target/test-classes/"))
         }
 
         var mark = false


### PR DESCRIPTION
@vsct-jburet: it looks like copying deps is not required (anymore).
Maven build and tests are ok without them, and looking at build log JARs appear twice:

`2020-12-11T18:38:33.604 [main] INFO  ai.tock.bot.admin.kotlin.compiler.KotlinCompiler - class path used : [target/dependency/kotlin-stdlib-jdk7-1.4.10.jar, ..., target/dependency/tock-shared-20.9.3-SNAPSHOT.jar, ..., /home/francois/.m2/repository/ai/tock/tock-shared/20.9.3-SNAPSHOT/tock-shared-20.9.3-SNAPSHOT.jar, /home/francois/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.4.10/kotlin-stdlib-jdk7-1.4.10.jar, ...]`

Signed-off-by: Francois Nollen <francois.nollen@gmail.com>