### PR TITLE
Evol config prettier

### DIFF
--- a/bot/admin/web/.prettierrc.json
+++ b/bot/admin/web/.prettierrc.json
@@ -3,7 +3,7 @@
   "bracketSpacing": true,
   "bracketSameLine": false,
   "endOfLine": "lf",
-  "printWidth": 100,
+  "printWidth": 140,
   "semi": true,
   "singleQuote": true,
   "singleAttributePerLine": true,


### PR DESCRIPTION
Proposition : modification de printWidth pour gagner en lisibilité et éviter les sauts de lignes intempestifs sur les constructeurs par exemple