### PR TITLE
fixes #1433 bug with actions when updating Media card

### DIFF
--- a/bot/admin/web/src/app/bot/model/story.ts
+++ b/bot/admin/web/src/app/bot/model/story.ts
@@ -706,6 +706,7 @@ export class MediaAction extends Media {
     const value = Object.create(MediaAction.prototype);
     const result = Object.assign(value, json, {
       title: I18nLabel.fromJSON(json.title),
+      internalId : Math.random(),
       type: MediaType.action
     });
     return result;


### PR DESCRIPTION
fixes #1433 bug with actions when updating Media card

It seems that Object.create and Object.assign do not create an internalId as expected. All media actions have the same name, that's why we see always the same input duplicated when multiple actions.