### PR TITLE
Fixes #1434 Web-Admin: remove internal repositories

### DIFF
--- a/bot/admin/web/pom.xml
+++ b/bot/admin/web/pom.xml
@@ -145,13 +145,13 @@
             </configuration>
           </execution>
           <execution>
-            <id>npm install</id>
+            <id>npm ci</id>
             <phase>process-resources</phase>
             <goals>
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install -d --loglevel warn --force</arguments>
+              <arguments>ci -d --loglevel warn --force</arguments>
             </configuration>
           </execution>
           <execution>

--- a/nlp/admin/web/package-lock.json
+++ b/nlp/admin/web/package-lock.json
@@ -2889,7 +2889,7 @@
     },
     "node_modules/@types/ckeditor": {
       "version": "4.9.10",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/@types/ckeditor/-/ckeditor-4.9.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor/-/ckeditor-4.9.10.tgz",
       "integrity": "sha512-dcOPCXM0Cr5Z0i6eF/aW5LvECrS+cdl2Gi7lU+rEUNWby0w9Yl6mBubjrs29OVAducpuZjB4mfDayE+o4/gGdQ==",
       "license": "MIT",
       "peer": true
@@ -2917,7 +2917,7 @@
     },
     "node_modules/@types/file-saver-es": {
       "version": "2.0.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/@types/file-saver-es/-/file-saver-es-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/file-saver-es/-/file-saver-es-2.0.1.tgz",
       "integrity": "sha1-URRwkCmeEQ55qeZ98hkT5TtL9IQ=",
       "dev": true,
       "license": "MIT"
@@ -8045,7 +8045,7 @@
     },
     "node_modules/file-saver-es": {
       "version": "2.0.5",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/file-saver-es/-/file-saver-es-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/file-saver-es/-/file-saver-es-2.0.5.tgz",
       "integrity": "sha1-Wvy5XDyYhLnPCFIEbsYNRrZ2eQw=",
       "license": "MIT"
     },
@@ -10530,7 +10530,7 @@
     },
     "node_modules/jquery": {
       "version": "3.6.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/jquery/-/jquery-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
       "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
       "license": "MIT",
       "peer": true
@@ -13695,7 +13695,7 @@
     },
     "node_modules/popper.js": {
       "version": "1.16.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/popper.js/-/popper.js-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
       "license": "MIT",
@@ -15973,7 +15973,7 @@
     },
     "node_modules/prettier": {
       "version": "2.6.2",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/prettier/-/prettier-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha1-4m1xoYp0w9DwWX9V8B+2wGwgYDI=",
       "license": "MIT",
       "bin": {
@@ -25408,7 +25408,7 @@
     },
     "@types/ckeditor": {
       "version": "4.9.10",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/@types/ckeditor/-/ckeditor-4.9.10.tgz",
+      "resolved": "https://registry.npmjs.org/@types/ckeditor/-/ckeditor-4.9.10.tgz",
       "integrity": "sha512-dcOPCXM0Cr5Z0i6eF/aW5LvECrS+cdl2Gi7lU+rEUNWby0w9Yl6mBubjrs29OVAducpuZjB4mfDayE+o4/gGdQ==",
       "peer": true
     },
@@ -25432,7 +25432,7 @@
     },
     "@types/file-saver-es": {
       "version": "2.0.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/@types/file-saver-es/-/file-saver-es-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/file-saver-es/-/file-saver-es-2.0.1.tgz",
       "integrity": "sha1-URRwkCmeEQ55qeZ98hkT5TtL9IQ=",
       "dev": true
     },
@@ -29297,7 +29297,7 @@
     },
     "file-saver-es": {
       "version": "2.0.5",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/file-saver-es/-/file-saver-es-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/file-saver-es/-/file-saver-es-2.0.5.tgz",
       "integrity": "sha1-Wvy5XDyYhLnPCFIEbsYNRrZ2eQw="
     },
     "file-uri-to-path": {
@@ -31054,7 +31054,7 @@
     },
     "jquery": {
       "version": "3.6.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/jquery/-/jquery-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
       "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
       "peer": true
     },
@@ -33348,7 +33348,7 @@
     },
     "popper.js": {
       "version": "1.16.1",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/popper.js/-/popper.js-1.16.1.tgz",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "peer": true
     },
@@ -34921,7 +34921,7 @@
     },
     "prettier": {
       "version": "2.6.2",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/prettier/-/prettier-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha1-4m1xoYp0w9DwWX9V8B+2wGwgYDI="
     },
     "pretty-bytes": {


### PR DESCRIPTION
Fixes #1434 
Remove internal repo from package-lock.json and use `npm ci` instead of `npm install`.
