### PR TITLE
resolves #1246 Web: connector bridge

### DIFF
--- a/bot/connector-web-model/pom.xml
+++ b/bot/connector-web-model/pom.xml
@@ -24,6 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tock-bot-connector-web-model</artifactId>
+    <name>Tock Bot Web Connector Model</name>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>

--- a/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/WebConnectorRequest.kt
+++ b/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/WebConnectorRequest.kt
@@ -24,6 +24,7 @@ interface WebConnectorRequestContract {
     val userId: String
     val locale: Locale
     val ref: String?
+    val connectorId: String?
 }
 
 data class WebConnectorRequestContent(
@@ -31,5 +32,6 @@ data class WebConnectorRequestContent(
     override val payload: String? = null,
     override val userId: String,
     override val locale: Locale,
-    override val ref: String? = null
+    override val ref: String? = null,
+    override val connectorId: String? = null
 ) : WebConnectorRequestContract

--- a/bot/connector-web/src/main/kotlin/WebConnectorRequest.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnectorRequest.kt
@@ -31,7 +31,8 @@ data class WebConnectorRequest(
     override val payload: String? = null,
     override val userId: String,
     override val locale: Locale = defaultLocale,
-    override val ref: String? = null
+    override val ref: String? = null,
+    override val connectorId: String? = null
 ) : WebConnectorRequestContract {
 
     fun toEvent(applicationId: String): Event =


### PR DESCRIPTION
Very simple implementation : no UI modifications, add `connectorId` to Web request to transfer to another connector.

No security checks (namespace etc.), but feature is disabled by default : `booleanProperty("tock_web_connector_bridge_enabled", false)`

Signed-off-by: Francois Nollen <francois.nollen@gmail.com>