### PR TITLE
fix #1349: Allow multiple role checking and restriction per endpoint

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -24,19 +24,7 @@ import ai.tock.bot.admin.BotAdminService.importStories
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotConfiguration
 import ai.tock.bot.admin.dialog.DialogReportQuery
-import ai.tock.bot.admin.model.BotAdminConfiguration
-import ai.tock.bot.admin.model.BotConnectorConfiguration
-import ai.tock.bot.admin.model.BotI18nLabel
-import ai.tock.bot.admin.model.BotI18nLabels
-import ai.tock.bot.admin.model.BotStoryDefinitionConfiguration
-import ai.tock.bot.admin.model.CreateI18nLabelRequest
-import ai.tock.bot.admin.model.CreateStoryRequest
-import ai.tock.bot.admin.model.DialogFlowRequest
-import ai.tock.bot.admin.model.DialogsSearchQuery
-import ai.tock.bot.admin.model.Feature
-import ai.tock.bot.admin.model.I18LabelQuery
-import ai.tock.bot.admin.model.StorySearchRequest
-import ai.tock.bot.admin.model.UserSearchQuery
+import ai.tock.bot.admin.model.*
 import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDump
 import ai.tock.bot.admin.test.TestPlanService
 import ai.tock.bot.admin.test.findTestService
@@ -51,11 +39,12 @@ import ai.tock.nlp.admin.model.ApplicationScopedQuery
 import ai.tock.nlp.admin.model.TranslateReport
 import ai.tock.nlp.front.client.FrontClient
 import ai.tock.nlp.front.shared.config.ApplicationDefinition
+import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.provide
-import ai.tock.shared.security.TockUserRole.admin
-import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.security.NoEncryptionPassException
+import ai.tock.shared.security.TockUserRole.*
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.Translator
@@ -761,7 +750,6 @@ open class BotAdminVerticle : AdminVerticle() {
         }
 
         blocking(GET, "/file/:id.:suffix", botUser) { context ->
-
             val id = context.path("id")
             if (!id.startsWith(context.organization)) {
                 unauthorized()

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -39,11 +39,9 @@ import ai.tock.nlp.admin.model.ApplicationScopedQuery
 import ai.tock.nlp.admin.model.TranslateReport
 import ai.tock.nlp.front.client.FrontClient
 import ai.tock.nlp.front.shared.config.ApplicationDefinition
-import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.provide
-import ai.tock.shared.security.NoEncryptionPassException
 import ai.tock.shared.security.TockUserRole.*
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -211,7 +211,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingJsonPost(
             "/sentences/dump/:dumpType/:applicationId",
-            admin
+            setOf(admin,technicalAdmin)
         ) { context, query: SearchQuery ->
             val id: Id<ApplicationDefinition> = context.pathId("applicationId")
             if (context.organization == front.getApplicationById(id)?.namespace) {
@@ -268,18 +268,6 @@ open class AdminVerticle : WebVerticle() {
                     DumpType.parseDumpType(it.path("dumpType")),
                     it.path("intent"),
                     it.pathToLocale("locale")
-                )
-            } else {
-                unauthorized()
-            }
-        }
-
-        blockingJsonPost("/sentences/dump/:dumpType/:applicationId", technicalAdmin) { context, query: SearchQuery ->
-            val id: Id<ApplicationDefinition> = context.pathId("applicationId")
-            if (context.organization == front.getApplicationById(id)?.namespace) {
-                front.exportSentences(
-                    query.toSentencesQuery(id),
-                    DumpType.parseDumpType(context.path("dumpType"))
                 )
             } else {
                 unauthorized()

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -65,9 +65,7 @@ import ai.tock.shared.namespace
 import ai.tock.shared.pingMongoDatabase
 import ai.tock.shared.provide
 import ai.tock.shared.security.NoEncryptionPassException
-import ai.tock.shared.security.TockUserRole.admin
-import ai.tock.shared.security.TockUserRole.nlpUser
-import ai.tock.shared.security.TockUserRole.technicalAdmin
+import ai.tock.shared.security.TockUserRole.*
 import ai.tock.shared.security.UNKNOWN_USER_LOGIN
 import ai.tock.shared.security.auth.TockAuthProvider
 import ai.tock.shared.security.decrypt


### PR DESCRIPTION
Allow multiple roles per endpoints with a set.
Still allow a defaultRole and a single role per endpoint.

Fix the duplicated endpoint `/sentences/dump/:dumpType/:applicationId` with admin and technical admin.