### PR TITLE
Draft: Refactor analytics computation

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -422,9 +422,9 @@ object BotAdminService {
         val applicationIds = applications.map { it._id }.toSet()
         val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
         val toDate = atTimeOfDay(request.to, LocalTime.MAX)
-        val usersData = dialogFlowDAO.search2(namespace, botId, applicationIds, request.from, request.to)
+        val usersData = dialogFlowDAO.countMessagesByDate(namespace, botId, applicationIds, request.from, request.to)
         val (dates, filledUsersData) = sortMessagesByDate2(fromDate, toDate, usersData, 1)
-        return UserAnalyticsQueryResult(dates, filledUsersData)
+        return UserAnalyticsQueryResult(dates, filledUsersData, listOf("Messages"))
     }
 
     fun reportMessagesByType(request: DialogFlowRequest): UserAnalyticsQueryResult {
@@ -457,6 +457,18 @@ object BotAdminService {
             },
             { if (it) "Tests" else "Users" }
         )
+    }
+
+    fun reportUsersByType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val applications = loadApplications(request)
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = applications.map { it._id }.toSet()
+        val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
+        val toDate = atTimeOfDay(request.to, LocalTime.MAX)
+        val usersData = dialogFlowDAO.countUsersByDate(namespace, botId, applicationIds, request.from, request.to)
+        val (dates, filledUsersData) = sortMessagesByDate2(fromDate, toDate, usersData, 1)
+        return UserAnalyticsQueryResult(dates, filledUsersData, listOf("Users"))
     }
 
     fun reportMessagesByConnectorType(request: DialogFlowRequest): UserAnalyticsQueryResult {

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -627,6 +627,21 @@ object BotAdminService {
         return reportMessagesByFunction(request, applications, dialogFlowDAO::searchByDateWithActionType)
     }
 
+    fun reportMessagesByActionType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val (series, data) = dialogFlowDAO.countMessagesByActionType(namespace, botId, applicationIds, request.from, request.to).toList().unzip()
+        val usedIntents = dialogFlowDAO.countMessagesByIntent(
+            namespace,
+            botId,
+            applicationIds,
+            request.from,
+            request.to
+        ).keys.toList()
+        return UserAnalyticsQueryResult(data, series, usedIntents)
+    }
+
     private fun reportAnalytics(
         request: DialogFlowRequest, method: DialogFlowDAO.(
             namespace: String,

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -560,6 +560,10 @@ object BotAdminService {
         ) { it?.let { stories.find { story -> story._id.toString() == it }?.name } ?: "$it" }
     }
 
+    fun reportMessagesByDateAndStory2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        return reportAnalytics(request, DialogFlowDAO::countMessagesByDateAndStory)
+    }
+
     fun reportMessagesByStoryType(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         val stories = storyDefinitionDAO.getStoryDefinitionsByNamespaceAndBotId(request.namespace, request.botId)

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -552,6 +552,14 @@ object BotAdminService {
         ) { it?.let { stories.find { story -> story._id.toString() == it }?.name } ?: "$it" }
     }
 
+    fun reportMessagesByStory2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val (series, data) = dialogFlowDAO.countMessagesByStory(namespace, botId, applicationIds, request.from, request.to).toList().unzip()
+        return UserAnalyticsQueryResult(data, series)
+    }
+
     fun reportMessagesByDateAndStory(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         val stories = storyDefinitionDAO.getStoryDefinitionsByNamespaceAndBotId(request.namespace, request.botId)

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -496,6 +496,16 @@ object BotAdminService {
         )
     }
 
+    fun reportMessagesByConfiguration2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
+        val toDate = atTimeOfDay(request.to, LocalTime.MAX)
+        val usersData = dialogFlowDAO.countMessagesByDateAndConfiguration(namespace, botId, applicationIds, request.from, request.to)
+        return prepareAnalyticsResponse(fromDate, toDate, usersData)
+    }
+
     fun reportMessagesByDayOfWeek(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         return reportMessagesBySeries(

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -580,6 +580,14 @@ object BotAdminService {
         ) { it?.let { stories.find { story -> story._id.toString() == it }?.currentType?.name } ?: "unknown" }
     }
 
+    fun reportMessagesByStoryType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val (series, data) = dialogFlowDAO.countMessagesByStoryType(namespace, botId, applicationIds, request.from, request.to).toList().unzip()
+        return UserAnalyticsQueryResult(data, series)
+    }
+
     fun reportMessagesByStoryCategory(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         val stories = storyDefinitionDAO.getStoryDefinitionsByNamespaceAndBotId(request.namespace, request.botId)

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -614,6 +614,14 @@ object BotAdminService {
         }
     }
 
+    fun reportMessagesByStoryLocale2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val (series, data) = dialogFlowDAO.countMessagesByStoryLocale(namespace, botId, applicationIds, request.from, request.to).toList().unzip()
+        return UserAnalyticsQueryResult(data, series)
+    }
+
     fun reportMessagesByActionType(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         return reportMessagesByFunction(request, applications, dialogFlowDAO::searchByDateWithActionType)

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -588,6 +588,14 @@ object BotAdminService {
         ) { it?.let { stories.find { story -> story._id.toString() == it }?.category } ?: "unknown" }
     }
 
+    fun reportMessagesByStoryCategory2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        val namespace = request.namespace
+        val botId = request.botId
+        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
+        val (series, data) = dialogFlowDAO.countMessagesByStoryCategory(namespace, botId, applicationIds, request.from, request.to).toList().unzip()
+        return UserAnalyticsQueryResult(data, series)
+    }
+
     fun reportMessagesByStoryLocale(request: DialogFlowRequest): UserAnalyticsQueryResult {
         val applications = loadApplications(request)
         val stories = storyDefinitionDAO.getStoryDefinitionsByNamespaceAndBotId(request.namespace, request.botId)

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -413,13 +413,7 @@ object BotAdminService {
     }
 
     fun reportMessagesByType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
-        val namespace = request.namespace
-        val botId = request.botId
-        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
-        val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
-        val toDate = atTimeOfDay(request.to, LocalTime.MAX)
-        val usersData = dialogFlowDAO.countMessagesByDate(namespace, botId, applicationIds, request.from, request.to)
-        return prepareAnalyticsResponse(fromDate, toDate, usersData)
+        return reportAnalytics(request, DialogFlowDAO::countMessagesByDate)
     }
 
     fun reportMessagesByType(request: DialogFlowRequest): UserAnalyticsQueryResult {
@@ -455,13 +449,7 @@ object BotAdminService {
     }
 
     fun reportUsersByType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
-        val namespace = request.namespace
-        val botId = request.botId
-        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
-        val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
-        val toDate = atTimeOfDay(request.to, LocalTime.MAX)
-        val usersData = dialogFlowDAO.countUsersByDate(namespace, botId, applicationIds, request.from, request.to)
-        return prepareAnalyticsResponse(fromDate, toDate, usersData)
+        return reportAnalytics(request, DialogFlowDAO::countUsersByDate)
     }
 
     fun reportMessagesByConnectorType(request: DialogFlowRequest): UserAnalyticsQueryResult {
@@ -476,13 +464,7 @@ object BotAdminService {
     }
 
     fun reportMessagesByConnectorType2(request: DialogFlowRequest): UserAnalyticsQueryResult {
-        val namespace = request.namespace
-        val botId = request.botId
-        val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
-        val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
-        val toDate = atTimeOfDay(request.to, LocalTime.MAX)
-        val usersData = dialogFlowDAO.countMessagesByDateAndConnectorType(namespace, botId, applicationIds, request.from, request.to)
-        return prepareAnalyticsResponse(fromDate, toDate, usersData)
+        return reportAnalytics(request, DialogFlowDAO::countMessagesByDateAndConnectorType)
     }
 
     fun reportMessagesByConfiguration(request: DialogFlowRequest): UserAnalyticsQueryResult {
@@ -497,12 +479,24 @@ object BotAdminService {
     }
 
     fun reportMessagesByConfiguration2(request: DialogFlowRequest): UserAnalyticsQueryResult {
+        return reportAnalytics(request, DialogFlowDAO::countMessagesByDateAndConfiguration)
+    }
+
+    private fun reportAnalytics(
+        request: DialogFlowRequest, method: DialogFlowDAO.(
+            namespace: String,
+            botId: String,
+            applicationIds: Set<Id<BotApplicationConfiguration>>,
+            from: ZonedDateTime?,
+            to: ZonedDateTime?
+        ) -> Map<String, List<DialogFlowAggregateData>>
+    ): UserAnalyticsQueryResult {
         val namespace = request.namespace
         val botId = request.botId
         val applicationIds = loadApplications(request).mapTo(mutableSetOf()) { it._id }
         val fromDate = atTimeOfDay(request.from, LocalTime.MIDNIGHT)
         val toDate = atTimeOfDay(request.to, LocalTime.MAX)
-        val usersData = dialogFlowDAO.countMessagesByDateAndConfiguration(namespace, botId, applicationIds, request.from, request.to)
+        val usersData = dialogFlowDAO.method(namespace, botId, applicationIds, request.from, request.to)
         return prepareAnalyticsResponse(fromDate, toDate, usersData)
     }
 

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -183,6 +183,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byConnectorType2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByConnectorType2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byDayOfWeek", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -170,6 +170,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byConfiguration2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByConfiguration2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byConnectorType", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -274,12 +274,38 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byDateAndIntent2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByDateAndIntent2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byIntent", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
                     {
                         BotAdminService.reportMessagesByIntent(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
+        blockingJsonPost("/analytics/messages/byIntent2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByIntent2(request)
                     }
                 )
             } else {

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -352,6 +352,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byStory2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByStory2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byStoryCategory", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -222,12 +222,38 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byDayOfWeek2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByDayOfWeek2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byHour", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(
                     context,
                     {
                         BotAdminService.reportMessagesByHour(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
+        blockingJsonPost("/analytics/messages/byHour2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByHour2(request)
                     }
                 )
             } else {

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -404,6 +404,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byStoryType2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByStoryType2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byStoryLocale", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -378,6 +378,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byStoryCategory2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByStoryCategory2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byStoryType", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -144,6 +144,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/users2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportUsersByType2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byConfiguration", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -326,6 +326,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byDateAndStory2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByDateAndStory2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byStory", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -105,6 +105,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByType2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -430,6 +430,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byStoryLocale2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByStoryLocale2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/analytics/messages/byActionType", botUser) { context, request: DialogFlowRequest ->
             if (context.organization == request.namespace) {
                 measureTimeMillis(

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -456,6 +456,19 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
+        blockingJsonPost("/analytics/messages/byActionType2", botUser) { context, request: DialogFlowRequest ->
+            if (context.organization == request.namespace) {
+                measureTimeMillis(
+                    context,
+                    {
+                        BotAdminService.reportMessagesByActionType2(request)
+                    }
+                )
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonGet("/dialog/:applicationId/:dialogId", botUser) { context ->
             val app = FrontClient.getApplicationById(context.pathId("applicationId"))
             if (context.organization == app?.namespace) {

--- a/bot/engine/src/main/kotlin/admin/dialog/DialogFlowAggregateData.kt
+++ b/bot/engine/src/main/kotlin/admin/dialog/DialogFlowAggregateData.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.dialog
+
+data class DialogFlowAggregateData(val seriesKey: String, val count: Int)

--- a/bot/engine/src/main/kotlin/admin/user/UserAnalyticsQueryResult.kt
+++ b/bot/engine/src/main/kotlin/admin/user/UserAnalyticsQueryResult.kt
@@ -21,4 +21,10 @@ data class UserAnalyticsQueryResult(
     val usersData: List<List<Int?>> = emptyList(),
     val connectorsType: List<String> = emptyList(),
     val intents: List<String> = emptyList()
-)
+) {
+    constructor(usersData: List<Int?>, series: List<String>): this(
+        dates = listOf("All Range"),
+        usersData = listOf(usersData),
+        connectorsType = series
+    )
+}

--- a/bot/engine/src/main/kotlin/admin/user/UserAnalyticsQueryResult.kt
+++ b/bot/engine/src/main/kotlin/admin/user/UserAnalyticsQueryResult.kt
@@ -22,9 +22,10 @@ data class UserAnalyticsQueryResult(
     val connectorsType: List<String> = emptyList(),
     val intents: List<String> = emptyList()
 ) {
-    constructor(usersData: List<Int?>, series: List<String>): this(
+    constructor(usersData: List<Int?>, series: List<String>, intents: List<String> = emptyList()): this(
         dates = listOf("All Range"),
         usersData = listOf(usersData),
-        connectorsType = series
+        connectorsType = series,
+        intents = intents
     )
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -83,6 +83,14 @@ interface DialogFlowDAO {
         intent: String? = null
     ): Pair<List<DialogFlowTransitionStatsData>, List<String>>
 
+    /**
+     * Counts the number of users per day over a given period of time.
+     *
+     * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.
+     * Values are singleton lists containing the data point for that day.
+     *
+     * @return a [Map] of user counts indexed by days
+     */
     fun countUsersByDate(
         namespace: String,
         botId: String,
@@ -91,6 +99,14 @@ interface DialogFlowDAO {
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
 
+    /**
+     * Counts the number of messages per day and connector type over a given period of time.
+     *
+     * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.
+     * Values are lists containing one data point for each represented connector type (web, messenger, etc.).
+     *
+     * @return a [Map] of message counts per connector type, indexed by days
+     */
     fun countMessagesByDateAndConnectorType(
         namespace: String,
         botId: String,
@@ -99,6 +115,14 @@ interface DialogFlowDAO {
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
 
+    /**
+     * Counts the number of messages per day and bot configuration over a given period of time.
+     *
+     * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.
+     * Values are lists containing one data point for each represented bot configuration.
+     *
+     * @return a [Map] of message counts per configuration, indexed by days
+     */
     fun countMessagesByDateAndConfiguration(
         namespace: String,
         botId: String,
@@ -107,6 +131,11 @@ interface DialogFlowDAO {
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
 
+    /**
+     * Counts the total number of messages sent on each day-of-week.
+     *
+     * @return a [Map] of message counts, indexed by day-of-week
+     */
     fun countMessagesByDayOfWeek(
         namespace: String,
         botId: String,
@@ -115,6 +144,11 @@ interface DialogFlowDAO {
         to: ZonedDateTime?
     ): Map<DayOfWeek, Int>
 
+    /**
+     * Counts the total number of messages sent on each hour of the day over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by hour (from 0 to 23)
+     */
     fun countMessagesByHour(
         namespace: String,
         botId: String,
@@ -122,4 +156,33 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<Int, Int>
+
+    /**
+     * Counts the number of messages per day and intent over a given period of time.
+     *
+     * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.
+     * Values are lists containing one data point for each represented intent.
+     *
+     * @return a [Map] of message counts per intent, indexed by day
+     */
+    fun countMessagesByDateAndIntent(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, List<DialogFlowAggregateData>>
+
+    /**
+     * Counts the total number of messages sent for each intent over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by intent name
+     */
+    fun countMessagesByIntent(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -227,4 +227,17 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, Int>
+
+    /**
+     * Counts the total number of messages sent for each story category over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by story category
+     */
+    fun countMessagesByStoryType(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -37,7 +37,7 @@ interface DialogFlowDAO {
         intent: String? = null
     ): ApplicationDialogFlowData
 
-    fun search2(
+    fun countMessagesByDate(
         namespace: String,
         botId: String,
         applicationIds: Set<Id<BotApplicationConfiguration>>,
@@ -80,4 +80,12 @@ interface DialogFlowDAO {
         to: ZonedDateTime?,
         intent: String? = null
     ): Pair<List<DialogFlowTransitionStatsData>, List<String>>
+
+    fun countUsersByDate(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, List<Int>>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.engine.dialog
 
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.dialog.ApplicationDialogFlowData
+import ai.tock.bot.admin.dialog.DialogFlowAggregateData
 import ai.tock.bot.admin.dialog.DialogFlowTransitionStatsData
 import ai.tock.bot.definition.BotDefinition
 import ai.tock.bot.definition.DialogFlowDefinition
@@ -43,7 +44,7 @@ interface DialogFlowDAO {
         applicationIds: Set<Id<BotApplicationConfiguration>>,
         from: ZonedDateTime?,
         to: ZonedDateTime?,
-    ): Map<String, List<Int>>
+    ): Map<String, List<DialogFlowAggregateData>>
 
     fun search(
         namespace: String,
@@ -87,5 +88,13 @@ interface DialogFlowDAO {
         applicationIds: Set<Id<BotApplicationConfiguration>>,
         from: ZonedDateTime?,
         to: ZonedDateTime?
-    ): Map<String, List<Int>>
+    ): Map<String, List<DialogFlowAggregateData>>
+
+    fun countMessagesByDateAndConnectorType(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, List<DialogFlowAggregateData>>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -37,6 +37,14 @@ interface DialogFlowDAO {
         intent: String? = null
     ): ApplicationDialogFlowData
 
+    fun search2(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?,
+    ): Map<String, List<Int>>
+
     fun search(
         namespace: String,
         botId: String,

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -23,6 +23,7 @@ import ai.tock.bot.admin.dialog.DialogFlowTransitionStatsData
 import ai.tock.bot.definition.BotDefinition
 import ai.tock.bot.definition.DialogFlowDefinition
 import org.litote.kmongo.Id
+import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
 interface DialogFlowDAO {
@@ -105,4 +106,20 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
+
+    fun countMessagesByDayOfWeek(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<DayOfWeek, Int>
+
+    fun countMessagesByHour(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<Int, Int>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -240,4 +240,17 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, Int>
+
+    /**
+     * Counts the total number of messages sent for each story locale over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by story category
+     */
+    fun countMessagesByStoryLocale(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -97,4 +97,12 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
+
+    fun countMessagesByDateAndConfiguration(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, List<DialogFlowAggregateData>>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -185,4 +185,20 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, Int>
+
+    /**
+     * Counts the number of messages per day and story over a given period of time.
+     *
+     * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.
+     * Values are lists containing one data point for each represented intent.
+     *
+     * @return a [Map] of message counts per intent, indexed by day
+     */
+    fun countMessagesByDateAndStory(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, List<DialogFlowAggregateData>>
 }

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -231,7 +231,7 @@ interface DialogFlowDAO {
     /**
      * Counts the total number of messages sent for each story category over a given period of time.
      *
-     * @return a [Map] of message counts, indexed by story category
+     * @return a [Map] of message counts, indexed by story type
      */
     fun countMessagesByStoryType(
         namespace: String,
@@ -244,9 +244,22 @@ interface DialogFlowDAO {
     /**
      * Counts the total number of messages sent for each story locale over a given period of time.
      *
-     * @return a [Map] of message counts, indexed by story category
+     * @return a [Map] of message counts, indexed by story locale
      */
     fun countMessagesByStoryLocale(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
+
+    /**
+     * Counts the total number of messages sent for each action type over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by action type
+     */
+    fun countMessagesByActionType(
         namespace: String,
         botId: String,
         applicationIds: Set<Id<BotApplicationConfiguration>>,

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -187,6 +187,19 @@ interface DialogFlowDAO {
     ): Map<String, Int>
 
     /**
+     * Counts the total number of messages sent for each story over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by story name
+     */
+    fun countMessagesByStory(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
+
+    /**
      * Counts the number of messages per day and story over a given period of time.
      *
      * In the returned map, the keys represent dates using the "YYYY-MM-DD" format.

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogFlowDAO.kt
@@ -214,4 +214,17 @@ interface DialogFlowDAO {
         from: ZonedDateTime?,
         to: ZonedDateTime?
     ): Map<String, List<DialogFlowAggregateData>>
+
+    /**
+     * Counts the total number of messages sent for each story category over a given period of time.
+     *
+     * @return a [Map] of message counts, indexed by story category
+     */
+    fun countMessagesByStoryCategory(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int>
 }

--- a/bot/storage-mongo/src/main/kotlin/DialogFlowMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogFlowMongoDAO.kt
@@ -471,6 +471,16 @@ internal object DialogFlowMongoDAO : DialogFlowDAO {
         return countMessagesByStoryProperty(applicationIds, from, to, "currentType")
     }
 
+    override fun countMessagesByStoryLocale(
+        namespace: String,
+        botId: String,
+        applicationIds: Set<Id<BotApplicationConfiguration>>,
+        from: ZonedDateTime?,
+        to: ZonedDateTime?
+    ): Map<String, Int> {
+        return countMessagesByStoryProperty(applicationIds, from, to, "userSentenceLocale")
+    }
+
     private fun countMessagesByStoryProperty(
         applicationIds: Set<Id<BotApplicationConfiguration>>,
         from: ZonedDateTime?,

--- a/bot/storage-mongo/src/main/kotlin/DialogFlowStateCol.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogFlowStateCol.kt
@@ -67,3 +67,10 @@ internal data class DialogFlowStateTransitionStatCol(
     val text: String?,
     val date: Instant = now()
 )
+
+@Data(internal = true)
+@JacksonData(internal = true)
+internal data class DialogFlowAggregateResult(
+    val date: String = "",
+    val count: Int = 0,
+)

--- a/bot/storage-mongo/src/main/kotlin/DialogFlowStateCol.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogFlowStateCol.kt
@@ -73,4 +73,12 @@ internal data class DialogFlowStateTransitionStatCol(
 internal data class DialogFlowAggregateResult(
     val date: String = "",
     val count: Int = 0,
+    val seriesKey: String = "",
+)
+
+@Data(internal = true)
+@JacksonData(internal = true)
+internal data class DialogFlowAggregateSeriesResult(
+    val values: List<DialogFlowAggregateResult>,
+    val seriesKey: String = "",
 )

--- a/nlp/admin/web/src/locale/messages.fr.xlf
+++ b/nlp/admin/web/src/locale/messages.fr.xlf
@@ -1,0 +1,20 @@
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en-US" datatype="plaintext" original="ng2.template">
+    <body>
+      <trans-unit id="search/search-sentences-placeholder" datatype="html">
+        <source>Rechercher une phrase</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/search/search.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="search/search-support-regexp-tooltip" datatype="html">
+        <source>Search support regexp (PCRE format)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">app/search/search.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
The current version of Tock Studio uses a rather large amount of memory to compute analytics, mostly due to loading every item from the database locally. This PR aims at reducing the server's memory and computation time by moving the workload of each analytics route to the Mongo setup.

Fixes #1343 

To do:
- [x] Rewrite all analytics routes
    - [x] `/analytics/messages`
    - [x] `/analytics/users`
    - [x] `/analytics/messages/byConfiguration`
    - [x] `/analytics/messages/byConnectorType`
    - [x] `/analytics/messages/byDayOfWeek`
    - [x] `/analytics/messages/byHour`
    - [x] `/analytics/messages/byDateAndIntent`
    - [x] `/analytics/messages/byIntent`
    - [x] `/analytics/messages/byDateAndStory`
    - [x] `/analytics/messages/byStoryCategory`
    - [x] `/analytics/messages/byStoryType`
    - [x] `/analytics/messages/byStoryLocale`
    - [x] `/analytics/messages/byActionType`
- [ ] Testing