### PR TITLE
Teams change action types

### DIFF
--- a/bot/connector-teams/src/main/kotlin/messages/TeamsBuilders.kt
+++ b/bot/connector-teams/src/main/kotlin/messages/TeamsBuilders.kt
@@ -63,8 +63,8 @@ fun <T : Bus<T>> T.nlpCardAction(
     title: CharSequence
 ): CardAction =
     translate(title).toString().let { t ->
-        CardAction(IM_BACK, t).apply {
-            displayText = t
+        CardAction(IM_BACK, t, t).apply {
+            value = t
             text = t
         }
     }

--- a/bot/connector-teams/src/main/kotlin/messages/TeamsBuilders.kt
+++ b/bot/connector-teams/src/main/kotlin/messages/TeamsBuilders.kt
@@ -19,7 +19,7 @@ package ai.tock.bot.connector.teams.messages
 import ai.tock.bot.connector.teams.teamsConnectorType
 import ai.tock.bot.engine.Bus
 import ai.tock.bot.engine.I18nTranslator
-import com.microsoft.bot.schema.ActionTypes.MESSAGE_BACK
+import com.microsoft.bot.schema.ActionTypes.IM_BACK
 import com.microsoft.bot.schema.ActionTypes.OPEN_URL
 import com.microsoft.bot.schema.CardAction
 import com.microsoft.bot.schema.CardImage
@@ -63,7 +63,7 @@ fun <T : Bus<T>> T.nlpCardAction(
     title: CharSequence
 ): CardAction =
     translate(title).toString().let { t ->
-        CardAction(MESSAGE_BACK, t).apply {
+        CardAction(IM_BACK, t).apply {
             displayText = t
             text = t
         }

--- a/bot/connector-teams/src/test/kotlin/messages/TeamsBotTextMessageTest.kt
+++ b/bot/connector-teams/src/test/kotlin/messages/TeamsBotTextMessageTest.kt
@@ -16,8 +16,7 @@
 
 package ai.tock.bot.connector.teams.messages
 
-import com.microsoft.bot.schema.ActionTypes
-import com.microsoft.bot.schema.ActionTypes.MESSAGE_BACK
+import com.microsoft.bot.schema.ActionTypes.IM_BACK
 import com.microsoft.bot.schema.ActionTypes.OPEN_URL
 import com.microsoft.bot.schema.CardAction
 import com.microsoft.bot.schema.CardImage
@@ -33,7 +32,7 @@ class TeamsBotTextMessageTest {
         text = "text"
         value = "value"
     }
-    private val differentCardAction = CardAction(MESSAGE_BACK, "title").apply {
+    private val differentCardAction = CardAction(IM_BACK, "title").apply {
         displayText = "displayText"
         text = "text"
         value = "value"


### PR DESCRIPTION
Following analysis with a Microsoft expert, we need to test the "ImBack" solution (https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-actions?tabs=json#action-type-imback) by adding the value element.

I only need a snapshot with these changes to test.