### PR TITLE
fixes #1164 Git: add .gitattributes to better Windows DX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# For generated-sources, force LF to prevent diff showing for Windows users
+**/target/generated-sources/** text eol=lf


### PR DESCRIPTION
fixes #1164 

Add .gitattributes to ensure in which fashion every file should be checkout, depending on developer's OS.