### PR TITLE
resolves #1305 allow extra headers by property

### DIFF
--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -129,4 +129,32 @@ A simple [Swagger descriptor](./Swagger_TOCKWebConnector.yaml) of the rest servi
 
 # React chat widget
 
-Please consult the related [documentation](https://github.com/theopenconversationkit/tock-react-kit).
+The [`tock-react-kit`](https://github.com/theopenconversationkit/tock-react-kit) component provides integration with
+Web pages, customizable chat widgets and orchestration with a Web connector back-end.
+
+# Extra headers
+
+Sometimes it is useful to allow extra HTTP headers to bot requests, for instance to provide/pass authentication or 
+custom parameters from the front-end.
+
+Not-allowed headers can cause [_CORS_](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) 
+errors on the front-end.
+
+The HTTP parameters, allowed by default can be found in [`WebConnector`](./src/main/kotlin/WebConnector.kt) source code.
+
+To allow extra parameters without modifying the Web connector, use the optional `tock_web_connector_extra_headers` 
+property.
+
+Docker-Compose example:
+
+```
+version: '3'
+services:
+bot_api:
+  image: tock/bot_api:$TAG
+  environment:
+    - tock_web_connector_extra_headers=header1,header2,my-other-header-param
+```
+
+> To add extra headers from a [`tock-react-kit`](https://github.com/theopenconversationkit/tock-react-kit) front-end, 
+> refer to its [README#extra-headers](https://github.com/theopenconversationkit/tock-react-kit#extra-headers).

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -55,6 +55,7 @@ import ai.tock.shared.Executor
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
+import ai.tock.shared.listProperty
 import ai.tock.shared.longProperty
 import ai.tock.shared.provide
 import ai.tock.shared.vertx.vertx
@@ -79,6 +80,8 @@ private val sseEnabled = booleanProperty("tock_web_sse", false)
 private val sseKeepaliveDelay = longProperty("tock_web_sse_keepalive_delay", 10)
 
 private val webConnectorBridgeEnabled = booleanProperty("tock_web_connector_bridge_enabled", false)
+
+private val webConnectorExtraHeaders = listProperty("tock_web_connector_extra_headers", emptyList())
 
 class WebConnector internal constructor(
     val applicationId: String,
@@ -112,7 +115,11 @@ class WebConnector internal constructor(
                         }
                         .allowedHeader("Access-Control-Allow-Origin")
                         .allowedHeader("Content-Type")
-                        .allowedHeader("X-Requested-With")
+                        .allowedHeader("X-Requested-With").apply {
+                            webConnectorExtraHeaders.forEach {
+                                this.allowedHeader(it)
+                            }
+                        }
                 )
             if (sseEnabled) {
                 router.route("$path/sse")


### PR DESCRIPTION
Allow extra headers on the Web connector (preventing CORS errors) using `tock_web_connector_extra_headers` property.
Typically used with the React kit : https://github.com/theopenconversationkit/tock-react-kit#extra-headers 