### PR TITLE
fixes #1279 doc: add trailing slashes to permalinks on documentation website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -24,9 +24,7 @@ title: Tock Documentation
 email: your-email@domain.com
 author: Tock
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  The website hosting the documentation for The Open Conversation Kit.
 
 baseurl: "/tock" # the subpath of your site, e.g. /blog
 
@@ -89,10 +87,10 @@ exclude: [_site, CHANGELOG.md, LICENSE, README.md, vendor, Gemfile, Gemfile.lock
 collections:
   en:
     output: true
-    permalink: /:collection/:path
+    permalink: /:collection/:path/
   fr:
     output: true
-    permalink: /:collection/:path
+    permalink: /:collection/:path/
 
 # Defaults
 defaults:

--- a/docs/_en/index.md
+++ b/docs/_en/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Tock
+permalink: /en/
 ---
 # Welcome to Tock - open conversational platform
 

--- a/docs/_fr/index.md
+++ b/docs/_fr/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Bienvenue !
+permalink: /fr/
 ---
 
 # Bienvenue sur Tock : une plateforme conversationnelle ouverte


### PR DESCRIPTION
With #1260 being merged, links with trailing slashes have been broken. This PR fixes that issue, as well as the website's description.