### PR TITLE
[Fix issue-1263] Draft : Enable ending story rule for built-in stories

### DIFF
--- a/bot/engine/src/main/kotlin/admin/story/StoryDefinitionConfiguration.kt
+++ b/bot/engine/src/main/kotlin/admin/story/StoryDefinitionConfiguration.kt
@@ -186,7 +186,7 @@ data class StoryDefinitionConfiguration(
         return dedicatedFeature?.switchToStoryId ?: features.find { it.switchToStoryId != null }?.switchToStoryId
     }
 
-    internal fun findEnabledEndWithStoryId(applicationId: String?): String? {
+     fun findEnabledEndWithStoryId(applicationId: String?): String? {
         val features = findEnabledFeatures(applicationId)
 
         // search first for dedicated features


### PR DESCRIPTION
Fix Stories rules : Enable ending story rule for built-in stories 

Note : This PR is about initializing the discussion for coming features and Tock design understanding, no test is coded.

Hello @vsct-jburet , I hope you are doing well. I ported the code concerning the stories ending rules from the ConfiguredStoryHandler handler to BotApiHandler, the idea is to discuss the code design (I had to inject the DAO layer into the BotApiHandler). I hope we can schedule a call if you will be available to discuss the various difficulties I encountered during development.

Thank you,