### PR TITLE
Bottn tock studio image accessibility

### DIFF
--- a/bot/admin/web/src/app/bot/model/story.ts
+++ b/bot/admin/web/src/app/bot/model/story.ts
@@ -611,6 +611,9 @@ export class SimpleAnswerConfiguration extends AnswerConfiguration {
           bot.duplicateLabel(clonedMediaMessage.subTitle, (i18n) => {
             clonedMediaMessage.subTitle = i18n;
           });
+          bot.duplicateLabel(clonedMediaMessage.file?.description, (i18n) => {
+            clonedMediaMessage.file.description = i18n;
+          });
           clonedMediaMessage.actions.forEach((action) => {
             bot.duplicateLabel(action.title, (i18n) => {
               action.title = i18n;
@@ -753,8 +756,11 @@ export class MediaFile {
     public name: string,
     public id: string,
     public type: AttachmentType,
-    public externalUrl?: string
+    public externalUrl?: string,
+    public description?: I18nLabel
   ) {}
+
+  public descriptionLabel: string;
 
   url(baseUrl: string): String {
     return this.externalUrl ? this.externalUrl : `${baseUrl}/file/${this.id}.${this.suffix}`;
@@ -786,7 +792,8 @@ export class MediaFile {
     }
     const value = Object.create(MediaFile.prototype);
     const result = Object.assign(value, json, {
-      type: AttachmentType[json.type]
+      type: AttachmentType[json.type],
+      description: json.description ? I18nLabel.fromJSON(json.description) : null
     });
     return result;
   }

--- a/bot/admin/web/src/app/bot/story/media/media-dialog.component.html
+++ b/bot/admin/web/src/app/bot/story/media/media-dialog.component.html
@@ -124,8 +124,22 @@
             />
           </span>
         </p>
-
-        <hr />
+        <!--- Description -->
+        <span
+          *ngIf="media.file"
+          class="nb-form-field inline">
+            <label>File Description</label>
+            <input
+              nbInput
+              type="text"
+              name="description"
+              placeholder="Description"
+              [(ngModel)]="media.file.descriptionLabel"
+              class="width-50"
+              nbTooltip="File Description"
+            />
+          </span>
+        <hr/>
         <!-- actions -->
         <div class="actions">
           <h6>Actions</h6>

--- a/bot/admin/web/src/app/bot/story/media/media-dialog.component.ts
+++ b/bot/admin/web/src/app/bot/story/media/media-dialog.component.ts
@@ -62,6 +62,11 @@ export class MediaDialogComponent implements OnInit {
         this.state.currentLocale
       ).label;
     }
+    if (this.media.file && this.media.file.description) {
+      this.media.file.descriptionLabel = this.media.file.description.defaultLocalizedLabelForLocale(
+        this.state.currentLocale
+      ).label;
+    }
 
     this.media.actions.forEach(
       (a) => (a.titleLabel = a.title.defaultLocalizedLabelForLocale(this.state.currentLocale).label)
@@ -87,6 +92,10 @@ export class MediaDialogComponent implements OnInit {
 
   private isSubtitle() {
     return this.media.subTitleLabel && this.media.subTitleLabel.trim().length !== 0;
+  }
+
+  private isDescription() {
+    return this.media.file && this.media.file.descriptionLabel && this.media.file.descriptionLabel.trim().length !== 0;
   }
 
   private isFile() {
@@ -171,6 +180,31 @@ export class MediaDialogComponent implements OnInit {
         }
       } else {
         this.media.subTitle = null;
+      }
+
+      if (this.isDescription()) {
+        if (this.media.file && this.media.file.description) {
+          this.bot
+            .saveI18nLabel(
+              this.media.file.description.changeDefaultLabelForLocale(
+                this.state.currentLocale,
+                this.media.file.descriptionLabel.trim()
+              )
+            )
+            .subscribe((_) => {});
+        } else {
+          this.bot
+            .createI18nLabel(
+              new CreateI18nLabelRequest(
+                this.category,
+                this.media.file.descriptionLabel.trim(),
+                this.state.currentLocale
+              )
+            )
+            .subscribe((i18n) => (this.media.file.description = i18n));
+        }
+      } else if (this.media.file) {
+        this.media.file.description = null;
       }
 
       this.media.actions = this.media.actions

--- a/bot/admin/web/src/app/bot/story/story.component.ts
+++ b/bot/admin/web/src/app/bot/story/story.component.ts
@@ -199,7 +199,6 @@ export class StoryComponent implements OnInit, OnChanges {
     dialogRef.afterClosed().subscribe((result) => {
       if (result && result.entities) {
         this.story.mandatoryEntities = result.entities;
-        // console.log(this.story);
         this.saveStory(this.story.selected);
       }
     });

--- a/bot/api/model/src/main/kotlin/message/bot/Attachment.kt
+++ b/bot/api/model/src/main/kotlin/message/bot/Attachment.kt
@@ -18,5 +18,6 @@ package ai.tock.bot.api.model.message.bot
 
 data class Attachment(
     val url: String,
-    val type: AttachmentType? = null
+    val type: AttachmentType? = null,
+    val description: I18nText? = null
 )

--- a/bot/api/service/src/main/kotlin/BotApiHandler.kt
+++ b/bot/api/service/src/main/kotlin/BotApiHandler.kt
@@ -251,7 +251,8 @@ internal class BotApiHandler(
                 MediaFile(
                     it.url,
                     it.url,
-                    it.type?.let { AttachmentType.valueOf(it.name) } ?: UploadedFilesService.attachmentType(it.url)
+                    it.type?.let { AttachmentType.valueOf(it.name) } ?: UploadedFilesService.attachmentType(it.url),
+                    translateText(it.description)
                 )
             },
             card.actions.map {

--- a/bot/connector-messenger/src/test/kotlin/MediaConverterTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/MediaConverterTest.kt
@@ -50,7 +50,7 @@ class MediaConverterTest {
         val mediaCard = MediaCard(
             "title",
             "subtitle",
-            MediaFile("https://a/image.png", "image"),
+            MediaFile("https://a/image.png", "image", description = "description File"),
             listOf(MediaAction("Test"))
         )
         val result = MediaConverter.toConnectorMessage(mediaCard).invoke(bus)

--- a/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/WebMediaFile.kt
+++ b/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/WebMediaFile.kt
@@ -19,5 +19,6 @@ package ai.tock.bot.connector.web.send
 data class WebMediaFile(
     val url: String,
     val name: String,
-    val type: String
+    val type: String,
+    val description: CharSequence? = null
 )

--- a/bot/connector-web/src/main/kotlin/WebBuilders.kt
+++ b/bot/connector-web/src/main/kotlin/WebBuilders.kt
@@ -287,13 +287,17 @@ fun <T : Bus<T>> T.webCardWithAttachment(
     attachmentUrl: CharSequence,
     buttons: List<Button>,
     type: AttachmentType = AttachmentType.file,
-    attachementName: String = ""
+    attachementName: String = "",
+    fileDescription: CharSequence? = null
 ): WebCard {
     return WebCard(
         title = translate(title).toString(),
         subTitle = translate(subTitle).toString(),
         file = WebMediaFile(
-            attachmentUrl.toString(), attachementName, type
+            attachmentUrl.toString(),
+            attachementName,
+            type,
+            if (fileDescription != null) translate(fileDescription).toString() else null
         ),
         buttons = buttons
     )
@@ -303,9 +307,15 @@ fun <T : Bus<T>> T.webCardWithAttachment(
  * Creates a [WebMessage] from a [WebImage].
  */
 
-fun <T : Bus<T>> T.webImage(imageUrl: String, title: CharSequence): WebMessage =
+fun <T : Bus<T>> T.webImage(imageUrl: String, title: CharSequence, description: CharSequence? = null): WebMessage =
     WebMessage(
-        image = WebImage(WebMediaFile(imageUrl, title.toString(), AttachmentType.image), title)
+        image = WebImage(
+            WebMediaFile(
+                imageUrl,
+                title.toString(),
+                AttachmentType.image,
+                if (description != null) translate(description).toString() else null
+            ),title)
     )
 
 /**

--- a/bot/connector-web/src/main/kotlin/WebModels.kt
+++ b/bot/connector-web/src/main/kotlin/WebModels.kt
@@ -112,14 +112,15 @@ fun Button.toChoice(): Choice =
     }
 
 fun WebMediaFile.toMediaFile(): MediaFile =
-    MediaFile(url, name, attachmentType(type))
+    MediaFile(url, name, attachmentType(type), description)
 
 fun MediaFile.toWebMediaFile(): WebMediaFile =
-    WebMediaFile(url, name, type)
+    WebMediaFile(url, name, type, description?.toString())
 
 fun WebMediaFile(
     url: String,
     name: String,
-    type: AttachmentType = attachmentType(url)
+    type: AttachmentType = attachmentType(url),
+    description: String? = null
 ): WebMediaFile =
-    WebMediaFile(url, name, type.name)
+    WebMediaFile(url, name, type.name, description)

--- a/bot/connector-web/src/test/kotlin/WebBuildersTest.kt
+++ b/bot/connector-web/src/test/kotlin/WebBuildersTest.kt
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import ai.tock.bot.connector.web.HrefTargetType
+import ai.tock.bot.connector.web.*
 import ai.tock.bot.connector.web.send.ButtonStyle
 import ai.tock.bot.connector.web.send.ButtonType
-import ai.tock.bot.connector.web.webIntentQuickReply
-import ai.tock.bot.connector.web.webNlpQuickReply
-import ai.tock.bot.connector.web.webPostbackButton
-import ai.tock.bot.connector.web.webUrlButton
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.engine.BotBus
+import ai.tock.bot.engine.action.SendAttachment
+import ai.tock.translator.raw
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -211,6 +211,64 @@ internal class WebBuildersTest {
             )
             Assertions.assertThat(webNlpQuickReply.type).isEqualTo(ButtonType.quick_reply)
             Assertions.assertThat(webNlpQuickReply).hasFieldOrPropertyWithValue("style", null)
+        }
+    }
+
+    @Nested
+    inner class WebImageTests {
+
+        @Test
+        fun `webImage with no description`() {
+            val webImageReply = bus.webImage(
+                imageUrl = "https://ab.c.de",
+                title = "title"
+            )
+            Assertions.assertThat(webImageReply.image?.file?.type).isEqualTo(SendAttachment.AttachmentType.image.toString())
+            Assertions.assertThat(webImageReply.image?.file?.description).isNull()
+        }
+
+        @Test
+        fun `webImage with description`() {
+            every { bus.translate("description") } returns "description".raw
+            val webImageReply = bus.webImage(
+                imageUrl = "https://ab.c.de",
+                title = "title",
+                description = "description"
+            )
+            Assertions.assertThat(webImageReply.image?.file?.type).isEqualTo(SendAttachment.AttachmentType.image.toString())
+            Assertions.assertThat(webImageReply.image?.file?.description).isEqualTo("description")
+            verify { bus.translate("description") }
+        }
+    }
+
+    @Nested
+    inner class WebCardWithAttachmentTests {
+
+        @Test
+        fun `webCard with no description`() {
+            val webCardWithAttachmentReply = bus.webCardWithAttachment(
+                title = "title",
+                subTitle = "subTitle",
+                attachmentUrl = "https://ab.c.de",
+                buttons = emptyList()
+            )
+            Assertions.assertThat(webCardWithAttachmentReply.file?.type).isEqualTo(SendAttachment.AttachmentType.file.toString())
+            Assertions.assertThat(webCardWithAttachmentReply.file?.description).isNull()
+        }
+
+        @Test
+        fun `webCard with description`() {
+            every { bus.translate("description") } returns "description".raw
+            val webCardWithAttachmentReply = bus.webCardWithAttachment(
+                title = "title",
+                subTitle = "subTitle",
+                attachmentUrl = "https://ab.c.de",
+                buttons = emptyList(),
+                fileDescription = "description"
+            )
+            Assertions.assertThat(webCardWithAttachmentReply.file?.type).isEqualTo(SendAttachment.AttachmentType.file.toString())
+            Assertions.assertThat(webCardWithAttachmentReply.file?.description).isEqualTo("description")
+            verify { bus.translate("description") }
         }
     }
 }

--- a/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
+++ b/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
@@ -170,6 +170,39 @@ internal class WebConnectorResponseTest {
     }
 
     @Test
+    fun `web card with buttons and description`() {
+        val expected = WebConnectorResponseContent(
+            responses = listOf(
+                WebMessageContent(
+                    card = WebCard(
+                        title = "title",
+                        subTitle = "subTitle",
+                        file = WebMediaFile(
+                            url = "http://www.sncf.com/image.png",
+                            name = "imageName",
+                            type = SendAttachment.AttachmentType.image,
+                            description = "description"
+                        ),
+                        buttons = listOf(
+                            PostbackButton(
+                                title = "title",
+                                payload = "payload"
+                            ),
+                            UrlButton(
+                                title = "title",
+                                url = "http://www.sncf.com"
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val deserializedEvent =
+            mapper.readValue<WebConnectorResponseContent>(resourceAsStream("/card_with_buttons_and_file_description.json"))
+        Assertions.assertThat(deserializedEvent).isEqualTo(expected)
+    }
+
+    @Test
     fun `carousel with two cards and one button`() {
         val expected = WebConnectorResponseContent(
             responses = listOf(

--- a/bot/connector-web/src/test/resources/card_with_buttons_and_file_description.json
+++ b/bot/connector-web/src/test/resources/card_with_buttons_and_file_description.json
@@ -1,0 +1,35 @@
+{
+  "responses": [
+    {
+      "card": {
+        "title": "title",
+        "subTitle": "subTitle",
+        "file": {
+          "name": "imageName",
+          "url": "http://www.sncf.com/image.png",
+          "type": "image",
+          "description": "description"
+        },
+        "buttons": [
+          {
+            "title": "title",
+            "payload": "payload",
+            "type": "postback",
+            "style": "primary",
+            "clazz": "postback_button"
+          },
+          {
+            "title": "title",
+            "url": "http://www.sncf.com",
+            "type": "web_url",
+            "target": "_blank",
+            "style": "primary",
+            "clazz": "url_button"
+          }
+        ]
+      },
+      "version": "1",
+      "type": "WebMessage"
+    }
+  ]
+}

--- a/bot/engine/src/main/kotlin/admin/story/dump/MediaFileDescriptorDump.kt
+++ b/bot/engine/src/main/kotlin/admin/story/dump/MediaFileDescriptorDump.kt
@@ -23,6 +23,7 @@ import ai.tock.bot.engine.config.UploadedFilesService.fileId
 import ai.tock.bot.engine.config.UploadedFilesService.getFileContentFromId
 import ai.tock.bot.engine.config.UploadedFilesService.uploadFile
 import ai.tock.shared.Dice
+import ai.tock.translator.I18nLabel
 
 /**
  * A file descriptor.
@@ -33,7 +34,8 @@ class MediaFileDescriptorDump(
     val data: ByteArray?,
     val id: String = Dice.newId(),
     val type: AttachmentType = UploadedFilesService.attachmentType(suffix),
-    val externalUrl: String? = null
+    val externalUrl: String? = null,
+    val description: I18nLabel?
 ) {
 
     constructor(file: MediaFileDescriptor) :
@@ -43,22 +45,23 @@ class MediaFileDescriptorDump(
             if (file.externalUrl == null) getFileContentFromId(fileId(file.id, file.suffix)) else null,
             file.id,
             file.type,
-            file.externalUrl
+            file.externalUrl,
+            file.description
         )
 
     fun toFile(controller: StoryDefinitionConfigurationDumpController): MediaFileDescriptor? =
         if (externalUrl != null) {
             MediaFileDescriptor(
-                suffix, name, id, type, externalUrl
+                suffix, name, id, type, externalUrl, description
             )
         } else {
             val content = getFileContentFromId(fileId(id, suffix))
             if (content != null && content.size == data?.size) {
                 MediaFileDescriptor(
-                    suffix, name, id, type
+                    suffix, name, id, type, description = description
                 )
             } else if (data != null) {
-                uploadFile(controller.targetNamespace, name, data)
+                uploadFile(controller.targetNamespace, name, data, description = description)
             } else {
                 null
             }

--- a/bot/engine/src/main/kotlin/connector/media/MediaFile.kt
+++ b/bot/engine/src/main/kotlin/connector/media/MediaFile.kt
@@ -26,7 +26,8 @@ import ai.tock.bot.engine.message.Attachment
 data class MediaFile(
     val url: String,
     val name: String,
-    val type: AttachmentType = UploadedFilesService.attachmentType(url)
+    val type: AttachmentType = UploadedFilesService.attachmentType(url),
+    val description: CharSequence?
 ) {
 
     internal fun toAttachment(): Attachment = Attachment(url, type)

--- a/bot/engine/src/main/kotlin/connector/media/MediaFileDescriptor.kt
+++ b/bot/engine/src/main/kotlin/connector/media/MediaFileDescriptor.kt
@@ -20,6 +20,9 @@ import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.action.SendAttachment.AttachmentType
 import ai.tock.bot.engine.config.UploadedFilesService
 import ai.tock.shared.Dice
+import ai.tock.translator.I18nLabel
+import ai.tock.translator.I18nLabelValue
+import ai.tock.translator.Translator
 
 /**
  * A file descriptor.
@@ -29,11 +32,13 @@ data class MediaFileDescriptor(
     val name: String,
     val id: String = Dice.newId(),
     val type: AttachmentType = UploadedFilesService.attachmentType(suffix),
-    val externalUrl: String? = null
+    val externalUrl: String? = null,
+    val description: I18nLabel? = null
 ) {
+
     /**
      * Creates a [MediaMessage] for the specified [BotBus].
      */
     fun toMessage(bus: BotBus): MediaFile =
-        MediaFile(externalUrl ?: UploadedFilesService.botFilePath(bus, id, suffix), name, type)
+        MediaFile(externalUrl ?: UploadedFilesService.botFilePath(bus, id, suffix), name, type, bus.translate(description?.let { I18nLabelValue(it) }).takeUnless { it.isBlank() })
 }

--- a/bot/engine/src/main/kotlin/engine/config/UploadedFilesService.kt
+++ b/bot/engine/src/main/kotlin/engine/config/UploadedFilesService.kt
@@ -25,11 +25,12 @@ import ai.tock.shared.cache.getFromCache
 import ai.tock.shared.cache.putInCache
 import ai.tock.shared.property
 import ai.tock.shared.vertx.blocking
+import ai.tock.translator.I18nLabel
 import io.vertx.core.buffer.Buffer
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
-import org.litote.kmongo.toId
 import java.util.UUID
+import org.litote.kmongo.toId
 
 /**
  * To manage uploaded files.
@@ -56,7 +57,12 @@ object UploadedFilesService {
             file
         }
 
-    fun uploadFile(namespace: String, fileName: String, bytes: ByteArray): MediaFileDescriptor? {
+    fun uploadFile(
+        namespace: String,
+        fileName: String,
+        bytes: ByteArray,
+        description: I18nLabel? = null
+    ): MediaFileDescriptor? {
         val id = (namespace + UUID.randomUUID().toString()).toLowerCase()
         val name = fileName.trim().toLowerCase()
         val lastDot = name.lastIndexOf(".")
@@ -67,7 +73,8 @@ object UploadedFilesService {
         val suffix = name.substring(lastDot + 1)
         val fileId = "$id.$suffix"
         putInCache(fileId.toId(), UPLOADED_TYPE, bytes)
-        return MediaFileDescriptor(suffix, fileName, id)
+
+        return MediaFileDescriptor(suffix, fileName, id, description = description)
     }
 
     fun downloadFile(context: RoutingContext, id: String, suffix: String) {

--- a/bot/engine/src/test/kotlin/engine/config/ConfiguredStoryHandlerTest.kt
+++ b/bot/engine/src/test/kotlin/engine/config/ConfiguredStoryHandlerTest.kt
@@ -251,17 +251,32 @@ class ConfiguredStoryHandlerTest {
                 SimpleAnswer(
                     key = I18nLabelValue(label2Card),
                     delay = -1,
-                    mediaMessage = MediaCardDescriptor(I18nLabelValue(label2Card), null, null, fillCarousel = true)
+                    mediaMessage = MediaCardDescriptor(
+                        I18nLabelValue(label2Card),
+                        null,
+                        null,
+                        fillCarousel = true
+                    )
                 ),
                 SimpleAnswer(
                     key = I18nLabelValue(label3Card),
                     delay = -1,
-                    mediaMessage = MediaCardDescriptor(I18nLabelValue(label3Card), null, null, fillCarousel = true)
+                    mediaMessage = MediaCardDescriptor(
+                        I18nLabelValue(label3Card),
+                        null,
+                        null,
+                        fillCarousel = true
+                    )
                 ),
                 SimpleAnswer(
                     key = I18nLabelValue(label4Card),
                     delay = -1,
-                    mediaMessage = MediaCardDescriptor(I18nLabelValue(label4Card), null, null, fillCarousel = true)
+                    mediaMessage = MediaCardDescriptor(
+                        I18nLabelValue(label4Card),
+                        null,
+                        null,
+                        fillCarousel = true
+                    )
                 ),
                 SimpleAnswer(
                     key = I18nLabelValue(label5Text),
@@ -274,12 +289,22 @@ class ConfiguredStoryHandlerTest {
                 SimpleAnswer(
                     key = I18nLabelValue(label7Card),
                     delay = -1,
-                    mediaMessage = MediaCardDescriptor(I18nLabelValue(label7Card), null, null, fillCarousel = true)
+                    mediaMessage = MediaCardDescriptor(
+                        I18nLabelValue(label7Card),
+                        null,
+                        null,
+                        fillCarousel = true
+                    )
                 ),
                 SimpleAnswer(
                     key = I18nLabelValue(label8Card),
                     delay = -1,
-                    mediaMessage = MediaCardDescriptor(I18nLabelValue(label8Card), null, null, fillCarousel = true)
+                    mediaMessage = MediaCardDescriptor(
+                        I18nLabelValue(label8Card),
+                        null,
+                        null,
+                        fillCarousel = true
+                    )
                 )
             )
         )


### PR DESCRIPTION
Linked to tock-react-kit PR [99](https://github.com/theopenconversationkit/tock-react-kit/pull/99)

This feature enables images from ImageTemplate or CardTemplate to have an alternative description for accessibility. Actually, the attribute alt for the web when a Card has an Image is equal to the title which can be too short or too constraining.