### PR TITLE
fixes #1459 connector_web: Fix SSE compatibility, update property name and documentation

### DIFF
--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -129,7 +129,12 @@ response:
 
 A simple [Swagger descriptor](./Swagger_TOCKWebConnector.yaml) of the rest service is provided¬.
 
-## Server-sent events (SSE)
+## Additional features
+
+Several features can be optionally used with the Web Connector. Some require specific properties to be set, either
+as a Java system property or as an environment variable (system property takes precedence).
+
+### Server-sent events (SSE)
 
 This connector supports sending messages using [Server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events).
 This feature can be enabled by setting the `tock_web_sse` optional property to `true`.
@@ -140,7 +145,7 @@ while it is listening to server-sent events.
 The `tock_web_sse_keepalive_delay` optional property can be used to configure the number of seconds between
 two SSE pings (default: 10).
 
-## React chat widget
+### React chat widget
 
 The [`tock-react-kit`](https://github.com/theopenconversationkit/tock-react-kit) component provides integration with
 Web pages, customizable chat widgets and orchestration with a Web connector back-end.
@@ -163,7 +168,7 @@ KMongoConfiguration.bsonMapper.subtypeResolver.registerSubtypes(
 )
 ```
 
-## Extra headers
+### Extra headers
 
 Sometimes it is useful to allow extra HTTP headers to bot requests, for instance to provide/pass authentication or 
 custom parameters from the front-end.
@@ -190,10 +195,17 @@ bot_api:
 > To add extra headers from a [`tock-react-kit`](https://github.com/theopenconversationkit/tock-react-kit) front-end, 
 > refer to its [README#extra-headers](https://github.com/theopenconversationkit/tock-react-kit#extra-headers).
 
-# Cookie storage for userId
+### Cookie storage for userId
 
 By default, a user's unique identifier is generated and stored by the client as an arbitrary string,
 which is passed to the web connector through the HTTP body and/or through query parameters.
-Setting the `tock_web_cookie_auth` environment variable to `true`
+Setting the `tock_web_cookie_auth` property to `true`
 makes it so the server stores users' identifiers in a secure, HTTP-only cookie, generating random unique identifiers
 (using the UUID V4 format) if no such cookie is found.
+
+### Markdown processing
+
+This connector can process [Markdown formatting](https://daringfireball.net/projects/markdown/) in messages.
+This feature can be enabled by setting the `tock_web_enable_markdown` property to `true`.
+When Markdown processing is enabled, the text content of each message is rendered with a Markdown to HTML converter before being sent to the client.
+Note that at the current time, only the main text body is rendered - markdown in cards and buttons is not supported yet.

--- a/bot/connector-web/src/main/kotlin/WebMarkdown.kt
+++ b/bot/connector-web/src/main/kotlin/WebMarkdown.kt
@@ -25,61 +25,57 @@ object WebMarkdown {
 
     internal val regex = "`{3}([\\S\\s]*?)`{3}|`([^`]*)`|~~([\\S\\s]*?)~~".toRegex()
 
-    fun markdown(text: String?): String? {
-        return if (text != null) {
-            val parser: Parser = Parser.builder().build()
-            val document: Node = parser.parse(text.toString())
-            val renderer = HtmlRenderer.builder().build()
-            var render = renderer.render(document).trim()
-            if (render.contains("<strong>")) {
-                render = render.replace("<strong>", "<strong style=\"font-weight: bold\">")
-            }
-            if (render.contains("<em>")) {
-                render = render.replace("<em>", "<em style=\"font-style: italic\">")
-            }
-            if (render.contains("<h1>")) {
-                render = render.replace(
-                    "<h1>",
-                    "<h1 style=\"display: block; font-size: 2em; margin-top: 0.67em; margin-bottom: 0.67em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
-                )
-            }
-            if (render.contains("<h2>")) {
-                render = render.replace(
-                    "<h2>",
-                    "<h2 style=\"display: block; font-size: 1.5em; margin-top: 0.83em; margin-bottom: 0.83em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
-                )
-            }
-            if (render.contains("<h3>")) {
-                render = render.replace(
-                    "<h3>",
-                    "<h3 style=\"display: block; font-size: 1.17em; margin-top: 1em; margin-bottom: 1em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
-                )
-            }
-            if (render.contains("<blockquote>")) {
-                render = render.replace(
-                    "<blockquote>",
-                    "<blockquote style=\"font-style: normal; font-size: 15px; margin-left: 0px; font-family: Arial; border-left: 4px solid rgb(0 0 0 / 28%); padding-left: 8px; background-color: #f5f5f5;\">"
-                )
-            }
-            if (render.contains("<code>")) {
-                render = render.replace(
-                    "<code>",
-                    "<code style=\"padding: 2px 4px; font-size: 90%; background-color: #f5f5f5; border-radius: 4px;\">"
-                )
-            }
-            if (render.contains("~~")) {
-                render = extractAllDataWithRegex(regex, render)
-            }
-            if (render.contains("<a href=")) {
-                render = render.replace(
-                    "<a href=",
-                    "<a target=\"_blank\" rel=\"noopener noreferrer\" href="
-                )
-            }
-            return render.replace("<p>", "").replace("</p>", "")
-        } else {
-            null
+    fun markdown(text: String): String {
+        val parser: Parser = Parser.builder().build()
+        val document: Node = parser.parse(text)
+        val renderer = HtmlRenderer.builder().build()
+        var render = renderer.render(document).trim()
+        if (render.contains("<strong>")) {
+            render = render.replace("<strong>", "<strong style=\"font-weight: bold\">")
         }
+        if (render.contains("<em>")) {
+            render = render.replace("<em>", "<em style=\"font-style: italic\">")
+        }
+        if (render.contains("<h1>")) {
+            render = render.replace(
+                "<h1>",
+                "<h1 style=\"display: block; font-size: 2em; margin-top: 0.67em; margin-bottom: 0.67em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
+            )
+        }
+        if (render.contains("<h2>")) {
+            render = render.replace(
+                "<h2>",
+                "<h2 style=\"display: block; font-size: 1.5em; margin-top: 0.83em; margin-bottom: 0.83em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
+            )
+        }
+        if (render.contains("<h3>")) {
+            render = render.replace(
+                "<h3>",
+                "<h3 style=\"display: block; font-size: 1.17em; margin-top: 1em; margin-bottom: 1em; margin-left: 0; margin-right: 0; font-weight: bold;\">"
+            )
+        }
+        if (render.contains("<blockquote>")) {
+            render = render.replace(
+                "<blockquote>",
+                "<blockquote style=\"font-style: normal; font-size: 15px; margin-left: 0px; font-family: Arial; border-left: 4px solid rgb(0 0 0 / 28%); padding-left: 8px; background-color: #f5f5f5;\">"
+            )
+        }
+        if (render.contains("<code>")) {
+            render = render.replace(
+                "<code>",
+                "<code style=\"padding: 2px 4px; font-size: 90%; background-color: #f5f5f5; border-radius: 4px;\">"
+            )
+        }
+        if (render.contains("~~")) {
+            render = extractAllDataWithRegex(regex, render)
+        }
+        if (render.contains("<a href=")) {
+            render = render.replace(
+                "<a href=",
+                "<a target=\"_blank\" rel=\"noopener noreferrer\" href="
+            )
+        }
+        return render.replace("<p>", "").replace("</p>", "")
     }
 
     internal fun extractAllDataWithRegex(regex: Regex, value: String): String {

--- a/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
+++ b/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.connector.web
+
+import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.action.SendSentence
+
+internal class WebMessageProcessor(private val processMarkdown: Boolean) {
+
+    fun process(action: Action): WebMessage? {
+        return if (action is SendSentence) {
+            val stringText = action.stringText
+
+            if (stringText != null) {
+                WebMessage(postProcess(stringText))
+            } else {
+                postProcess(action.message(webConnectorType) as? WebMessage)
+            }
+        } else {
+            null
+        }
+    }
+
+    private fun postProcess(message: WebMessage?): WebMessage? {
+        if (message?.text != null) {
+            return message.copy(text = postProcess(message.text))
+        }
+
+        return message
+    }
+
+    private fun postProcess(text: String): String {
+        if (processMarkdown) {
+            return WebMarkdown.markdown(text)
+        }
+
+        return text
+    }
+}

--- a/bot/connector-web/src/test/kotlin/WebMessageProcessorTest.kt
+++ b/bot/connector-web/src/test/kotlin/WebMessageProcessorTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ai.tock.bot.connector.web.WebMarkdown
+import ai.tock.bot.connector.web.WebMessage
+import ai.tock.bot.connector.web.WebMessageProcessor
+import ai.tock.bot.connector.web.send.QuickReply
+import ai.tock.bot.engine.action.SendSentence
+import ai.tock.bot.engine.user.PlayerId
+import org.junit.Test
+import org.junit.jupiter.api.Assertions
+
+class WebMessageProcessorTest {
+    private val markdownText = "Hello *user*"
+    private val renderedText = WebMarkdown.markdown(markdownText)
+
+    @Test
+    fun `web messages do not get processed by default`() {
+        val playerId = PlayerId("")
+        val action = SendSentence(playerId, "", playerId, markdownText)
+        val messageProcessor = WebMessageProcessor(false)
+        Assertions.assertEquals(WebMessage(markdownText), messageProcessor.process(action))
+    }
+
+    @Test
+    fun `simple web messages get rendered as HTML when markdown is enabled`() {
+        val playerId = PlayerId("")
+        val action = SendSentence(playerId, "", playerId, markdownText)
+        val messageProcessor = WebMessageProcessor(true)
+        Assertions.assertEquals(WebMessage(renderedText), messageProcessor.process(action))
+    }
+
+    @Test
+    fun `web messages' bodies get rendered as HTML when markdown is enabled`() {
+        val playerId = PlayerId("")
+        val quickReplies = listOf(QuickReply("QR", null, null))
+        val action = SendSentence(playerId, "", playerId, null, mutableListOf(WebMessage(markdownText, quickReplies)))
+        val messageProcessor = WebMessageProcessor(true)
+        Assertions.assertEquals(WebMessage(renderedText, quickReplies), messageProcessor.process(action))
+    }
+}


### PR DESCRIPTION
Fixes #1459 

This PR:
- moves the web message processing logic into its own class, used by both the default web connector callback and the SSE channels handler
- adds processing logic for already constructed `WebMessage`s
- renames the property from `allow_markdown` to `tock_web_enable_markdown` to be more in line with other TOCK properties
    - the old property is kept as a fallback for backward compatibility
- updates the README to mention the markdown feature and its limitations