### PR TITLE
Studio: add tooltips to the channel icons in the Answers menu

### DIFF
--- a/bot/admin/web/package-lock.json
+++ b/bot/admin/web/package-lock.json
@@ -15232,6 +15232,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/bot/admin/web/src/app/bot/i18n/i18n-label.component.html
+++ b/bot/admin/web/src/app/bot/i18n/i18n-label.component.html
@@ -57,9 +57,9 @@
 
             <!-- Interface type -->
             <div class="i18n-label__entry__mode">
-              <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 0" mat-list-avatar>chat
+              <mat-icon class="i18n-label__entry__mode__icon" nbTooltip="Answer in Text Channels" *ngIf="l.interfaceType === 0" mat-list-avatar>chat
               </mat-icon>
-              <mat-icon class="i18n-label__entry__mode__icon" *ngIf="l.interfaceType === 1" mat-list-avatar>
+              <mat-icon class="i18n-label__entry__mode__icon" nbTooltip="Answer in Voice Channels" *ngIf="l.interfaceType === 1" mat-list-avatar>
                 record_voice_over
               </mat-icon>
             </div>


### PR DESCRIPTION
While learning this tool, I noticed the icons denoting the type of channel for which an answer is applicable but had to ask what they meant as their purpose was not immediately clear to me. I believe the application could get a small boost in usability from adding tooltips to those icons, so I made a PR to do exactly that.

![location](https://user-images.githubusercontent.com/79657435/109195547-f2f8e980-779a-11eb-9638-71f06c7b1a36.png)

Tooltip for text answers:
![image](https://user-images.githubusercontent.com/79657435/109195607-0310c900-779b-11eb-9c0c-ae11ad9d25a2.png)

Tooltip for voice answers:
![image](https://user-images.githubusercontent.com/79657435/109195670-1754c600-779b-11eb-882c-26621ca2e438.png)
