### PR TITLE
Breaking change : Proposal of verticle error handling

### DIFF
--- a/bot/admin/kotlin-compiler/server/src/main/kotlin/KotlinCompilerVerticle.kt
+++ b/bot/admin/kotlin-compiler/server/src/main/kotlin/KotlinCompilerVerticle.kt
@@ -20,8 +20,10 @@ import ai.tock.bot.admin.kotlin.compiler.KotlinCompilationException
 import ai.tock.bot.admin.kotlin.compiler.KotlinFile
 import ai.tock.bot.admin.kotlin.compiler.KotlinFileCompilation
 import ai.tock.bot.admin.kotlin.compiler.TockKotlinCompiler
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.security.TockUserRole
 import ai.tock.shared.vertx.WebVerticle
+import ai.tock.shared.vertx.toRequestHandler
 import io.vertx.ext.web.RoutingContext
 import mu.KLogger
 import mu.KotlinLogging
@@ -29,19 +31,18 @@ import mu.KotlinLogging
 /**
  *
  */
-class KotlinCompilerVerticle : WebVerticle() {
+class KotlinCompilerVerticle : WebVerticle<CommonException>() {
 
     override val logger: KLogger = KotlinLogging.logger {}
 
     override fun configure() {
-        blockingJsonPost("/compile", TockUserRole.admin) { _, file: KotlinFile ->
-
+        blockingJsonPost("/compile", TockUserRole.admin, handler = toRequestHandler{ _, file: KotlinFile ->
             try {
                 KotlinFileCompilation(TockKotlinCompiler.compile(file.script, file.fileName))
             } catch (e: KotlinCompilationException) {
                 KotlinFileCompilation(null, e.errors)
             }
-        }
+        })
     }
 
     override fun defaultHealthcheck(): (RoutingContext) -> Unit {

--- a/bot/admin/server/src/main/kotlin/AdminTestClient.kt
+++ b/bot/admin/server/src/main/kotlin/AdminTestClient.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.admin
 
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.admin.service.BotAdminService
 import ai.tock.bot.admin.test.TestClientService
 import ai.tock.bot.admin.test.TestPlan
 import ai.tock.bot.admin.test.TestPlanExecution

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -16,11 +16,6 @@
 
 package ai.tock.bot.admin
 
-import ai.tock.bot.admin.BotAdminService.createI18nRequest
-import ai.tock.bot.admin.BotAdminService.dialogReportDAO
-import ai.tock.bot.admin.BotAdminService.getBotConfigurationByApplicationIdAndBotId
-import ai.tock.bot.admin.BotAdminService.getBotConfigurationsByNamespaceAndBotId
-import ai.tock.bot.admin.BotAdminService.importStories
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotConfiguration
 import ai.tock.bot.admin.constants.Properties
@@ -40,9 +35,20 @@ import ai.tock.bot.admin.model.Feature
 import ai.tock.bot.admin.model.I18LabelQuery
 import ai.tock.bot.admin.model.StorySearchRequest
 import ai.tock.bot.admin.model.UserSearchQuery
+import ai.tock.bot.admin.service.BotAdminService
+import ai.tock.bot.admin.service.BotAdminService.createI18nRequest
+import ai.tock.bot.admin.service.BotAdminService.dialogReportDAO
+import ai.tock.bot.admin.service.BotAdminService.getBotConfigurationByApplicationIdAndBotId
+import ai.tock.bot.admin.service.BotAdminService.getBotConfigurationsByNamespaceAndBotId
+import ai.tock.bot.admin.service.BotAdminService.importStories
+import ai.tock.bot.admin.service.FaqAdminService
 import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDump
 import ai.tock.bot.admin.test.TestPlanService
 import ai.tock.bot.admin.test.findTestService
+import ai.tock.bot.admin.verticle.AnalyticsVerticle
+import ai.tock.bot.admin.verticle.ChildVerticle
+import ai.tock.bot.admin.verticle.ParentVerticle
+import ai.tock.bot.admin.verticle.StoryVerticle
 import ai.tock.bot.connector.ConnectorType.Companion.rest
 import ai.tock.bot.connector.ConnectorTypeConfiguration
 import ai.tock.bot.connector.rest.addRestConnector
@@ -58,6 +64,7 @@ import ai.tock.nlp.front.shared.config.ApplicationDefinition
 import ai.tock.nlp.front.shared.config.FaqSettingsQuery
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.error
+import ai.tock.shared.exception.admin.AdminException
 import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.provide
@@ -66,7 +73,9 @@ import ai.tock.shared.security.TockUserRole.admin
 import ai.tock.shared.security.TockUserRole.botUser
 import ai.tock.shared.security.TockUserRole.faqBotUser
 import ai.tock.shared.security.TockUserRole.faqNlpUser
+import ai.tock.shared.vertx.RequestSucceeded
 import ai.tock.shared.vertx.ServerStatus
+import ai.tock.shared.vertx.toRequestHandler
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.Translator
@@ -83,7 +92,7 @@ import org.litote.kmongo.toId
 /**
  *
  */
-open class BotAdminVerticle : AdminVerticle() {
+open class BotAdminVerticle : AdminVerticle(), ParentVerticle<AdminException> {
 
     private val botAdminConfiguration = BotAdminConfiguration()
 
@@ -97,6 +106,8 @@ open class BotAdminVerticle : AdminVerticle() {
 
     override val supportCreateNamespace: Boolean = !botAdminConfiguration.botApiSupport
 
+    override fun protectedPaths(): Set<String> = setOf(rootPath)
+
     override fun configureServices() {
         vertx.eventBus().consumer<Boolean>(ServerStatus.SERVER_STARTED) {
             if (it.body() && booleanProperty(Properties.FAQ_MIGRATION_ENABLED, false)) {
@@ -105,7 +116,6 @@ open class BotAdminVerticle : AdminVerticle() {
         }
         initTranslator()
         dialogFlowDAO.initFlowStatCrawl()
-
         super.configureServices()
     }
 
@@ -125,355 +135,238 @@ open class BotAdminVerticle : AdminVerticle() {
             unauthorized()
         }
 
+    override fun children(): List<ChildVerticle<AdminException>> {
+        return listOf(
+            AnalyticsVerticle(),
+            StoryVerticle(),
+        )
+    }
+
     override fun configure() {
         configureServices()
 
-        blockingJsonPost("/users/search", botUser) { context, query: UserSearchQuery ->
+        preConfigure()
+
+        blockingJsonPost("/users/search", botUser, handler = toRequestHandler { context, query: UserSearchQuery ->
             if (context.organization == query.namespace) {
                 BotAdminService.searchUsers(query)
             } else {
                 unauthorized()
             }
-        }
+        })
 
-        blockingJsonPost("/analytics/messages", setOf(botUser, faqBotUser)) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByType(request)
-            }
-        }
 
-        blockingJsonPost("/analytics/users", setOf(botUser, faqBotUser)) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportUsersByType(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byConnectorType",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.countMessagesByConnectorType(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byConfiguration",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByConfiguration(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byConnectorType",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByConnectorType(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byDayOfWeek",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByDayOfWeek(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byHour",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByHour(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byIntent",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByIntent(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byDateAndIntent",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByDateAndIntent(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byDateAndStory",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByDateAndStory(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byStory",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByStory(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byStoryCategory",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByStoryCategory(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byStoryType",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByStoryType(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byStoryLocale",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByStoryLocale(request)
-            }
-        }
-
-        blockingJsonPost(
-            "/analytics/messages/byActionType",
-            setOf(botUser, faqBotUser)
-        ) { context, request: DialogFlowRequest ->
-            checkAndMeasure(context, request) {
-                BotAdminAnalyticsService.reportMessagesByActionType(request)
-            }
-        }
-
-        blockingJsonGet("/dialog/:applicationId/:dialogId", setOf(botUser, faqBotUser)) { context ->
-            val app = FrontClient.getApplicationById(context.pathId("applicationId"))
-            if (context.organization == app?.namespace) {
-                dialogReportDAO
-                    .search(
-                        DialogReportQuery(
-                            context.organization,
-                            app.name,
-                            dialogId = context.path("dialogId")
+        blockingJsonGet("/dialog/:applicationId/:dialogId", setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                val app = FrontClient.getApplicationById(context.pathId("applicationId"))
+                if (context.organization == app?.namespace) {
+                    dialogReportDAO
+                        .search(
+                            DialogReportQuery(
+                                context.organization,
+                                app.name,
+                                dialogId = context.path("dialogId")
+                            )
                         )
-                    )
-                    .run {
-                        dialogs.firstOrNull()
-                    }
-            } else {
-                unauthorized()
-            }
-        }
+                        .run {
+                            dialogs.firstOrNull()
+                        }
+                } else {
+                    unauthorized()
+                }
+            })
 
         blockingJsonPost(
             "/dialogs/search",
-            setOf(botUser, faqNlpUser, faqBotUser)
-        ) { context, query: DialogsSearchQuery ->
-            if (context.organization == query.namespace) {
-                BotAdminService.search(query)
-            } else {
-                unauthorized()
-            }
-        }
+            setOf(botUser, faqNlpUser, faqBotUser),
+            handler = toRequestHandler { context, query: DialogsSearchQuery ->
+                if (context.organization == query.namespace) {
+                    BotAdminService.search(query)
+                } else {
+                    unauthorized()
+                }
+            })
 
-        blockingJsonGet("/bots/:botId", setOf(botUser, faqNlpUser, faqBotUser)) { context ->
-            BotAdminService.getBots(context.organization, context.path("botId"))
-        }
+        blockingJsonGet("/bots/:botId", setOf(botUser, faqNlpUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                BotAdminService.getBots(context.organization, context.path("botId"))
+            })
 
         blockingJsonPost(
             "/bot", admin,
             logger = logger<BotConfiguration>(" Create or Update Bot Configuration") { _, c ->
                 c?.let { FrontClient.getApplicationByNamespaceAndName(it.namespace, it.nlpModel)?._id }
-            }
-        ) { context, bot: BotConfiguration ->
-            if (context.organization == bot.namespace) {
-                BotAdminService.save(bot)
-            } else {
-                unauthorized()
-            }
-        }
+            },
+            handler = toRequestHandler { context, bot: BotConfiguration ->
+                if (context.organization == bot.namespace) {
+                    BotAdminService.save(bot)
+                } else {
+                    unauthorized()
+                }
+            })
 
-        blockingJsonGet("/configuration/bots/:botId", setOf(botUser, faqBotUser)) { context ->
-            BotAdminService.getBotConfigurationsByNamespaceAndBotId(context.organization, context.path("botId"))
-        }
+        blockingJsonGet("/configuration/bots/:botId", setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                BotAdminService.getBotConfigurationsByNamespaceAndBotId(context.organization, context.path("botId"))
+            })
 
-        blockingJsonPost("/configuration/bots") { context, query: ApplicationScopedQuery ->
+        blockingJsonPost("/configuration/bots", handler = toRequestHandler { context, query: ApplicationScopedQuery ->
             if (context.organization == query.namespace) {
                 BotAdminService.getBotConfigurationsByNamespaceAndNlpModel(query.namespace, query.applicationName)
             } else {
                 unauthorized()
             }
-        }
+        })
 
         blockingJsonPost(
             "/configuration/bot", admin,
             logger = logger<BotConnectorConfiguration>("Create or Update Bot Connector Configuration") { _, c ->
                 c?.let { FrontClient.getApplicationByNamespaceAndName(it.namespace, it.nlpModel)?._id }
-            }
-        ) { context, bot: BotConnectorConfiguration ->
-            if (context.organization == bot.namespace) {
-                if (bot._id != null) {
-                    val conf = BotAdminService.getBotConfigurationById(bot._id)
-                    if (conf == null || bot.namespace != conf.namespace || bot.botId != conf.botId) {
-                        unauthorized()
-                    }
-                    if (getBotConfigurationByApplicationIdAndBotId(bot.namespace, bot.applicationId, bot.botId)
-                            ?.run { _id != conf._id } == true
-                    ) {
-                        badRequest("Connector identifier already exists")
-                    }
-                } else {
-                    if (getBotConfigurationByApplicationIdAndBotId(
-                            bot.namespace,
-                            bot.applicationId,
-                            bot.botId
-                        ) != null
-                    ) {
-                        badRequest("Connector identifier already exists")
-                    }
-                }
-                bot.path?.let {
-                    if (getBotConfigurationsByNamespaceAndBotId(
-                            bot.namespace,
-                            bot.botId
-                        ).any { conf -> conf._id != bot._id && conf.path?.lowercase() == it.lowercase() }
-                    )
-                        badRequest("Connector path already exists (case-insensitive)")
-                }
-                val conf = bot.toBotApplicationConfiguration()
-                val connectorProvider = BotRepository.findConnectorProvider(conf.connectorType)
-                if (connectorProvider != null) {
-                    val filledConf = if (bot.fillMandatoryValues) {
-                        val additionalProperties = connectorProvider
-                            .configuration()
-                            .fields
-                            .filter { it.mandatory && !bot.parameters.containsKey(it.key) }
-                            .map {
-                                it.key to "Please fill a value"
-                            }
-                            .toMap()
-                        conf.copy(parameters = conf.parameters + additionalProperties)
+            },
+            handler = toRequestHandler { context, bot: BotConnectorConfiguration ->
+                if (context.organization == bot.namespace) {
+                    if (bot._id != null) {
+                        val conf = BotAdminService.getBotConfigurationById(bot._id)
+                        if (conf == null || bot.namespace != conf.namespace || bot.botId != conf.botId) {
+                            unauthorized()
+                        }
+                        if (getBotConfigurationByApplicationIdAndBotId(bot.namespace, bot.applicationId, bot.botId)
+                                ?.run { _id != conf._id } == true
+                        ) {
+                            badRequest("Connector identifier already exists")
+                        }
                     } else {
-                        conf
+                        if (getBotConfigurationByApplicationIdAndBotId(
+                                bot.namespace,
+                                bot.applicationId,
+                                bot.botId
+                            ) != null
+                        ) {
+                            badRequest("Connector identifier already exists")
+                        }
                     }
-                    connectorProvider.check(filledConf.toConnectorConfiguration())
-                        .apply {
-                            if (isNotEmpty()) {
-                                badRequest(joinToString())
-                            }
+                    bot.path?.let {
+                        if (getBotConfigurationsByNamespaceAndBotId(
+                                bot.namespace,
+                                bot.botId
+                            ).any { conf -> conf._id != bot._id && conf.path?.lowercase() == it.lowercase() }
+                        )
+                            badRequest("Connector path already exists (case-insensitive)")
+                    }
+                    val conf = bot.toBotApplicationConfiguration()
+                    val connectorProvider = BotRepository.findConnectorProvider(conf.connectorType)
+                    if (connectorProvider != null) {
+                        val filledConf = if (bot.fillMandatoryValues) {
+                            val additionalProperties = connectorProvider
+                                .configuration()
+                                .fields
+                                .filter { it.mandatory && !bot.parameters.containsKey(it.key) }
+                                .associate { it.key to "Please fill a value" }
+                            conf.copy(parameters = conf.parameters + additionalProperties)
+                        } else {
+                            conf
                         }
-                    try {
-                        BotAdminService.saveApplicationConfiguration(filledConf)
-                        // add rest connector
-                        if (bot._id == null && bot.connectorType != rest) {
-                            addRestConnector(filledConf).apply {
-                                BotAdminService.saveApplicationConfiguration(
-                                    BotApplicationConfiguration(
-                                        connectorId,
-                                        filledConf.botId,
-                                        filledConf.namespace,
-                                        filledConf.nlpModel,
-                                        type,
-                                        ownerConnectorType,
-                                        getName(),
-                                        getBaseUrl(),
-                                        path = path,
-                                        targetConfigurationId = conf._id
+                        connectorProvider.check(filledConf.toConnectorConfiguration())
+                            .apply {
+                                if (isNotEmpty()) {
+                                    badRequest(joinToString())
+                                }
+                            }
+                        try {
+                            BotAdminService.saveApplicationConfiguration(filledConf)
+                            // add rest connector
+                            if (bot._id == null && bot.connectorType != rest) {
+                                addRestConnector(filledConf).apply {
+                                    BotAdminService.saveApplicationConfiguration(
+                                        BotApplicationConfiguration(
+                                            connectorId,
+                                            filledConf.botId,
+                                            filledConf.namespace,
+                                            filledConf.nlpModel,
+                                            type,
+                                            ownerConnectorType,
+                                            getName(),
+                                            getBaseUrl(),
+                                            path = path,
+                                            targetConfigurationId = conf._id
+                                        )
                                     )
-                                )
+                                }
                             }
+                        } catch (t: Throwable) {
+                            badRequest("Error creating/updating configuration: ${t.message}")
                         }
-                    } catch (t: Throwable) {
-                        badRequest("Error creating/updating configuration: ${t.message}")
+                    } else {
+                        badRequest("unknown connector provider ${conf.connectorType}")
                     }
                 } else {
-                    badRequest("unknown connector provider ${conf.connectorType}")
+                    unauthorized()
                 }
-            } else {
-                unauthorized()
-            }
-        }
+            })
 
         blockingJsonDelete(
             "/configuration/bot/:confId",
             admin,
-            simpleLogger("Delete Bot Configuration", { it.path("confId") to true })
-        ) { context ->
-            BotAdminService.getBotConfigurationById(context.pathId("confId"))
-                ?.let {
-                    if (context.organization == it.namespace) {
-                        BotAdminService.deleteApplicationConfiguration(it)
-                        true
-                    } else {
-                        null
-                    }
-                } ?: unauthorized()
-        }
+            simpleLogger("Delete Bot Configuration", { it.path("confId") to true }),
+            handler = toRequestHandler { context ->
+                BotAdminService.getBotConfigurationById(context.pathId("confId"))
+                    ?.let {
+                        if (context.organization == it.namespace) {
+                            BotAdminService.deleteApplicationConfiguration(it)
+                            true
+                        } else {
+                            false
+                        }
+                    } ?: unauthorized()
+            })
 
-        blockingJsonGet("/action/nlp-stats/:actionId", setOf(botUser, faqBotUser)) { context ->
-            dialogReportDAO.getNlpCallStats(context.pathId("actionId"), context.organization)
-        }
+        blockingJsonGet("/action/nlp-stats/:actionId", setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                dialogReportDAO.getNlpCallStats(context.pathId("actionId"), context.organization)
+            })
 
-        blockingJsonGet("/feature/:applicationId", setOf(botUser, faqBotUser)) { context ->
-            val applicationId = context.path("applicationId")
-            BotAdminService.getFeatures(applicationId, context.organization)
-        }
+        blockingJsonGet("/feature/:applicationId", setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                BotAdminService.getFeatures(applicationId, context.organization)
+            })
 
         blockingPost(
             "/feature/:applicationId/toggle",
             setOf(botUser, faqBotUser),
-            simpleLogger("Toogle Application Feature", { it.body().asString() })
-        ) { context ->
-            val applicationId = context.path("applicationId")
-            val body = context.body().asString()
-            val feature: Feature = mapper.readValue(body)
-            BotAdminService.toggleFeature(applicationId, context.organization, feature)
-        }
+            simpleLogger("Toogle Application Feature", { it.body().asString() }),
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                val body = context.body().asString()
+                val feature: Feature = mapper.readValue(body)
+                BotAdminService.toggleFeature(applicationId, context.organization, feature)
+            })
 
         blockingPost(
             "/feature/:applicationId/update",
             setOf(botUser, faqBotUser),
-            simpleLogger("Update Application Feature", { it.body().asString() })
-        ) { context ->
-            val applicationId = context.path("applicationId")
-            val body = context.body().asString()
-            val feature: Feature = mapper.readValue(body)
-            BotAdminService.updateDateAndEnableFeature(
-                applicationId,
-                context.organization,
-                feature
-            )
-        }
+            simpleLogger("Update Application Feature", { it.body().asString() }),
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                val body = context.body().asString()
+                val feature: Feature = mapper.readValue(body)
+                BotAdminService.updateDateAndEnableFeature(
+                    applicationId,
+                    context.organization,
+                    feature
+                )
+            })
 
         blockingPost(
             "/feature/:applicationId/add",
             setOf(botUser, faqBotUser),
-            simpleLogger("Create Application Feature", { it.body().asString() })
-        ) { context ->
-            val applicationId = context.path("applicationId")
-            val body = context.body().asString()
-            val feature: Feature = mapper.readValue(body)
-            BotAdminService.addFeature(applicationId, context.organization, feature)
-        }
+            simpleLogger("Create Application Feature", { it.body().asString() }),
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                val body = context.body().asString()
+                val feature: Feature = mapper.readValue(body)
+                BotAdminService.addFeature(applicationId, context.organization, feature)
+            })
 
         blockingDelete(
             "/feature/:botId/:category/:name/",
@@ -481,13 +374,13 @@ open class BotAdminVerticle : AdminVerticle() {
             simpleLogger(
                 "Delete Application Feature",
                 { listOf(it.path("botId"), it.path("category"), it.path("name")) }
-            )
-        ) { context ->
-            val category = context.path("category")
-            val name = context.path("name")
-            val botId = context.path("botId")
-            BotAdminService.deleteFeature(botId, context.organization, category, name, null)
-        }
+            ),
+            handler = toRequestHandler { context ->
+                val category = context.path("category")
+                val name = context.path("name")
+                val botId = context.path("botId")
+                BotAdminService.deleteFeature(botId, context.organization, category, name, null)
+            })
 
         blockingDelete(
             "/feature/:botId/:category/:name/:applicationId",
@@ -495,33 +388,35 @@ open class BotAdminVerticle : AdminVerticle() {
             simpleLogger(
                 "Delete Application Feature",
                 { listOf(it.path("botId"), it.path("category"), it.path("name"), it.path("applicationId")) }
-            )
-        ) { context ->
-            val applicationId = context.path("applicationId")
-            val category = context.path("category")
-            val name = context.path("name")
-            val botId = context.path("botId")
-            BotAdminService.deleteFeature(
-                botId,
-                context.organization,
-                category,
-                name,
-                applicationId.takeUnless { it.isBlank() }
-            )
-        }
+            ),
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                val category = context.path("category")
+                val name = context.path("name")
+                val botId = context.path("botId")
+                BotAdminService.deleteFeature(
+                    botId,
+                    context.organization,
+                    category,
+                    name,
+                    applicationId.takeUnless { it.isBlank() }
+                )
+            })
 
-        blockingJsonGet("/application/:applicationId/plans", botUser) { context ->
-            val applicationId = context.path("applicationId")
-            TestPlanService.getTestPlansByApplication(applicationId).filter { it.namespace == context.organization }
-        }
+        blockingJsonGet("/application/:applicationId/plans", botUser,
+            handler = toRequestHandler { context ->
+                val applicationId = context.path("applicationId")
+                TestPlanService.getTestPlansByApplication(applicationId).filter { it.namespace == context.organization }
+            })
 
-        blockingJsonPost("/application/plans", botUser) { context, query: ApplicationScopedQuery ->
-            if (context.organization == query.namespace) {
-                TestPlanService.getTestPlansByNamespaceAndNlpModel(query.namespace, query.applicationName)
-            } else {
-                unauthorized()
-            }
-        }
+        blockingJsonPost("/application/plans", botUser,
+            handler = toRequestHandler { context, query: ApplicationScopedQuery ->
+                if (context.organization == query.namespace) {
+                    TestPlanService.getTestPlansByNamespaceAndNlpModel(query.namespace, query.applicationName)
+                } else {
+                    unauthorized()
+                }
+            })
 
         blockingJsonPost(
             "/bot/story/new",
@@ -537,37 +432,37 @@ open class BotAdminVerticle : AdminVerticle() {
                             )?._id
                         }
                 }
-            }
-        ) { context, query: CreateStoryRequest ->
-            BotAdminService.createStory(context.organization, query, context.userLogin) ?: unauthorized()
-        }
+            },
+            handler = toRequestHandler { context, query: CreateStoryRequest ->
+                BotAdminService.createStory(context.organization, query, context.userLogin) ?: unauthorized()
+            })
 
-        blockingJsonGet("/bot/story/:appName/export", botUser) { context ->
+        blockingJsonGet("/bot/story/:appName/export", botUser, handler= toRequestHandler { context ->
             BotAdminService.exportStories(context.organization, context.path("appName"))
-        }
+        })
 
-        blockingJsonGet("/bot/story/:appName/export/:storyConfigurationId", botUser) { context ->
+        blockingJsonGet("/bot/story/:appName/export/:storyConfigurationId", botUser, handler= toRequestHandler { context ->
             val exportStory = BotAdminService.exportStory(
                 context.organization,
                 context.path("appName"),
                 context.path("storyConfigurationId")
             )
             exportStory?.let { listOf(it) } ?: emptyList()
-        }
+        })
 
         blockingUploadJsonPost(
             "/bot/story/:appName/:locale/import",
             botUser,
-            simpleLogger("JSON Import Response Labels")
-        ) { context, stories: List<StoryDefinitionConfigurationDump> ->
-            importStories(
-                context.organization,
-                context.path("appName"),
-                context.pathToLocale("locale"),
-                stories,
-                context.userLogin
-            )
-        }
+            simpleLogger("JSON Import Response Labels"),
+            handler = toRequestHandler { context, stories: List<StoryDefinitionConfigurationDump> ->
+                importStories(
+                    context.organization,
+                    context.path("appName"),
+                    context.pathToLocale("locale"),
+                    stories,
+                    context.userLogin
+                )
+            })
 
         blockingJsonPost(
             "/bot/story",
@@ -583,288 +478,308 @@ open class BotAdminVerticle : AdminVerticle() {
                             )?._id
                         }
                 }
-            }
-        ) { context, story: BotStoryDefinitionConfiguration ->
-            BotAdminService.saveStory(context.organization, story, context.userLogin) ?: unauthorized()
-        }
+            },
+            handler = toRequestHandler { context, story: BotStoryDefinitionConfiguration ->
+                BotAdminService.saveStory(context.organization, story, context.userLogin) ?: unauthorized()
+            })
 
-        blockingJsonPost("/bot/story/load", setOf(botUser, faqBotUser)) { context, request: StorySearchRequest ->
-            if (context.organization == request.namespace) {
-                BotAdminService.loadStories(request)
-            } else {
-                unauthorized()
-            }
-        }
-
-        blockingJsonPost("/bot/story/search", setOf(botUser, faqBotUser)) { context, request: StorySearchRequest ->
-            if (context.organization == request.namespace) {
-                BotAdminService.searchStories(request)
-            } else {
-                unauthorized()
-            }
-        }
-
-        blockingJsonGet("/bot/story/:storyId", setOf(botUser, faqBotUser)) { context ->
-            BotAdminService.findStory(context.organization, context.path("storyId"))
-        }
-
-        blockingJsonGet("/bot/story/:botId/settings", botUser) { context ->
-            BotAdminService.findRuntimeStorySettings(context.organization, context.path("botId"))
-        }
-
-        blockingJsonGet("/bot/story/:botId/:intent", botUser) { context ->
-            BotAdminService.findConfiguredStoryByBotIdAndIntent(
-                context.organization,
-                context.path("botId"),
-                context.path("intent")
-            )
-        }
-
-        blockingJsonDelete(
-            "/bot/story/:storyId",
+        blockingJsonPost(
+            "/bot/story/load",
             setOf(botUser, faqBotUser),
-            simpleLogger("Delete Story", { it.path("storyId") })
-        ) { context ->
-            BotAdminService.deleteStory(context.organization, context.path("storyId"))
-        }
-
-        blockingJsonPost("/flow", botUser) { context, request: DialogFlowRequest ->
-            if (context.organization == request.namespace) {
-                measureTimeMillis(
-                    context
-                ) {
-                    BotAdminService.loadDialogFlow(request)
+            handler = toRequestHandler { context, request: StorySearchRequest ->
+                if (context.organization == request.namespace) {
+                    BotAdminService.loadStories(request)
+                } else {
+                    unauthorized()
                 }
-            } else {
-                unauthorized()
-            }
-        }
+            })
 
-        blockingJsonGet("/i18n", setOf(botUser, faqBotUser)) { context ->
-            val stats = i18n.getLabelStats(context.organization).groupBy { it.labelId }
-            BotI18nLabels(
-                i18n
-                    .getLabels(context.organization)
-                    .map {
-                        BotI18nLabel(
-                            it,
-                            stats[it._id] ?: emptyList()
-                        )
+        blockingJsonPost("/bot/story/search",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context, request: StorySearchRequest ->
+                if (context.organization == request.namespace) {
+                    BotAdminService.searchStories(request)
+                } else {
+                    unauthorized()
+                }
+            })
+
+        blockingJsonGet("/bot/story/:storyId",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                BotAdminService.findStory(context.organization, context.path("storyId"))
+            })
+
+        blockingJsonGet("/bot/story/:botId/settings",
+            botUser,
+            handler = toRequestHandler { context ->
+                BotAdminService.findRuntimeStorySettings(context.organization, context.path("botId"))
+            })
+
+        blockingJsonGet("/bot/story/:botId/:intent",
+            botUser,
+            handler = toRequestHandler { context ->
+                BotAdminService.findConfiguredStoryByBotIdAndIntent(
+                    context.organization,
+                    context.path("botId"),
+                    context.path("intent")
+                )
+            })
+
+        blockingJsonPost("/flow",
+            botUser,
+            handler = toRequestHandler { context, request: DialogFlowRequest ->
+                if (context.organization == request.namespace) {
+                    measureTimeMillis(
+                        context
+                    ) {
+                        BotAdminService.loadDialogFlow(request)
                     }
-            )
-        }
+                } else {
+                    unauthorized()
+                }
+            })
+
+        blockingJsonGet("/i18n",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                val stats = i18n.getLabelStats(context.organization).groupBy { it.labelId }
+                BotI18nLabels(
+                    i18n
+                        .getLabels(context.organization)
+                        .map {
+                            BotI18nLabel(
+                                it,
+                                stats[it._id] ?: emptyList()
+                            )
+                        }
+                )
+            })
 
         blockingJsonPost(
             "/i18n/complete",
             setOf(botUser, faqBotUser),
-            simpleLogger("Complete Responses Labels")
-        ) { context, labels: List<I18nLabel> ->
-            if (!injector.provide<TranslatorEngine>().supportAdminTranslation) {
-                badRequest("Translation is not activated for this account")
-            }
-            TranslateReport(Translator.completeAllLabels(labels.filter { it.namespace == context.organization }))
-        }
+            simpleLogger("Complete Responses Labels"),
+            handler = toRequestHandler
+            { context, labels: List<I18nLabel> ->
+                if (!injector.provide<TranslatorEngine>().supportAdminTranslation) {
+                    badRequest("Translation is not activated for this account")
+                }
+                TranslateReport(Translator.completeAllLabels(labels.filter { it.namespace == context.organization }))
+            })
 
         blockingJsonPost(
             "/i18n/saveAll",
             setOf(botUser, faqBotUser),
-            simpleLogger("Save Responses Labels")
-        ) { context, labels: List<I18nLabel> ->
-            i18n.save(labels.filter { it.namespace == context.organization })
-        }
+            simpleLogger("Save Responses Labels"), handler = toRequestHandler { context, labels: List<I18nLabel> ->
+                i18n.save(labels.filter { it.namespace == context.organization })
+            })
 
         blockingJsonPost(
             "/i18n/save",
             setOf(botUser, faqBotUser),
-            simpleLogger("Save Response Label")
-        ) { context, label: I18nLabel ->
-            if (label.namespace == context.organization) {
-                i18n.save(label)
-            } else {
-                unauthorized()
-            }
-        }
+            simpleLogger("Save Response Label"),
+            handler = toRequestHandler { context, label: I18nLabel ->
+                if (label.namespace == context.organization) {
+                    i18n.save(label)
+                } else {
+                    unauthorized()
+                }
+            })
 
         blockingJsonPost(
             "/i18n/create",
             setOf(botUser, faqBotUser),
-            simpleLogger("Create Response Label")
-        ) { context, request: CreateI18nLabelRequest ->
-            createI18nRequest(context.organization, request)
-        }
+            simpleLogger("Create Response Label"), handler = toRequestHandler { context, request: CreateI18nLabelRequest ->
+                createI18nRequest(context.organization, request)
+            })
 
         blockingDelete(
             "/i18n/:id",
             setOf(botUser, faqBotUser),
-            simpleLogger("Delete Response Label", { it.path("id") })
-        ) { context ->
-            i18n.deleteByNamespaceAndId(context.organization, context.pathId("id"))
-        }
+            simpleLogger("Delete Response Label", { it.path("id") }), handler = toRequestHandler { context ->
+                i18n.deleteByNamespaceAndId(context.organization, context.pathId("id"))
+            })
 
-        blockingJsonGet("/i18n/export/csv", setOf(botUser, faqBotUser)) { context ->
-            I18nCsvCodec.exportCsv(context.organization)
-        }
+        blockingJsonGet(
+            "/i18n/export/csv",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                I18nCsvCodec.exportCsv(context.organization)
+            })
 
-        blockingJsonPost("/i18n/export/csv", setOf(botUser, faqBotUser)) { context, query: I18LabelQuery ->
-            I18nCsvCodec.exportCsv(context.organization, query)
-        }
+        blockingJsonPost("/i18n/export/csv",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context, query: I18LabelQuery ->
+                I18nCsvCodec.exportCsv(context.organization, query)
+            })
 
         blockingUploadPost(
             "/i18n/import/csv",
             botUser,
-            simpleLogger("CSV Import Response Labels")
-        ) { context, content ->
-            measureTimeMillis(context) {
-                I18nCsvCodec.importCsv(context.organization, content)
-            }
-        }
+            simpleLogger("CSV Import Response Labels"),
+            handler = toRequestHandler { context, content ->
+                measureTimeMillis(context) {
+                    I18nCsvCodec.importCsv(context.organization, content)
+                }
+            })
 
-        blockingJsonGet("/i18n/export/json", setOf(botUser, faqBotUser)) { context ->
-            mapper.writeValueAsString(i18n.getLabels(context.organization))
-        }
+        blockingJsonGet("/i18n/export/json",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                mapper.writeValueAsString(i18n.getLabels(context.organization))
+            })
 
-        blockingJsonPost("/i18n/export/json", setOf(botUser, faqBotUser)) { context, query: I18LabelQuery ->
-            val labels = i18n.getLabels(context.organization, query.toI18nLabelFilter())
-            mapper.writeValueAsString(labels)
-        }
+        blockingJsonPost("/i18n/export/json",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context, query: I18LabelQuery ->
+                val labels = i18n.getLabels(context.organization, query.toI18nLabelFilter())
+                mapper.writeValueAsString(labels)
+            })
 
         blockingUploadJsonPost(
             "/i18n/import/json",
             setOf(botUser, faqBotUser),
-            simpleLogger("JSON Import Response Labels")
-        ) { context, labels: List<I18nLabel> ->
-            measureTimeMillis(context) {
-                labels
-                    .filter { it.i18n.any { i18n -> i18n.validated } }
-                    .map {
-                        it.copy(
-                            _id = it._id.toString().replaceFirst(it.namespace, context.organization).toId(),
-                            namespace = context.organization
-                        )
-                    }.apply {
-                        i18n.save(this)
-                    }
-                    .size
-            }
-        }
+            simpleLogger("JSON Import Response Labels"),
+            handler = toRequestHandler { context, labels: List<I18nLabel> ->
+                measureTimeMillis(context) {
+                    labels
+                        .filter { it.i18n.any { i18n -> i18n.validated } }
+                        .map {
+                            it.copy(
+                                _id = it._id.toString().replaceFirst(it.namespace, context.organization).toId(),
+                                namespace = context.organization
+                            )
+                        }.apply {
+                            i18n.save(this)
+                        }
+                        .size
+                }
+            })
 
-        blockingUploadBinaryPost("/file", botUser) { context, (fileName, bytes) ->
+        blockingUploadBinaryPost("/file", botUser, handler = toRequestHandler { context, (fileName, bytes) ->
             val file = UploadedFilesService.uploadFile(context.organization, fileName, bytes)
                 ?: badRequest("file must have an extension (ie file.png)")
             file
-        }
+        })
 
-        blocking(GET, "/file/:id.:suffix", botUser) { context ->
-            val id = context.path("id")
-            if (!id.startsWith(context.organization)) {
-                unauthorized()
-            } else {
-                downloadFile(context, id, context.path("suffix"))
-            }
-        }
+        blocking(GET, "/file/:id.:suffix", botUser,
+            handler = toRequestHandler { context ->
+                val id = context.path("id")
+                if (!id.startsWith(context.organization)) {
+                    unauthorized()
+                } else {
+                    downloadFile(context, id, context.path("suffix"))
+                }
+            })
 
         blockingJsonGet("/connectorTypes", setOf(botUser, faqBotUser, faqNlpUser)) {
-            ConnectorTypeConfiguration.connectorConfigurations
+            RequestSucceeded(ConnectorTypeConfiguration.connectorConfigurations)
         }
 
-        blockingGet("/connectorIcon/:connectorType/icon.svg", null, basePath) { context ->
-            val connectorType = context.path("connectorType")
-            context.response().putHeader("Content-Type", "image/svg+xml")
-            context.response().putHeader("Cache-Control", "max-age=84600, public")
-            ConnectorTypeConfiguration.connectorConfigurations.firstOrNull { it.connectorType.id == connectorType }?.svgIcon
-                ?: ""
-        }
+        blockingGet("/connectorIcon/:connectorType/icon.svg", null, basePath,
+            handler = toRequestHandler { context ->
+                val connectorType = context.path("connectorType")
+                context.response().putHeader("Content-Type", "image/svg+xml")
+                context.response().putHeader("Cache-Control", "max-age=84600, public")
+                ConnectorTypeConfiguration.connectorConfigurations.firstOrNull { it.connectorType.id == connectorType }?.svgIcon
+                    ?: ""
+            })
 
         blockingJsonPost(
             "/faq",
             setOf(botUser, faqBotUser),
-            logger<FaqDefinitionRequest>("Save FAQ")
-        ) { context, query: FaqDefinitionRequest ->
-            if (query.utterances.isEmpty() && query.title.isBlank() && query.answer.isBlank()) {
-                badRequest("Missing argument or trouble in query: $query")
-            } else {
-                val applicationDefinition = front.getApplicationByNamespaceAndName(namespace = context.organization, name = query.applicationName)
-                if (context.organization == applicationDefinition?.namespace) {
-                    return@blockingJsonPost FaqAdminService.saveFAQ(query, context.userLogin, applicationDefinition)
+            logger<FaqDefinitionRequest>("Save FAQ"),
+            handler = toRequestHandler { context, query: FaqDefinitionRequest ->
+                if (query.utterances.isEmpty() && query.title.isBlank() && query.answer.isBlank()) {
+                    badRequest("Missing argument or trouble in query: $query")
                 } else {
-                    unauthorized()
+                    val applicationDefinition = front.getApplicationByNamespaceAndName(
+                        namespace = context.organization,
+                        name = query.applicationName
+                    )
+                    if (context.organization == applicationDefinition?.namespace) {
+                        return@toRequestHandler FaqAdminService.saveFAQ(query, context.userLogin, applicationDefinition)
+                    } else {
+                        unauthorized()
+                    }
                 }
-            }
-        }
+            })
 
         blockingJsonDelete(
             "/faq/:faqId",
             setOf(botUser, faqBotUser),
-            simpleLogger("Delete Story", { it.path("faqId") })
-        ) { context ->
-            FaqAdminService.deleteFaqDefinition(context.organization, context.path("faqId"))
-        }
+            simpleLogger("Delete Story", { it.path("faqId") }),
+            handler = toRequestHandler { context ->
+                FaqAdminService.deleteFaqDefinition(context.organization, context.path("faqId"))
+            })
 
-        blockingJsonPost("/faq/tags", setOf(botUser, faqBotUser)) { context, applicationId: String ->
-            val applicationDefinition = front.getApplicationById(applicationId.toId())
-            if (context.organization == applicationDefinition?.namespace) {
-                try {
-                    FaqAdminService.searchTags(applicationDefinition._id.toString())
-                } catch (t: Exception) {
-                    logger.error(t)
-                    badRequest("Error searching faq tags: ${t.message}")
+        blockingJsonPost(
+            "/faq/tags",
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context, applicationId: String ->
+                val applicationDefinition = front.getApplicationById(applicationId.toId())
+                if (context.organization == applicationDefinition?.namespace) {
+                    try {
+                        FaqAdminService.searchTags(applicationDefinition._id.toString())
+                    } catch (t: Exception) {
+                        logger.error(t)
+                        badRequest("Error searching faq tags: ${t.message}")
+                    }
+                } else {
+                    unauthorized()
                 }
-            } else {
-                unauthorized()
-            }
-        }
+            })
 
         blockingJsonPost(
             "/faq/search",
             setOf(botUser, faqBotUser),
-            logger<FaqSearchRequest>("Search FAQ")
-        )
-        { context, request: FaqSearchRequest ->
-            val applicationDefinition =
-                front.getApplicationByNamespaceAndName(request.namespace, request.applicationName)
-            if (context.organization == applicationDefinition?.namespace) {
-                try {
-                    measureTimeMillis(context) {
-                        FaqAdminService.searchFAQ(request, applicationDefinition)
+            logger<FaqSearchRequest>("Search FAQ"),
+            handler = toRequestHandler { context, request: FaqSearchRequest ->
+                val applicationDefinition =
+                    front.getApplicationByNamespaceAndName(request.namespace, request.applicationName)
+                if (context.organization == applicationDefinition?.namespace) {
+                    try {
+                        measureTimeMillis(context) {
+                            FaqAdminService.searchFAQ(request, applicationDefinition)
+                        }
+                    } catch (t: NoEncryptionPassException) {
+                        logger.error(t)
+                        badRequest("Error obfuscating faq: ${t.message}")
+                    } catch (t: Exception) {
+                        logger.error(t)
+                        badRequest("Error searching faq: ${t.message}")
                     }
-                } catch (t: NoEncryptionPassException) {
-                    logger.error(t)
-                    badRequest("Error obfuscating faq: ${t.message}")
-                } catch (t: Exception) {
-                    logger.error(t)
-                    badRequest("Error searching faq: ${t.message}")
+                } else {
+                    unauthorized()
                 }
-            } else {
-                unauthorized()
-            }
-        }
+            })
 
         blockingJsonGet(
             "/faq/settings/:applicationId",
-            setOf(botUser, faqBotUser)
-        ) { context ->
-            val applicationDefinition = front.getApplicationById(context.pathId("applicationId"))
-            if (context.organization == applicationDefinition?.namespace) {
-                FaqAdminService.getSettings(applicationDefinition)
-            } else {
-                unauthorized()
-            }
-        }
+            setOf(botUser, faqBotUser),
+            handler = toRequestHandler { context ->
+                val applicationDefinition = front.getApplicationById(context.pathId("applicationId"))
+                if (context.organization == applicationDefinition?.namespace) {
+                    FaqAdminService.getSettings(applicationDefinition)
+                } else {
+                    unauthorized()
+                }
+            })
 
         blockingJsonPost(
             "/faq/settings/:applicationId",
-            setOf(botUser, faqBotUser)
-        ) { context, faqSettingsQuery: FaqSettingsQuery ->
-            val applicationDefinition = front.getApplicationById(context.pathId("applicationId"))
-            if (context.organization == applicationDefinition?.namespace) {
-                FaqAdminService.saveSettings(applicationDefinition, faqSettingsQuery)
-            } else {
-                unauthorized()
-            }
-        }
+            setOf(botUser, faqBotUser), handler = toRequestHandler { context, faqSettingsQuery: FaqSettingsQuery ->
+                val applicationDefinition = front.getApplicationById(context.pathId("applicationId"))
+                if (context.organization == applicationDefinition?.namespace) {
+                    FaqAdminService.saveSettings(applicationDefinition, faqSettingsQuery)
+                } else {
+                    unauthorized()
+                }
+            })
 
         blockingJsonGet("/configuration") {
-            botAdminConfiguration
+            RequestSucceeded(botAdminConfiguration)
         }
 
         findTestService().registerServices().invoke(this)
@@ -889,4 +804,6 @@ open class BotAdminVerticle : AdminVerticle() {
         }
         return super.saveApplication(existingApp, app)
     }
+
+
 }

--- a/bot/admin/server/src/main/kotlin/service/BotAdminAnalyticsService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BotAdminAnalyticsService.kt
@@ -1,23 +1,39 @@
-package ai.tock.bot.admin
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByActionType
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDate
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDateAndConfiguration
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDateAndConnectorType
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDateAndIntent
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDateAndStory
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByDayOfWeek
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByHour
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByIntent
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByStory
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByStoryCategory
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByStoryLocale
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countMessagesByStoryType
-import ai.tock.bot.admin.BotAdminAnalyticsService.Operation.countUsersByDate
+package ai.tock.bot.admin.service
+
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
 import ai.tock.bot.admin.dialog.DialogFlowAggregateData
 import ai.tock.bot.admin.model.DialogFlowRequest
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByActionType
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDate
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDateAndConfiguration
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDateAndConnectorType
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDateAndIntent
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDateAndStory
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByDayOfWeek
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByHour
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByIntent
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByStory
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByStoryCategory
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByStoryLocale
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countMessagesByStoryType
+import ai.tock.bot.admin.service.BotAdminAnalyticsService.Operation.countUsersByDate
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
 import ai.tock.bot.admin.user.UserAnalyticsQueryResult
 import ai.tock.bot.connector.ConnectorType
@@ -29,6 +45,9 @@ import ai.tock.shared.provide
 import com.github.salomonbrys.kodein.instance
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
+import org.bson.types.ObjectId
+import org.litote.kmongo.Id
+import org.litote.kmongo.toId
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDate
@@ -36,15 +55,11 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZonedDateTime
 import java.time.format.TextStyle.FULL_STANDALONE
-import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit.HOURS
-import java.time.temporal.ChronoUnit.MINUTES
 import java.util.stream.LongStream
 import java.util.stream.Stream
 import kotlin.streams.toList
-import org.bson.types.ObjectId
-import org.litote.kmongo.Id
-import org.litote.kmongo.toId
+
 
 object BotAdminAnalyticsService {
 

--- a/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
@@ -560,10 +560,8 @@ object BotAdminService {
                 var newIntent = front.getIntentByNamespaceAndName(app.namespace, intent.name)
                 val existingEntity = newIntent?.findEntity(role)
                 val entityTypeName = entity.entityTypeName
-                if (existingEntity == null) {
-                    if (front.getEntityTypeByName(entityTypeName) == null) {
-                        front.save(EntityTypeDefinition(entityTypeName))
-                    }
+                if (existingEntity == null && front.getEntityTypeByName(entityTypeName) == null) {
+                    front.save(EntityTypeDefinition(entityTypeName))
                 }
                 if (newIntent == null) {
                     newIntent = IntentDefinition(
@@ -733,11 +731,8 @@ object BotAdminService {
                     }
                 }
             }
-            if (storyWithSameNsBotAndName != null && storyWithSameNsBotAndName._id != storyWithSameId?._id
-            ) {
-                if (storyWithSameNsBotAndName.currentType != builtin) {
-                    badRequest("Story ${story.name} (${story.currentType}) already exists")
-                }
+            if (storyWithSameNsBotAndName != null && storyWithSameNsBotAndName._id != storyWithSameId?._id && storyWithSameNsBotAndName.currentType != builtin) {
+                badRequest("Story ${story.name} (${story.currentType}) already exists")
             }
 
             val newStory = when {

--- a/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
@@ -88,22 +88,21 @@ import ai.tock.translator.I18nKeyProvider
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.I18nLabelValue
 import ai.tock.translator.Translator
-import com.github.salomonbrys.kodein.instance
+import java.time.Instant
+import java.util.Locale
 import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.toId
-import java.time.Instant
-import java.util.Locale
 
 object BotAdminService {
 
     private val logger = KotlinLogging.logger {}
 
-    private val userReportDAO: UserReportDAO by injector.instance()
-    internal val dialogReportDAO: DialogReportDAO by injector.instance()
-    private val applicationConfigurationDAO: BotApplicationConfigurationDAO by injector.instance()
-    private val storyDefinitionDAO: StoryDefinitionConfigurationDAO by injector.instance()
-    private val featureDAO: FeatureDAO by injector.instance()
+    private val userReportDAO: UserReportDAO get() = injector.provide()
+    internal val dialogReportDAO: DialogReportDAO get() = injector.provide()
+    private val applicationConfigurationDAO: BotApplicationConfigurationDAO get() = injector.provide()
+    private val storyDefinitionDAO: StoryDefinitionConfigurationDAO get() = injector.provide()
+    private val featureDAO: FeatureDAO get() = injector.provide()
     private val dialogFlowDAO: DialogFlowDAO get() = injector.provide()
     private val front = FrontClient
 

--- a/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BotAdminService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.admin
+package ai.tock.bot.admin.service
 
 import ai.tock.bot.admin.answer.AnswerConfiguration
 import ai.tock.bot.admin.answer.AnswerConfigurationType.builtin

--- a/bot/admin/server/src/main/kotlin/service/FaqAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/service/FaqAdminService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.admin
+package ai.tock.bot.admin.service
 
 import ai.tock.bot.admin.answer.AnswerConfigurationType
 import ai.tock.bot.admin.answer.SimpleAnswer
@@ -50,7 +50,6 @@ import ai.tock.shared.injector
 import ai.tock.shared.provide
 import ai.tock.shared.security.UNKNOWN_USER_LOGIN
 import ai.tock.shared.security.UserLogin
-import ai.tock.shared.vertx.BadRequestException
 import ai.tock.shared.vertx.WebVerticle.Companion.badRequest
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel

--- a/bot/admin/server/src/main/kotlin/service/StoryService.kt
+++ b/bot/admin/server/src/main/kotlin/service/StoryService.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.story.StoryDefinitionConfiguration
+import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
+import ai.tock.bot.admin.story.StoryDefinitionConfigurationFeature
+import ai.tock.nlp.front.service.storage.ApplicationDefinitionDAO
+import ai.tock.shared.injector
+import ai.tock.shared.provide
+import mu.KLogger
+import mu.KotlinLogging
+import org.litote.kmongo.toId
+
+/**
+ * Service that manage the scenario functionality
+ */
+object StoryService {
+
+
+    private val logger: KLogger = KotlinLogging.logger {}
+    private val storyDefinitionDAO: StoryDefinitionConfigurationDAO get() = injector.provide()
+    private val applicationDefinitionDAO: ApplicationDefinitionDAO get() = injector.provide()
+
+    /**
+     * Get a [StoryDefinitionConfiguration]
+     * @param namespace : the namespace
+     * @param botId : the id of the bot
+     * @param storyId : functional id of story to delete
+     */
+    fun getStoryByNamespaceAndBotIdAndStoryId(
+        namespace: String,
+        botId: String,
+        storyId: String
+    ): StoryDefinitionConfiguration? = storyDefinitionDAO
+        .getStoryDefinitionByNamespaceAndBotIdAndStoryId(namespace, botId, storyId)
+
+    /**
+     * Update the activation feature of story
+     * @param namespace : the namespace
+     * @param botId : the id of the bot
+     * @param feature : feature to add to the story
+     */
+    fun updateActivateStoryFeatureByNamespaceAndBotIdAndStoryId(
+        namespace: String,
+        botId: String,
+        storyId: String,
+        feature: StoryDefinitionConfigurationFeature
+    ): Boolean {
+        val story = storyDefinitionDAO.getStoryDefinitionByNamespaceAndBotIdAndStoryId(namespace, botId, storyId)
+        if (story != null) {
+            val botConf = BotAdminService.getBotConfigurationsByNamespaceAndBotId(namespace, story.botId).firstOrNull()
+            if (botConf != null) {
+                storyDefinitionDAO.save(
+                    story.copy(features = story.features.filterNot { it.isStoryActivationFeature() } + feature))
+            }
+        }
+        return false
+    }
+
+    /**
+     * Delete a [StoryDefinitionConfiguration]
+     * @param namespace : the namespace
+     * @param storyDefinitionConfigurationId : technical id of story to delete
+     */
+    fun deleteStoryByNamespaceAndStoryDefinitionConfigurationId(
+        namespace: String,
+        storyDefinitionConfigurationId: String
+    ): Boolean {
+        val story = storyDefinitionDAO.getStoryDefinitionById(storyDefinitionConfigurationId.toId())
+        if (story != null) {
+            val botConf = BotAdminService.getBotConfigurationsByNamespaceAndBotId(namespace, story.botId).firstOrNull()
+            if (botConf != null) {
+                storyDefinitionDAO.delete(story)
+            }
+        }
+        return false
+    }
+
+    /**
+     * Delete a [StoryDefinitionConfiguration]
+     * @param namespace : the namespace
+     * @param botId : the id of the bot
+     * @param storyId : functional id of story to delete
+     */
+    fun deleteStoryByNamespaceAndBotIdAndStoryId(
+        namespace: String,
+        botId: String,
+        storyId: String
+    ): Boolean {
+        val story = storyDefinitionDAO.getStoryDefinitionByNamespaceAndBotIdAndStoryId(namespace, botId, storyId)
+        if (story != null) {
+            val botConf = BotAdminService.getBotConfigurationsByNamespaceAndBotId(namespace, story.botId).firstOrNull()
+            if (botConf != null) {
+                storyDefinitionDAO.delete(story)
+            }
+        }
+        return false
+    }
+
+    // FIXME : Migrate all story methods here
+}

--- a/bot/admin/server/src/main/kotlin/verticle/AnalyticsVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/AnalyticsVerticle.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.verticle
+
+import ai.tock.bot.admin.model.DialogFlowRequest
+import ai.tock.bot.admin.service.BotAdminAnalyticsService
+import ai.tock.nlp.admin.model.ApplicationScopedQuery
+import ai.tock.shared.exception.admin.AdminException
+import ai.tock.shared.security.TockUserRole
+import ai.tock.shared.vertx.WebVerticle
+import ai.tock.shared.vertx.toRequestHandler
+import io.vertx.ext.web.RoutingContext
+
+
+class AnalyticsVerticle : ChildVerticle<AdminException>{
+
+    override fun configure(parent: WebVerticle<AdminException>) {
+        with(parent) {
+
+            fun <R> measureTimeMillis(context: RoutingContext, function: () -> R): R {
+                val before = System.currentTimeMillis()
+                val result = function()
+                logger.debug { "${context.normalizedPath()} took ${System.currentTimeMillis() - before} ms." }
+                return result
+            }
+
+            fun <R> checkAndMeasure(context: RoutingContext, request: ApplicationScopedQuery, function: () -> R): R =
+                if (context.organization == request.namespace) {
+                    measureTimeMillis(context){
+                        function()
+                    }
+                } else {
+                    WebVerticle.unauthorized()
+                }
+
+            blockingJsonPost(
+                "/analytics/messages",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByType(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/users",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportUsersByType(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byConnectorType",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.countMessagesByConnectorType(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byConfiguration",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByConfiguration(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byConnectorType",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByConnectorType(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byDayOfWeek",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByDayOfWeek(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byHour",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByHour(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byIntent",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByIntent(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byDateAndIntent",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByDateAndIntent(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byDateAndStory",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByDateAndStory(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byStory",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByStory(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byStoryCategory",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByStoryCategory(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byStoryType",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByStoryType(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byStoryLocale",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByStoryLocale(request)
+                    }
+                })
+
+            blockingJsonPost(
+                "/analytics/messages/byActionType",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler { context, request: DialogFlowRequest ->
+                    checkAndMeasure(context, request) {
+                        BotAdminAnalyticsService.reportMessagesByActionType(request)
+                    }
+                })
+
+        }
+    }
+
+}

--- a/bot/admin/server/src/main/kotlin/verticle/BusinessVerticles.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/BusinessVerticles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.bot.admin.verticle
 
 import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
+import ai.tock.shared.vertx.WebVerticle
 
-/**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
- */
-interface CASAuthProviderFactory {
+interface ChildVerticle<T : ToRestException> {
+    fun configure(verticle: WebVerticle<T>)
+}
 
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
+interface ParentVerticle<T : ToRestException> {
+
+    fun children(): List<ChildVerticle<T>>
+
+    fun preConfigure() {
+        if (this !is WebVerticle<*>)
+            throw IllegalStateException("ParentVerticle must be a WebVerticle")
+
+        children().forEach { it.configure(this as WebVerticle<T>) }
+    }
 }

--- a/bot/admin/server/src/main/kotlin/verticle/StoryVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/StoryVerticle.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.verticle
+
+import ai.tock.bot.admin.service.StoryService
+import ai.tock.shared.exception.admin.AdminException
+import ai.tock.shared.security.TockUser
+import ai.tock.shared.security.TockUserRole
+import ai.tock.shared.vertx.WebVerticle
+import ai.tock.shared.vertx.toRequestHandler
+import io.vertx.ext.web.RoutingContext
+import mu.KLogger
+import mu.KotlinLogging
+
+/**
+ * [StoryVerticle] contains all the routes and actions associated with the stories
+ */
+class StoryVerticle: ChildVerticle<AdminException> {
+
+    companion object {
+        private val logger: KLogger = KotlinLogging.logger {}
+
+        private const val baseURL = "/bot"
+        private const val storyURL = "$baseURL/story"
+    }
+
+    /**
+     * Declaration of routes and association to the appropriate handler
+     */
+    override fun configure(verticle: WebVerticle<AdminException>) {
+        logger.info { "configure StoryVerticle" }
+
+        with(verticle) {
+
+            val deleteStoryByStoryDefinitionConfigurationId: (RoutingContext) -> Boolean = { context ->
+                val storyDefinitionConfigurationId = context.pathParam("storyDefinitionConfigurationId")
+                Companion.logger.debug { "request to delete story <$storyDefinitionConfigurationId>" }
+                val namespace = (context.user() as TockUser).namespace
+                StoryService.deleteStoryByNamespaceAndStoryDefinitionConfigurationId(namespace, storyDefinitionConfigurationId)
+            }
+
+            blockingJsonDelete(
+                "$storyURL/:storyDefinitionConfigurationId",
+                setOf(TockUserRole.botUser, TockUserRole.faqBotUser),
+                handler = toRequestHandler(deleteStoryByStoryDefinitionConfigurationId)
+            )
+        }
+            // TODO : migrate all story vert.x handlers to here  (ex BotAdminVerticle)
+    }
+}

--- a/bot/admin/server/src/test/kotlin/BotAdminServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/BotAdminServiceTest.kt
@@ -17,13 +17,14 @@
 package ai.tock.bot.admin
 
 import ai.tock.bot.admin.answer.AnswerConfigurationType
+import ai.tock.bot.admin.service.BotAdminService
 import ai.tock.bot.admin.story.StoryDefinitionConfiguration
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
 import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDump
 import ai.tock.bot.definition.IntentWithoutNamespace
 import ai.tock.nlp.front.shared.config.ApplicationDefinition
+import ai.tock.shared.exception.rest.BadRequestException
 import ai.tock.shared.tockInternalInjector
-import ai.tock.shared.vertx.BadRequestException
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
 import com.github.salomonbrys.kodein.bind

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.admin
 
 import ai.tock.bot.admin.answer.AnswerConfigurationType
+import ai.tock.bot.admin.service.FaqAdminService
 import ai.tock.bot.admin.story.StoryDefinitionConfiguration
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
 import ai.tock.bot.definition.IntentWithoutNamespace

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
@@ -21,6 +21,7 @@ import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.model.BotStoryDefinitionConfiguration
 import ai.tock.bot.admin.model.FaqDefinitionRequest
 import ai.tock.bot.admin.model.FaqSearchRequest
+import ai.tock.bot.admin.service.*
 import ai.tock.bot.admin.story.StoryDefinitionConfiguration
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
 import ai.tock.bot.connector.ConnectorType
@@ -43,7 +44,7 @@ import ai.tock.nlp.front.shared.config.IntentDefinition
 import ai.tock.nlp.front.shared.config.SentencesQueryResult
 import ai.tock.shared.security.UserLogin
 import ai.tock.shared.tockInternalInjector
-import ai.tock.shared.vertx.BadRequestException
+import ai.tock.shared.exception.rest.BadRequestException
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.I18nLocalizedLabel
@@ -58,10 +59,13 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkObject
 import io.mockk.verify
 import org.apache.commons.lang3.StringUtils
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/bot/admin/test/xray/src/main/kotlin/XrayTestService.kt
+++ b/bot/admin/test/xray/src/main/kotlin/XrayTestService.kt
@@ -22,6 +22,7 @@ import ai.tock.bot.xray.XrayPlanExecutionConfiguration
 import ai.tock.bot.xray.XrayService
 import ai.tock.nlp.admin.AdminVerticle
 import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.vertx.toRequestHandler
 
 private val testCoreService = TestCoreService()
 
@@ -33,18 +34,21 @@ class XrayTestService : TestService by testCoreService {
          * Triggered on "Create" button, after providing connector and test plan key.
          * Will reach Jira to gather all test steps and send them to the bot as a conversation
          */
-        blockingJsonPost("/xray/execute", botUser) { context, configuration: XrayPlanExecutionConfiguration ->
-            XrayService(
-                listOfNotNull(configuration.configurationId),
-                listOfNotNull(configuration.testPlanKey),
-                listOfNotNull(configuration.testKey),
-                configuration.testedBotId
-            ).execute(context.organization)
-        }
+        blockingJsonPost(
+            "/xray/execute",
+            botUser,
+            handler = toRequestHandler { context, configuration: XrayPlanExecutionConfiguration ->
+                XrayService(
+                    listOfNotNull(configuration.configurationId),
+                    listOfNotNull(configuration.testPlanKey),
+                    listOfNotNull(configuration.testKey),
+                    configuration.testedBotId
+                ).execute(context.organization)
+            })
 
-        blockingJsonGet("/xray/test/plans", botUser) {
+        blockingJsonGet("/xray/test/plans", botUser, handler = toRequestHandler { _ ->
             XrayService().getTestPlans()
-        }
+        })
     }
 
     override fun priority(): Int = 1

--- a/bot/admin/web/angular.json
+++ b/bot/admin/web/angular.json
@@ -118,6 +118,9 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@angular-eslint/schematics"]
+    "schematicCollections": [
+      "@angular-eslint/schematics"
+    ],
+    "analytics": false
   }
 }

--- a/bot/api/webhook-base/src/main/kotlin/WebhookVerticle.kt
+++ b/bot/api/webhook-base/src/main/kotlin/WebhookVerticle.kt
@@ -21,16 +21,18 @@ import ai.tock.bot.api.client.TockClientBus
 import ai.tock.bot.api.client.toConfiguration
 import ai.tock.bot.api.model.websocket.RequestData
 import ai.tock.bot.api.model.websocket.ResponseData
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.vertx.WebVerticle
+import ai.tock.shared.vertx.toRequestHandler
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.vertx.core.http.HttpMethod
 import io.vertx.ext.web.RoutingContext
 
-internal class WebhookVerticle(private val botDefinition: ClientBotDefinition) : WebVerticle() {
+internal class WebhookVerticle(private val botDefinition: ClientBotDefinition) : WebVerticle<CommonException>() {
 
     override fun configure() {
-        blocking(HttpMethod.POST, "/webhook") { context ->
+        blocking(HttpMethod.POST, "/webhook", handler = toRequestHandler { context ->
             val content = context.body().asString()
             val request: RequestData = mapper.readValue(content)
             if (request.botRequest != null) {
@@ -47,10 +49,11 @@ internal class WebhookVerticle(private val botDefinition: ClientBotDefinition) :
                         )
                     )
                 )
+                Unit
             } else {
                 error("unknown request: $content")
             }
-        }
+        })
     }
 
     override val defaultPort: Int = 8887

--- a/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorCallback.kt
+++ b/bot/connector-iadvize/src/main/kotlin/IadvizeConnectorCallback.kt
@@ -36,9 +36,9 @@ import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.event.Event
 import ai.tock.shared.defaultLocale
 import ai.tock.shared.error
+import ai.tock.shared.exception.rest.RestException
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.loadProperties
-import ai.tock.shared.vertx.RestException
 import io.vertx.core.Future
 import io.vertx.core.http.HttpServerResponse
 import io.vertx.ext.web.RoutingContext

--- a/bot/engine/src/main/kotlin/admin/story/StoryDefinitionConfigurationFeature.kt
+++ b/bot/engine/src/main/kotlin/admin/story/StoryDefinitionConfigurationFeature.kt
@@ -23,10 +23,10 @@ import org.litote.kmongo.Id
  * In order to manage story activation, redirection and handling with configured "end story".
  */
 data class StoryDefinitionConfigurationFeature(
-    val botApplicationConfigurationId: Id<BotApplicationConfiguration>?,
+    val botApplicationConfigurationId: Id<BotApplicationConfiguration>? = null,
     val enabled: Boolean = true,
-    val switchToStoryId: String?,
-    val endWithStoryId: String?
+    val switchToStoryId: String? = null,
+    val endWithStoryId: String? = null
 ) {
     constructor(
         botApplicationConfigurationId: Id<BotApplicationConfiguration>?,
@@ -52,4 +52,6 @@ data class StoryDefinitionConfigurationFeature(
     internal fun supportDedicatedConfiguration(conf: BotApplicationConfiguration): Boolean =
         botApplicationConfigurationId == conf._id ||
             botApplicationConfigurationId == conf.targetConfigurationId
+
+    fun isStoryActivationFeature() = switchToStoryId == null && endWithStoryId == null
 }

--- a/bot/engine/src/main/kotlin/engine/BotVerticle.kt
+++ b/bot/engine/src/main/kotlin/engine/BotVerticle.kt
@@ -21,6 +21,7 @@ import ai.tock.bot.engine.config.UploadedFilesService
 import ai.tock.bot.engine.nlp.NlpProxyBotService
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.error
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.listProperty
 import ai.tock.shared.property
 import ai.tock.shared.security.auth.TockAuthProvider
@@ -45,7 +46,7 @@ import java.util.concurrent.CopyOnWriteArraySet
 internal class BotVerticle(
     private val nlpProxyOnBot: Boolean = booleanProperty("tock_nlp_proxy_on_bot", false),
     private val serveUploadedFiles: Boolean = booleanProperty("tock_bot_serve_files", true)
-) : WebVerticle() {
+) : WebVerticle<CommonException>() {
 
     inner class ServiceInstaller(
         val serviceId: String,
@@ -85,7 +86,7 @@ internal class BotVerticle(
 
     override val defaultCorsWithCredentials: Boolean = false
 
-    override fun authProvider(): TockAuthProvider? = defaultAuthProvider()
+    override fun authProvider(): TockAuthProvider<CommonException>? = defaultAuthProvider()
 
     fun registerServices(serviceIdentifier: String, installer: (Router) -> Any?): ServiceInstaller {
         return ServiceInstaller(serviceIdentifier, installer).also {

--- a/docs/dokka/tock/ai.tock.shared.vertx/-bad-request-exception/-init-.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-bad-request-exception/-init-.html
@@ -8,8 +8,8 @@
 <a href="../../index.html">tock</a>&nbsp;/&nbsp;<a href="../index.html">ai.tock.shared.vertx</a>&nbsp;/&nbsp;<a href="index.html">BadRequestException</a>&nbsp;/&nbsp;<a href="./-init-.html">&lt;init&gt;</a><br/>
 <br/>
 <h1>&lt;init&gt;</h1>
-<a name="ai.tock.shared.vertx.BadRequestException$&lt;init&gt;(kotlin.String)"></a>
-<code><span class="identifier">BadRequestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.vertx.BadRequestException$<init>(kotlin.String)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">)</span></code>
+<a name="ai.tock.shared.exception.rest.BadRequestException$&lt;init&gt;(kotlin.String)"></a>
+<code><span class="identifier">BadRequestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.exception.rest.BadRequestException$<init>(kotlin.String)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">)</span></code>
 <p>Http 400 exception.</p>
 </BODY>
 </HTML>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-bad-request-exception/index.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-bad-request-exception/index.html
@@ -19,7 +19,7 @@
 </td>
 <td>
 <p>Http 400 exception.</p>
-<code><span class="identifier">BadRequestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.vertx.BadRequestException$<init>(kotlin.String)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">)</span></code></td>
+<code><span class="identifier">BadRequestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.exception.rest.BadRequestException$<init>(kotlin.String)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">)</span></code></td>
 </tr>
 </tbody>
 </table>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-not-found-exception/-init-.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-not-found-exception/-init-.html
@@ -8,7 +8,7 @@
 <a href="../../index.html">tock</a>&nbsp;/&nbsp;<a href="../index.html">ai.tock.shared.vertx</a>&nbsp;/&nbsp;<a href="index.html">NotFoundException</a>&nbsp;/&nbsp;<a href="./-init-.html">&lt;init&gt;</a><br/>
 <br/>
 <h1>&lt;init&gt;</h1>
-<a name="ai.tock.shared.vertx.NotFoundException$&lt;init&gt;()"></a>
+<a name="ai.tock.shared.exception.rest.NotFoundException$&lt;init&gt;()"></a>
 <code><span class="identifier">NotFoundException</span><span class="symbol">(</span><span class="symbol">)</span></code>
 <p>Http 404 exception.</p>
 </BODY>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/-init-.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/-init-.html
@@ -8,8 +8,8 @@
 <a href="../../index.html">tock</a>&nbsp;/&nbsp;<a href="../index.html">ai.tock.shared.vertx</a>&nbsp;/&nbsp;<a href="index.html">RestException</a>&nbsp;/&nbsp;<a href="./-init-.html">&lt;init&gt;</a><br/>
 <br/>
 <h1>&lt;init&gt;</h1>
-<a name="ai.tock.shared.vertx.RestException$&lt;init&gt;(kotlin.String, kotlin.Int)"></a>
-<code><span class="identifier">RestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.vertx.RestException$<init>(kotlin.String, kotlin.Int)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">, </span><span class="identifier" id="ai.tock.shared.vertx.RestException$<init>(kotlin.String, kotlin.Int)/code">code</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a>&nbsp;<span class="symbol">=</span>&nbsp;500<span class="symbol">)</span></code>
+<a name="ai.tock.shared.exception.rest.RestException$&lt;init&gt;(kotlin.String, kotlin.Int)"></a>
+<code><span class="identifier">RestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.exception.rest.RestException$<init>(kotlin.String, kotlin.Int)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">, </span><span class="identifier" id="ai.tock.shared.exception.rest.RestException$<init>(kotlin.String, kotlin.Int)/code">code</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a>&nbsp;<span class="symbol">=</span>&nbsp;500<span class="symbol">)</span></code>
 <p>Base class for rest exceptions.</p>
 </BODY>
 </HTML>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/code.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/code.html
@@ -8,7 +8,7 @@
 <a href="../../index.html">tock</a>&nbsp;/&nbsp;<a href="../index.html">ai.tock.shared.vertx</a>&nbsp;/&nbsp;<a href="index.html">RestException</a>&nbsp;/&nbsp;<a href="./code.html">code</a><br/>
 <br/>
 <h1>code</h1>
-<a name="ai.tock.shared.vertx.RestException$code"></a>
+<a name="ai.tock.shared.exception.rest.RestException$code"></a>
 <code><span class="keyword">val </span><span class="identifier">code</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a></code> <a href="https://github.com/theopenconversationkit/tock/blob/master/shared/src/main/kotlin/vertx/RestException.kt#L22">(source)</a>
 </BODY>
 </HTML>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/index.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-rest-exception/index.html
@@ -19,7 +19,7 @@
 </td>
 <td>
 <p>Base class for rest exceptions.</p>
-<code><span class="identifier">RestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.vertx.RestException$<init>(kotlin.String, kotlin.Int)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">, </span><span class="identifier" id="ai.tock.shared.vertx.RestException$<init>(kotlin.String, kotlin.Int)/code">code</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a>&nbsp;<span class="symbol">=</span>&nbsp;500<span class="symbol">)</span></code></td>
+<code><span class="identifier">RestException</span><span class="symbol">(</span><span class="identifier" id="ai.tock.shared.exception.rest.RestException$<init>(kotlin.String, kotlin.Int)/message">message</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">, </span><span class="identifier" id="ai.tock.shared.exception.rest.RestException$<init>(kotlin.String, kotlin.Int)/code">code</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a>&nbsp;<span class="symbol">=</span>&nbsp;500<span class="symbol">)</span></code></td>
 </tr>
 </tbody>
 </table>

--- a/docs/dokka/tock/ai.tock.shared.vertx/-unauthorized-exception/-init-.html
+++ b/docs/dokka/tock/ai.tock.shared.vertx/-unauthorized-exception/-init-.html
@@ -8,7 +8,7 @@
 <a href="../../index.html">tock</a>&nbsp;/&nbsp;<a href="../index.html">ai.tock.shared.vertx</a>&nbsp;/&nbsp;<a href="index.html">UnauthorizedException</a>&nbsp;/&nbsp;<a href="./-init-.html">&lt;init&gt;</a><br/>
 <br/>
 <h1>&lt;init&gt;</h1>
-<a name="ai.tock.shared.vertx.UnauthorizedException$&lt;init&gt;()"></a>
+<a name="ai.tock.shared.exception.rest.UnauthorizedException$&lt;init&gt;()"></a>
 <code><span class="identifier">UnauthorizedException</span><span class="symbol">(</span><span class="symbol">)</span></code>
 <p>Http 401 exception.</p>
 </BODY>

--- a/nlp/build-model-worker/src/main/kotlin/HealthCheckVerticle.kt
+++ b/nlp/build-model-worker/src/main/kotlin/HealthCheckVerticle.kt
@@ -18,6 +18,7 @@ package ai.tock.nlp.build
 
 import ai.tock.shared.TOCK_FRONT_DATABASE
 import ai.tock.shared.TOCK_MODEL_DATABASE
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.pingMongoDatabase
 import ai.tock.shared.vertx.WebVerticle
@@ -29,7 +30,7 @@ import io.vertx.ext.web.RoutingContext
  */
 class HealthCheckVerticle(
     private val buildVerticle: BuildModelWorkerVerticle
-) : WebVerticle() {
+) : WebVerticle<CommonException>() {
 
     override fun configure() {
         // do nothing

--- a/nlp/build-model-worker/src/main/kotlin/OnDemandHealthCheckVerticle.kt
+++ b/nlp/build-model-worker/src/main/kotlin/OnDemandHealthCheckVerticle.kt
@@ -17,6 +17,7 @@
 package ai.tock.nlp.build
 
 import ai.tock.nlp.build.ondemand.WorkerOnDemandVerticle
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.vertx.WebVerticle
 import ai.tock.shared.vertx.detailedHealthcheck
 import io.vertx.ext.web.RoutingContext
@@ -26,7 +27,7 @@ import io.vertx.ext.web.RoutingContext
  */
 class OnDemandHealthCheckVerticle(
     private val workerOnDemandVerticles: List<WorkerOnDemandVerticle>
-) : WebVerticle() {
+) : WebVerticle<CommonException>() {
 
     override fun configure() {
         // do nothing

--- a/nlp/entity-evaluator/duckling/service/src/main/kotlin/DucklingVerticle.kt
+++ b/nlp/entity-evaluator/duckling/service/src/main/kotlin/DucklingVerticle.kt
@@ -17,10 +17,12 @@
 package ai.tock.duckling.service
 
 import ai.tock.shared.error
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.vertx.WebVerticle
 import ai.tock.shared.vertx.blocking
 import ai.tock.shared.vertx.detailedHealthcheck
+import ai.tock.shared.vertx.toRequestHandler
 import clojure.lang.Keyword
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.JsonSerializer
@@ -36,7 +38,7 @@ import java.time.ZonedDateTime
 /**
  *
  */
-class DucklingVerticle : WebVerticle() {
+class DucklingVerticle : WebVerticle<CommonException>() {
 
     data class ParseRequest(
         val language: String,
@@ -59,11 +61,11 @@ class DucklingVerticle : WebVerticle() {
     override val logger: KLogger = KotlinLogging.logger {}
 
     override fun configure() {
-        blockingJsonPost("/parse") { _, request: ParseRequest ->
+        blockingJsonPost("/parse", handler = toRequestHandler { _, request: ParseRequest ->
             with(request) {
                 DucklingBridge.parse(language, textToParse, dimensions, referenceDate, referenceTimezone)
             }
-        }
+        })
     }
 
     override fun defaultHealthcheck(): (RoutingContext) -> Unit {

--- a/samples/tock-sample-cas-auth-provider/README.md
+++ b/samples/tock-sample-cas-auth-provider/README.md
@@ -28,11 +28,11 @@ git init
 ```
 
 Edit following line in `my-company-cas/pom.xml` according to `tock/` location
-```
+```xml
  <relativePath>../../pom.xml</relativePath>
 ```
 
-Using JDK 8+
+Using JDK 11+
 ```shell
 mvn clean install
 ```
@@ -40,7 +40,6 @@ mvn clean install
 >> **Warning**
 >>
 >> By default, CAS login page is configured to https://casserver.herokuapp.com/cas/login Which is only meant for test purposes
-
 
 
 ## How to run locally (Intellij)
@@ -61,7 +60,36 @@ Plus Button -> JARs or Directories
 
 Select from this project `target/XX-shaded.jar`, and configure it as `Runtime` dependency
 
+#### An example
+Add in `tock-bot` pom.xml when built locally or pushed on repository manager like Nexus or Artifactory  
+And also added as a module in your Tock project  
+File -> New -> Module from existing sources and select the project you created for example `my-company-cas`
+```xml
 
+<module>module file name</module>
+        
+...
+
+<dependency>
+    <groupId>ai.tock</groupId>
+    <artifactId>artifact name</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
+
+For example with this project added as a module project:
+```xml
+
+<module>my-company-cas</module>
+        
+...
+
+<dependency>
+    <groupId>ai.tock</groupId>
+    <artifactId>tock-sample-cas-auth-provider</artifactId>
+    <version>${project.version}</version>
+</dependency>
+```
 
 ### Configure BotAdmin runner
 
@@ -80,11 +108,8 @@ Plug then activate  [conf/dev/tock-bot-admin-server.env](conf/dev/tock-bot-admin
 ### Test result in Chrome
 
 - Launch BotAdmin (default port is `7999`)
-- Open http://localhost:7999 
+- Open http://localhost:7999
 
 By default you would be prompted for user/password by demo CAS
 
 Demo CAS Credentials: `casuser` / `Mellon`.
-
-
-

--- a/samples/tock-sample-cas-auth-provider/conf/dev/tock-bot-admin-server.env
+++ b/samples/tock-sample-cas-auth-provider/conf/dev/tock-bot-admin-server.env
@@ -1,5 +1,7 @@
-tock_cas_auth_proxy_host=127.0.0.1
-tock_cas_auth_proxy_port=3128
+#use another proxy host if needed
+#tock_cas_auth_proxy_host=127.0.0.1
+#tock_cas_auth_proxy_port=3128
+#can be changed to dev or prod
 tock_env=integ
 tock_https_env=false
 botadminverticle_content_path=bot/admin/web/target/frontend/dist

--- a/samples/tock-sample-cas-auth-provider/pom.xml
+++ b/samples/tock-sample-cas-auth-provider/pom.xml
@@ -5,7 +5,10 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-root</artifactId>
-        <version>21.9.7-SNAPSHOT</version>
+        <!-- when fully operational as explained in README can be moved to the following parent
+         <artifactId>tock-bot</artifactId>-->
+        <version>22.9.6-SNAPSHOT</version>
+        <!-- when fully operational as explained in README can be removed-->
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -74,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <version>${kotlin}</version>
             <scope>test</scope>
         </dependency>
@@ -85,8 +88,46 @@
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${plugin.surefire}</version>
+                <configuration>
+
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <includes>
+                        <include>**/*Test.*</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/samples/tock-sample-cas-auth-provider/src/main/kotlin/security/auth.cas/SampleAuthProvidersFactory.kt
+++ b/samples/tock-sample-cas-auth-provider/src/main/kotlin/security/auth.cas/SampleAuthProvidersFactory.kt
@@ -1,5 +1,6 @@
-package security.auth
+package security.auth.cas
 
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.security.auth.CASAuthProvider
 import ai.tock.shared.security.auth.spi.CASAuthProviderFactory
 import io.vertx.core.Vertx
@@ -18,8 +19,7 @@ class SampleAuthProvidersFactory : CASAuthProviderFactory {
         // Ease SPI
     }
 
-    override fun getCasAuthProvider(vertx: Vertx): CASAuthProvider {
-
-        return SampleCASAuthProvider(vertx)
+    override fun <E: ToRestException>getCasAuthProvider (vertx: Vertx): CASAuthProvider<E> {
+        return SampleCASAuthProvider(vertx) as CASAuthProvider<E>
     }
 }

--- a/samples/tock-sample-cas-auth-provider/src/main/resources/META-INF/services/ai.tock.shared.security.auth.spi.CASAuthProviderFactory
+++ b/samples/tock-sample-cas-auth-provider/src/main/resources/META-INF/services/ai.tock.shared.security.auth.spi.CASAuthProviderFactory
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-security.auth.SampleAuthProvidersFactory
+security.auth.cas.SampleAuthProvidersFactory

--- a/samples/tock-sample-cas-auth-provider/src/test/kotlin/security/auth/SampleCASAuthProviderTest.kt
+++ b/samples/tock-sample-cas-auth-provider/src/test/kotlin/security/auth/SampleCASAuthProviderTest.kt
@@ -14,26 +14,28 @@
  * limitations under the License.
  */
 
-package security.auth
+package security.auth.cas
 
-import io.mockk.mockk
-import org.junit.jupiter.api.Assertions.assertEquals
+import ai.tock.shared.VertxMock
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.pac4j.core.profile.CommonProfile
+import org.pac4j.core.profile.UserProfile
 import org.pac4j.vertx.auth.Pac4jUser
+import kotlin.test.assertEquals
 
 internal class SampleCASAuthProviderTest {
 
-    @DisplayName("Ability to read login from principal")
+    @DisplayName("Ability to read userId attribute from principal")
     @Test
-    fun `Ability to read login from principal`() {
+    fun `Ability to read userId attribute from principal`() {
         //GIVEN
-        val cas = SampleCASAuthProvider(mockk(relaxed = true))
+        val cas = SampleCASAuthProvider(VertxMock())
 
-        val profileMap = HashMap<String, CommonProfile>()
-        profileMap["CasClient"] = CommonProfile()
+        val profileMap = HashMap<String, UserProfile>()
+        profileMap["CasClient"] = CommonProfile(true)
         profileMap["CasClient"]!!.id = "123"
+        profileMap["CasClient"]!!.addAttribute("userId", "123")
 
         val user = Pac4jUser()
         user.setUserProfiles(profileMap)

--- a/shared/src/main/kotlin/exception/ToRestException.kt
+++ b/shared/src/main/kotlin/exception/ToRestException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.shared.exception
 
-import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
+import ai.tock.shared.exception.rest.RestException
 
-/**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
- */
-interface CASAuthProviderFactory {
-
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
+abstract class ToRestException(override val message: String?): Exception(message) {
+    abstract fun toRestException(): RestException
 }

--- a/shared/src/main/kotlin/exception/admin/AdminException.kt
+++ b/shared/src/main/kotlin/exception/admin/AdminException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.vertx
+package ai.tock.shared.exception.admin
 
-/**
- * Base class for rest exceptions.
- */
-open class RestException(message: String, val code: Int = 500) : Exception(message)
+import ai.tock.shared.exception.ToRestException
+
+sealed class AdminException(override val message: String?): ToRestException(message)

--- a/shared/src/main/kotlin/exception/error/ErrorMessage.kt
+++ b/shared/src/main/kotlin/exception/error/ErrorMessage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.shared.exception.error
 
-import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
-
-/**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
- */
-interface CASAuthProviderFactory {
-
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
-}
+data class ErrorMessage(val code: String? = null, val message: String)

--- a/shared/src/main/kotlin/exception/error/ErrorMessageWrapper.kt
+++ b/shared/src/main/kotlin/exception/error/ErrorMessageWrapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.vertx
+package ai.tock.shared.exception.error
 
 /**
- * Http 404 exception.
+ * A wrapper of [ErrorMessage]
  */
-class NotFoundException : RestException("not found", 404)
+data class ErrorMessageWrapper(val errors: Set<ErrorMessage> = emptySet()) {
+    constructor(message: String) : this(setOf(ErrorMessage(message = message)))
+}

--- a/shared/src/main/kotlin/exception/rest/BadRequestException.kt
+++ b/shared/src/main/kotlin/exception/rest/BadRequestException.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.shared.exception.rest
+
+import ai.tock.shared.exception.error.ErrorMessage
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import io.netty.handler.codec.http.HttpResponseStatus
+
+/**
+ * Http 400 exception.
+ */
+class BadRequestException(httpResponseBody: ErrorMessageWrapper)
+    : RestException(httpResponseBody, HttpResponseStatus.BAD_REQUEST) {
+        constructor(message: String) : this(ErrorMessageWrapper(message))
+
+        constructor(messages: Set<String>) : this(ErrorMessageWrapper(messages.map { ErrorMessage(message = it) }.toSet()))
+    }

--- a/shared/src/main/kotlin/exception/rest/CommonException.kt
+++ b/shared/src/main/kotlin/exception/rest/CommonException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.vertx
+package ai.tock.shared.exception.rest
 
-/**
- * Http 400 exception.
- */
-class BadRequestException(message: String) : RestException(message, 400)
+import ai.tock.shared.exception.ToRestException
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import io.netty.handler.codec.http.HttpResponseStatus
+
+class CommonException(override val message: String): ToRestException(message) {
+    override fun toRestException(): RestException {
+        return RestException(ErrorMessageWrapper(message), HttpResponseStatus.INTERNAL_SERVER_ERROR)
+    }
+}

--- a/shared/src/main/kotlin/exception/rest/ConflictException.kt
+++ b/shared/src/main/kotlin/exception/rest/ConflictException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.shared.exception.rest
 
-import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import io.netty.handler.codec.http.HttpResponseStatus
 
 /**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
+ * Http 409 exception.
  */
-interface CASAuthProviderFactory {
-
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
+class ConflictException(httpResponseBody: ErrorMessageWrapper) :
+    RestException(httpResponseBody, HttpResponseStatus.CONFLICT) {
+    constructor(message: String) : this(ErrorMessageWrapper(message))
 }
+

--- a/shared/src/main/kotlin/exception/rest/NotFoundException.kt
+++ b/shared/src/main/kotlin/exception/rest/NotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2021 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,16 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.vertx
+package ai.tock.shared.exception.rest
+
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import io.netty.handler.codec.http.HttpResponseStatus
 
 /**
- * Http 401 exception.
+ * Http 404 exception.
  */
-class UnauthorizedException() : RestException("Not authorized", 401)
+class NotFoundException(httpResponseBody: ErrorMessageWrapper)
+    : RestException(httpResponseBody, HttpResponseStatus.NOT_FOUND) {
+    constructor() : this(ErrorMessageWrapper())
+    constructor(message: String) : this(ErrorMessageWrapper(message))
+}

--- a/shared/src/main/kotlin/exception/rest/RestException.kt
+++ b/shared/src/main/kotlin/exception/rest/RestException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,19 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.shared.exception.rest
 
 import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import io.netty.handler.codec.http.HttpResponseStatus
 
 /**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
+ * Base class for rest exceptions.
  */
-interface CASAuthProviderFactory {
+open class RestException (
+    val httpResponseBody: ErrorMessageWrapper = ErrorMessageWrapper(),
+    val httpResponseStatus: HttpResponseStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR)
+    : ToRestException(httpResponseStatus.reasonPhrase()){
+    override fun toRestException(): RestException  = this
 
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
 }

--- a/shared/src/main/kotlin/exception/rest/UnauthorizedException.kt
+++ b/shared/src/main/kotlin/exception/rest/UnauthorizedException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017/2020 e-voyageurs technologies
+ * Copyright (C) 2017/2022 e-voyageurs technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-package ai.tock.shared.security.auth.spi
+package ai.tock.shared.exception.rest
 
-import ai.tock.shared.exception.ToRestException
-import ai.tock.shared.security.auth.CASAuthProvider
-import io.vertx.core.Vertx
+import io.netty.handler.codec.http.HttpResponseStatus
 
 /**
- * Construct CAS Authentication provider
- *
- * NOTE: Intended to be implemented in another JAR as SPI (Service Provider Interface)
+ * Http 401 exception.
  */
-interface CASAuthProviderFactory {
-
-    /**
-     * Creates CAS Authentication provider
-     */
-    fun <E: ToRestException>getCasAuthProvider(vertx: Vertx): CASAuthProvider<E>
-}
+class UnauthorizedException : RestException(httpResponseStatus = HttpResponseStatus.UNAUTHORIZED)

--- a/shared/src/main/kotlin/security/auth/CASAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/CASAuthProvider.kt
@@ -2,6 +2,7 @@ package ai.tock.shared.security.auth
 
 import ai.tock.shared.Executor
 import ai.tock.shared.booleanProperty
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.injector
 import ai.tock.shared.intProperty
 import ai.tock.shared.jackson.mapper
@@ -32,7 +33,7 @@ import org.pac4j.vertx.handler.impl.CallbackHandlerOptions
 import org.pac4j.vertx.handler.impl.SecurityHandler
 import org.pac4j.vertx.handler.impl.SecurityHandlerOptions
 
-abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
+abstract class CASAuthProvider<E: ToRestException>(vertx: Vertx) : SSOTockAuthProvider<E>(vertx) {
 
     protected val sessionStore: VertxSessionStore
     private val executor: Executor get() = injector.provide()
@@ -108,7 +109,7 @@ abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
      */
     abstract fun readRolesByNamespace(user: Pac4jUser): Map<String, Set<String>>
 
-    override fun createAuthHandler(verticle: WebVerticle): AuthenticationHandler {
+    override fun createAuthHandler(verticle: WebVerticle<E>): AuthenticationHandler {
         val options: SecurityHandlerOptions = SecurityHandlerOptions().setClients("CasClient")
         options.authorizers = enabledPacAuthorizers
 
@@ -154,7 +155,7 @@ abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
     }
 
     override fun protectPaths(
-        verticle: WebVerticle,
+        verticle: WebVerticle<E>,
         pathsToProtect: Set<String>,
         sessionHandler: SessionHandler
     ): AuthenticationHandler {
@@ -204,8 +205,8 @@ abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
         return authHandler
     }
 
-    override fun excludedPaths(verticle: WebVerticle): Set<Regex> =
+    override fun excludedPaths(verticle: WebVerticle<E>): Set<Regex> =
         super.excludedPaths(verticle) + callbackPath(verticle).toRegex()
 
-    private fun callbackPath(verticle: WebVerticle): String = "${verticle.basePath}/callback"
+    private fun callbackPath(verticle: WebVerticle<E>): String = "${verticle.basePath}/callback"
 }

--- a/shared/src/main/kotlin/security/auth/GithubOAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/GithubOAuthProvider.kt
@@ -39,7 +39,7 @@ private val defaultBaseUrl = property("tock_bot_admin_rest_default_base_url", "h
 /**
  *
  */
-internal class GithubOAuthProvider<E:ToRestException>(
+internal class GithubOAuthProvider<E : ToRestException>(
     vertx: Vertx,
     private val oauth2: OAuth2Auth = GithubAuth.create(
         vertx,
@@ -62,7 +62,7 @@ internal class GithubOAuthProvider<E:ToRestException>(
         val authHandler =
             super.protectPaths(verticle, pathsToProtect, sessionHandler)
         (authHandler as OAuth2AuthHandler).apply {
-                setupCallback(verticle.router.get(callbackPath(verticle)))
+            setupCallback(verticle.router.get(callbackPath(verticle)))
         }
 
         verticle.router.route("/*")

--- a/shared/src/main/kotlin/security/auth/OAuth2Provider.kt
+++ b/shared/src/main/kotlin/security/auth/OAuth2Provider.kt
@@ -18,6 +18,7 @@ package ai.tock.shared.security.auth
 
 import ai.tock.shared.Executor
 import ai.tock.shared.defaultLocale
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.injector
 import ai.tock.shared.intProperty
 import ai.tock.shared.mapProperty
@@ -37,13 +38,13 @@ import io.vertx.ext.auth.oauth2.OAuth2Options
 import io.vertx.ext.web.handler.AuthenticationHandler
 import io.vertx.ext.web.handler.OAuth2AuthHandler
 import io.vertx.ext.web.handler.SessionHandler
-import java.util.Base64
 import mu.KotlinLogging
+import java.util.Base64
 
 /**
  *
  */
-internal class OAuth2Provider(
+internal class OAuth2Provider<E: ToRestException>(
     vertx: Vertx,
     private val oauth2: OAuth2Auth = OAuth2Auth.create(
         vertx, OAuth2Options()
@@ -78,7 +79,7 @@ internal class OAuth2Provider(
                 }
             }
     )
-) : SSOTockAuthProvider(vertx), OAuth2Auth by oauth2 {
+) : SSOTockAuthProvider<E>(vertx), OAuth2Auth by oauth2 {
 
     companion object {
         private val logger = KotlinLogging.logger {}
@@ -90,11 +91,11 @@ internal class OAuth2Provider(
 
     private val executor: Executor get() = injector.provide()
 
-    override fun createAuthHandler(verticle: WebVerticle): AuthenticationHandler =
+    override fun createAuthHandler(verticle: WebVerticle<E>): AuthenticationHandler =
         OAuth2AuthHandler.create(vertx, oauth2, "$defaultBaseUrl/rest/callback")
 
     override fun protectPaths(
-        verticle: WebVerticle,
+        verticle: WebVerticle<E>,
         pathsToProtect: Set<String>,
         sessionHandler: SessionHandler
     ): AuthenticationHandler {
@@ -158,10 +159,10 @@ internal class OAuth2Provider(
             .map { it.name }
             .toSet()
 
-    override fun excludedPaths(verticle: WebVerticle): Set<Regex> =
+    override fun excludedPaths(verticle: WebVerticle<E>): Set<Regex> =
         super.excludedPaths(verticle) + callbackPath(verticle).toRegex()
 
-    private fun callbackPath(verticle: WebVerticle): String = "${verticle.basePath}/callback"
+    private fun callbackPath(verticle: WebVerticle<E>): String = "${verticle.basePath}/callback"
 
 }
 

--- a/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/PropertyBasedAuthProvider.kt
@@ -16,23 +16,13 @@
 
 package ai.tock.shared.security.auth
 
-import ai.tock.shared.Executor
-import ai.tock.shared.defaultNamespace
-import ai.tock.shared.injector
+import ai.tock.shared.*
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.jackson.mapper
-import ai.tock.shared.listProperty
-import ai.tock.shared.property
-import ai.tock.shared.provide
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.security.TockUserListener
 import ai.tock.shared.security.TockUserRole
-import ai.tock.shared.security.TockUserRole.admin
-import ai.tock.shared.security.TockUserRole.botUser
-import ai.tock.shared.security.TockUserRole.faqBotUser
-import ai.tock.shared.security.TockUserRole.faqNlpUser
-import ai.tock.shared.security.TockUserRole.nlpUser
-import ai.tock.shared.security.TockUserRole.technicalAdmin
-import ai.tock.shared.security.TockUserRole.values
+import ai.tock.shared.security.TockUserRole.*
 import ai.tock.shared.vertx.WebVerticle
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.vertx.core.AsyncResult
@@ -46,9 +36,9 @@ import io.vertx.ext.web.handler.SessionHandler
 import mu.KotlinLogging
 
 /**
- * Simple [AuthProvider] used in dev mode.
+ * Simple [TockAuthProvider] used in dev mode.
  */
-internal object PropertyBasedAuthProvider : TockAuthProvider {
+internal class PropertyBasedAuthProvider<E: ToRestException>: TockAuthProvider<E> {
 
     private val logger = KotlinLogging.logger {}
 
@@ -71,7 +61,7 @@ internal object PropertyBasedAuthProvider : TockAuthProvider {
     private val executor: Executor get() = injector.provide()
 
     override fun protectPaths(
-        verticle: WebVerticle,
+        verticle: WebVerticle<E>,
         pathsToProtect: Set<String>,
         sessionHandler: SessionHandler
     ): AuthenticationHandler {

--- a/shared/src/main/kotlin/security/auth/SSOTockAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/SSOTockAuthProvider.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.shared.security.auth
 
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.vertx.WebVerticle
 import io.vertx.core.Handler
@@ -28,7 +29,7 @@ import io.vertx.ext.web.handler.SessionHandler
 /**
  *
  */
-abstract class SSOTockAuthProvider(val vertx: Vertx) : TockAuthProvider {
+abstract class SSOTockAuthProvider<E: ToRestException>(val vertx: Vertx) : TockAuthProvider<E> {
 
     object AddSSOCookieHandler : Handler<RoutingContext> {
 
@@ -43,10 +44,10 @@ abstract class SSOTockAuthProvider(val vertx: Vertx) : TockAuthProvider {
 
     override val sessionCookieName: String get() = "tock-sso-session"
 
-    abstract fun createAuthHandler(verticle: WebVerticle): AuthenticationHandler
+    abstract fun createAuthHandler(verticle: WebVerticle<E>): AuthenticationHandler
 
     override fun protectPaths(
-        verticle: WebVerticle,
+        verticle: WebVerticle<E>,
         pathsToProtect: Set<String>,
         sessionHandler: SessionHandler
     ): AuthenticationHandler {

--- a/shared/src/main/kotlin/security/auth/TockAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/TockAuthProvider.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.shared.security.auth
 
+import ai.tock.shared.exception.ToRestException
 import ai.tock.shared.security.TockUser
 import ai.tock.shared.vertx.WebVerticle
 import io.vertx.ext.auth.authentication.AuthenticationProvider
@@ -26,14 +27,14 @@ import io.vertx.ext.web.handler.SessionHandler
 /**
  * Base interface for [AuthenticationProvider] in Tock framework.
  */
-interface TockAuthProvider : AuthenticationProvider {
+interface TockAuthProvider<E: ToRestException> : AuthenticationProvider {
 
     /**
      * The tock session cookie name.
      */
     val sessionCookieName: String get() = "tock-session"
 
-    fun defaultExcludedPaths(verticle: WebVerticle): Set<Regex> = listOfNotNull(
+    fun <E: ToRestException>defaultExcludedPaths(verticle: WebVerticle<E>): Set<Regex> = listOfNotNull(
         verticle.healthcheckPath?.toRegex(),
         verticle.livenesscheckPath?.toRegex(),
         verticle.readinesscheckPath?.toRegex(),
@@ -43,14 +44,14 @@ interface TockAuthProvider : AuthenticationProvider {
     /**
      * Paths to exclude from the [AuthProvider].
      */
-    fun excludedPaths(verticle: WebVerticle): Set<Regex> = defaultExcludedPaths(verticle)
+    fun excludedPaths(verticle: WebVerticle<E>): Set<Regex> = defaultExcludedPaths(verticle)
 
     /**
      * Protect paths for the specified verticle.
      * @return the [AuthHandler].
      */
     fun protectPaths(
-        verticle: WebVerticle,
+        verticle: WebVerticle<E>,
         pathsToProtect: Set<String>,
         sessionHandler: SessionHandler
     ): AuthenticationHandler

--- a/shared/src/main/kotlin/vertx/RequestHandlers.kt
+++ b/shared/src/main/kotlin/vertx/RequestHandlers.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2017/2022 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.shared.vertx
+
+import ai.tock.shared.exception.ToRestException
+import ai.tock.shared.exception.error.ErrorMessageWrapper
+import ai.tock.shared.exception.rest.RestException
+import io.vertx.ext.web.RoutingContext
+
+// region request handlers
+typealias RequestHandler<T,E> = (RoutingContext) -> RequestHandlerResult<T,E>
+
+typealias BiRequestHandler<R,T,E> = (RoutingContext, R) -> RequestHandlerResult<T,E>
+
+typealias TriRequestHandler<R,S,T,E> = (RoutingContext, R, S) -> RequestHandlerResult<T,E>
+
+// endregion
+
+// region RequestHandlerResult
+sealed class RequestHandlerResult<T, E:Throwable> {
+    fun <R> map(handleFailure: (E) -> Unit = {}, successMapper: (T) -> R): RequestHandlerResult<R, E> {
+        return when(this) {
+            is RequestSucceeded -> RequestSucceeded(successMapper(value))
+            is RequestFailed -> {
+                handleFailure(error)
+                RequestFailed(error)
+            }
+        }
+    }
+
+    fun mapToSuccessUnit(handleFailure: (E) -> Unit = {}, handleSuccess: (T) -> Unit = {}): RequestHandlerResult<Unit, E> {
+        return when(this) {
+            is RequestSucceeded -> {
+                handleSuccess(value)
+                RequestSucceeded(Unit)
+            }
+
+            is RequestFailed -> {
+                handleFailure(error)
+                RequestSucceeded(Unit)
+            }
+        }
+    }
+
+}
+
+data class RequestSucceeded<T, E:Throwable>(val value: T): RequestHandlerResult<T, E>()
+
+data class RequestFailed<T, E:Throwable>(val error: E): RequestHandlerResult<T, E>()
+
+// endregion
+
+// region toRequestHandler functions
+inline fun <T, reified E: ToRestException> toRequestHandler(crossinline requestHandler: (RoutingContext) -> T) : RequestHandler<T, E>{
+    return { context ->
+        try {
+            RequestSucceeded(requestHandler(context))
+        } catch (e: Throwable) {
+            handleThrowable(e)
+        }
+    }
+}
+
+inline fun <T, R, reified E: ToRestException> toRequestHandler(crossinline requestHandler: (RoutingContext, R) -> T) : BiRequestHandler<R,T, E>{
+    return { context, r ->
+        try {
+            RequestSucceeded(requestHandler(context, r))
+        } catch (e: Throwable) {
+            handleThrowable(e)
+        }
+    }
+}
+
+inline fun <T, R, S, reified E: ToRestException> toRequestHandler(crossinline requestHandler: (RoutingContext, R, S) -> T) : TriRequestHandler<R, S,T, E>{
+    return { context, r, s ->
+        try {
+            RequestSucceeded(requestHandler(context, r, s))
+        } catch (e: Throwable) {
+           handleThrowable(e)
+        }
+    }
+}
+
+inline fun <T, reified E : ToRestException> handleThrowable(e: Throwable) : RequestHandlerResult<T, E> = if (e is E) {
+    RequestFailed(e)
+} else {
+    throw RestException(ErrorMessageWrapper(e.message ?: ""))
+}
+// endregion

--- a/shared/src/main/kotlin/vertx/WebVerticle.kt
+++ b/shared/src/main/kotlin/vertx/WebVerticle.kt
@@ -19,6 +19,11 @@ package ai.tock.shared.vertx
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.devEnvironment
 import ai.tock.shared.error
+import ai.tock.shared.exception.ToRestException
+import ai.tock.shared.exception.rest.BadRequestException
+import ai.tock.shared.exception.rest.NotFoundException
+import ai.tock.shared.exception.rest.RestException
+import ai.tock.shared.exception.rest.UnauthorizedException
 import ai.tock.shared.intProperty
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.longProperty
@@ -62,16 +67,16 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.Locale
 import java.util.ServiceLoader
-import kotlin.LazyThreadSafetyMode.PUBLICATION
 import mu.KLogger
 import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.toId
+import kotlin.LazyThreadSafetyMode.PUBLICATION
 
 /**
  * Base class for web Tock [io.vertx.core.Verticle]s. Provides utility methods.
  */
-abstract class WebVerticle : AbstractVerticle() {
+abstract class WebVerticle<E : ToRestException> : AbstractVerticle() {
 
     companion object {
         fun unauthorized(): Nothing = throw UnauthorizedException()
@@ -100,11 +105,13 @@ abstract class WebVerticle : AbstractVerticle() {
 
     val router: Router by lazy {
         Router.router(sharedVertx).apply {
+            errorHandler(400, defaultErrorHandler(400))
             errorHandler(404, defaultErrorHandler(404))
             errorHandler(405, defaultErrorHandler(405))
             errorHandler(406, defaultErrorHandler(406))
+            errorHandler(409, defaultErrorHandler(409))
             errorHandler(415, defaultErrorHandler(415))
-            errorHandler(400, defaultErrorHandler(400))
+            errorHandler(500, defaultErrorHandler(500))
         }
     }
 
@@ -118,7 +125,7 @@ abstract class WebVerticle : AbstractVerticle() {
 
     open val basePath: String = "/rest"
 
-    protected open val rootPath: String = ""
+    open val rootPath: String = ""
 
     open val authenticatePath: String get() = "$basePath/authenticate"
 
@@ -141,7 +148,7 @@ abstract class WebVerticle : AbstractVerticle() {
      */
     open val livenesscheckPath: String? get() = verticleProperty("tock_vertx_livenesscheck_path", "/health/liveness")
 
-    private val cachedAuthProvider: TockAuthProvider? by lazy(PUBLICATION) {
+    private val cachedAuthProvider: TockAuthProvider<E>? by lazy(PUBLICATION) {
         authProvider()
     }
 
@@ -174,8 +181,8 @@ abstract class WebVerticle : AbstractVerticle() {
      */
     open fun detailedHealthcheck(): (RoutingContext) -> Unit = defaultHealthcheck()
 
-    private fun loadCasAuthProvider(vertx: Vertx): CASAuthProvider? {
-        var result: CASAuthProvider? = null
+    private fun loadCasAuthProvider(vertx: Vertx): CASAuthProvider<E>? {
+        var result: CASAuthProvider<E>? = null
         val loader = ServiceLoader.load(CASAuthProviderFactory::class.java)
 
         val it = loader.iterator()
@@ -236,9 +243,10 @@ abstract class WebVerticle : AbstractVerticle() {
     }
 
     fun addAuth(
-        authProvider: TockAuthProvider = defaultAuthProvider(),
-        pathsToProtect: Set<String> = protectedPaths().map { "$it/*" }.toSet()
+        authProvider: TockAuthProvider<E> = defaultAuthProvider(),
+        pathsToProtect: MutableSet<String> = protectedPaths().map { "$it/*" }.toMutableSet()
     ) {
+        pathsToProtect.addAll(protectedPaths())
         val https = !devEnvironment && booleanProperty("tock_https_env", true)
         val sessionHandler = SessionHandler.create(LocalSessionStore.create(vertx))
             .setSessionTimeout(6 * 60 * 60 * 1000 /*6h*/)
@@ -253,20 +261,20 @@ abstract class WebVerticle : AbstractVerticle() {
     /**
      * The auth provider provided by default.
      */
-    protected open fun defaultAuthProvider(): TockAuthProvider =
+    protected open fun defaultAuthProvider(): TockAuthProvider<E> =
         when {
             booleanProperty("tock_github_oauth_enabled", false) -> GithubOAuthProvider(sharedVertx)
             booleanProperty("tock_oauth2_enabled", false) -> OAuth2Provider(sharedVertx)
             booleanProperty("tock_cas_auth_enabled", false) ->
-                loadCasAuthProvider(sharedVertx) ?: PropertyBasedAuthProvider
+                loadCasAuthProvider(sharedVertx) ?: PropertyBasedAuthProvider()
 
-            else -> PropertyBasedAuthProvider
+            else -> PropertyBasedAuthProvider()
         }
 
     /**
      * By default there is no auth provider - ie nothing is protected.
      */
-    protected open fun authProvider(): TockAuthProvider? = null
+    protected open fun authProvider(): TockAuthProvider<E>? = null
 
     /**
      * The default role of a service.
@@ -323,7 +331,6 @@ abstract class WebVerticle : AbstractVerticle() {
         basePath: String = rootPath,
         handler: (RoutingContext) -> Unit
     ) {
-
         router.route(method, "$basePath$path")
             .handler { context ->
                 val user = context.user()
@@ -346,7 +353,7 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         role: TockUserRole,
         basePath: String = rootPath,
-        handler: (RoutingContext) -> Unit
+        handler: RequestHandler<Unit, E>
     ) {
         blocking(method, path, setOf(role), basePath, handler)
     }
@@ -356,7 +363,7 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         basePath: String = rootPath,
-        handler: (RoutingContext) -> Unit
+        handler: RequestHandler<Unit, E>
     ) {
         register(method, path, roles, basePath) { it.executeBlocking(handler) }
     }
@@ -391,21 +398,22 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         roles: Set<TockUserRole>?,
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, I) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<I, O, E>
     ) {
-        blocking(method, path, roles) { context ->
-            var input: I? = null
-            try {
-                input = context.readJson()
-
-                val result = handler.invoke(context, input)
-                context.endJson(result)
-                logger.log(context, input)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, input, true)
-                }
-                throw t
+        blocking(method, path, roles, basePath) { context ->
+            with(context.readJson() as I) {
+                handler
+                    .invoke(context, this)
+                    .map(
+                        successMapper = {
+                            context.endJson(it).also { logger.log(context, this) }
+                        },
+                        handleFailure = {
+                            if (it !is UnauthorizedException) {
+                                logger.log(context, this, true)
+                            }
+                        })
             }
         }
     }
@@ -414,59 +422,69 @@ abstract class WebVerticle : AbstractVerticle() {
         method: HttpMethod,
         path: String,
         roles: Set<TockUserRole>?,
-        handler: (RoutingContext) -> O
+        basePath: String = rootPath,
+        handler: RequestHandler<O, E>
     ) {
-        blocking(method, path, roles) { context ->
-            val result = handler.invoke(context)
-            context.endJson(result)
+        blocking(method, path, roles, basePath) { context ->
+            handler.invoke(context).map { context.endJson(it) }
         }
     }
 
     fun <O> blockingJsonGet(
         path: String,
         role: TockUserRole,
-        handler: (RoutingContext) -> O
+        basePath: String = rootPath,
+        handler: RequestHandler<O, E>
     ) {
-        blockingJsonGet(path, setOf(role), handler)
+        blockingJsonGet(path = path, roles = setOf(role), basePath = basePath, handler = handler)
     }
 
     fun <O> blockingJsonGet(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
-        handler: (RoutingContext) -> O
+        basePath: String = rootPath,
+        handler: RequestHandler<O, E>
     ) {
-        blocking(GET, path, roles) { context ->
-            val result = handler.invoke(context)
-            context.endJson(result)
+        blocking(GET, path, roles, basePath) { context ->
+            handler.invoke(context).map { context.endJson(it) }
         }
+    }
+
+    protected fun blockingPostEmptyResponse(
+        path: String,
+        roles: Set<TockUserRole>? = defaultRoles(),
+        logger: RequestLogger = defaultRequestLogger,
+        basePath: String = rootPath,
+        handler: RequestHandler<Unit, E>
+    ) {
+        blockingPost(path, roles, logger, basePath, success = successEmpty, handler)
     }
 
     protected fun blockingPost(
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Unit
+        basePath: String = rootPath,
+        handler: RequestHandler<Unit, E>
     ) {
-        blockingPost(path, setOf(role), logger, handler)
+        blockingPost(path = path, roles = setOf(role), logger = logger, basePath = basePath, handler = handler)
     }
 
     protected fun blockingPost(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Unit
+        basePath: String = rootPath,
+        success: (RoutingContext) -> Unit = successTrue,
+        handler: RequestHandler<Unit, E>
     ) {
-        blocking(POST, path, roles) { context ->
-            try {
-                handler.invoke(context)
-                context.success()
-                logger.log(context, null)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, null, true)
-                }
-                throw t
-            }
+        blocking(POST, path, roles, basePath) { context ->
+            handler
+                .invoke(context)
+                .map(
+                    successMapper = { success.invoke(context).also { logger.log(context, null) } },
+                    handleFailure = { handleUnauthorizedException(it, logger, context) }
+                )
         }
     }
 
@@ -474,41 +492,38 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         basePath: String = rootPath,
-        handler: (RoutingContext) -> String
+        handler: RequestHandler<String, E>
     ) {
         blocking(GET, path, roles, basePath) { context ->
-            context.response().end(handler.invoke(context))
+            handler.invoke(context).map { context.response().end(it) }
         }
     }
 
-    protected inline fun <reified F : Any, O> blockingUploadJsonPost(
+    inline fun <reified F : Any, O> blockingUploadJsonPost(
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, F) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<F, O, E>
     ) {
-        blockingUploadJsonPost(path, setOf(role), logger, handler)
+        blockingUploadJsonPost(path, setOf(role), logger, basePath, handler)
     }
 
-    protected inline fun <reified F : Any, O> blockingUploadJsonPost(
+    inline fun <reified F : Any, O> blockingUploadJsonPost(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, F) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<F, O, E>
     ) {
-        blocking(POST, path, roles) { context ->
-            val upload = context.fileUploads().first()
-            var f: F? = null
-            try {
-                f = readJson(upload)
-                val result = handler.invoke(context, f)
-                context.endJson(result)
-                logger.log(context, f)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, f, true)
-                }
-                throw t
+        blocking(POST, path, roles, basePath) { context ->
+            with(readJson(context.fileUploads().first()) as F) {
+                handler
+                    .invoke(context, this)
+                    .map(
+                        successMapper = { context.endJson(it).also { logger.log(context, this) } },
+                        handleFailure = { handleUnauthorizedException(it, logger, context) }
+                    )
             }
         }
     }
@@ -517,29 +532,27 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, String) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<String, O, E>
     ) {
-        blockingUploadPost(path, setOf(role), logger, handler)
+        blockingUploadPost(path, setOf(role), logger, basePath, handler)
     }
 
     protected inline fun <O> blockingUploadPost(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, String) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<String, O, E>
     ) {
-        blocking(POST, path, roles) { context ->
-            val upload = context.fileUploads().first()
-            try {
-                val f = readString(upload)
-                val result = handler.invoke(context, f)
-                context.endJson(result)
-                logger.log(context, upload)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, upload, true)
-                }
-                throw t
+        blocking(POST, path, roles, basePath) { context ->
+            with(readString(context.fileUploads().first())) {
+                handler
+                    .invoke(context, this)
+                    .map(
+                        successMapper = { context.endJson(it).also { logger.log(context, this) } },
+                        handleFailure = { handleUnauthorizedException(it, logger, context) }
+                    )
             }
         }
     }
@@ -547,7 +560,7 @@ abstract class WebVerticle : AbstractVerticle() {
     protected inline fun <O> blockingUploadBinaryPost(
         path: String,
         role: TockUserRole,
-        crossinline handler: (RoutingContext, Pair<String, ByteArray>) -> O
+        crossinline handler: BiRequestHandler<Pair<String, ByteArray>, O, E>
     ) {
         blockingUploadBinaryPost(path, setOf(role), handler)
     }
@@ -555,12 +568,13 @@ abstract class WebVerticle : AbstractVerticle() {
     protected inline fun <O> blockingUploadBinaryPost(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
-        crossinline handler: (RoutingContext, Pair<String, ByteArray>) -> O
+        crossinline handler: BiRequestHandler<Pair<String, ByteArray>, O, E>
     ) {
         blocking(POST, path, roles) { context ->
             val upload = context.fileUploads().first()
-            val result = handler.invoke(context, upload.fileName() to readBytes(upload))
-            context.endJson(result)
+            handler
+                .invoke(context, upload.fileName() to readBytes(upload))
+                .map { context.endJson(it) }
         }
     }
 
@@ -568,64 +582,87 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, I) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<I, O, E>
     ) {
-        blockingWithBodyJson(POST, path, roles, logger, handler)
+        blockingWithBodyJson(POST, path, roles, logger, basePath, handler)
     }
 
     inline fun <reified I : Any, O> blockingJsonPost(
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, I) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<I, O, E>
     ) {
-        blockingWithBodyJson(POST, path, setOf(role), logger, handler)
+        blockingWithBodyJson(POST, path, setOf(role), logger, basePath, handler)
     }
 
-    protected inline fun <reified I : Any, O> blockingJsonPut(
+    inline fun <reified I : Any, O> blockingJsonPut(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, I) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<I, O, E>
     ) {
-        blockingWithBodyJson(PUT, path, roles, logger, handler)
+        blockingWithBodyJson(PUT, path, roles, logger, basePath, handler)
     }
 
     protected inline fun <reified I : Any, O> blockingJsonPut(
         path: String,
-        role: TockUserRole? = defaultRole(),
+        role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        crossinline handler: (RoutingContext, I) -> O
+        basePath: String = rootPath,
+        crossinline handler: BiRequestHandler<I, O, E>
     ) {
-        blockingWithBodyJson(PUT, path, role?.let { setOf(role) }, logger, handler)
+        blockingWithBodyJson(PUT, path, setOf(role), logger, basePath, handler)
+    }
+
+    fun blockingDeleteEmptyResponse(
+        path: String,
+        roles: Set<TockUserRole>? = defaultRoles(),
+        logger: RequestLogger = defaultRequestLogger,
+        basePath: String = rootPath,
+        handler: RequestHandler<Unit, E>
+    ) {
+        blockingDelete(path, roles, logger, basePath, successEmpty, handler)
     }
 
     fun blockingDelete(
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Unit
+        basePath: String = rootPath,
+        handler: RequestHandler<Unit, E>
     ) {
-        blockingDelete(path, setOf(role), logger, handler)
+        blockingDelete(path = path, roles = setOf(role), logger = logger, basePath = basePath, handler = handler)
     }
 
     fun blockingDelete(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Unit
+        basePath: String = rootPath,
+        success: (RoutingContext) -> Unit = successTrue,
+        handler: RequestHandler<Unit, E>
     ) {
-        blocking(DELETE, path, roles) { context ->
-            try {
-                handler.invoke(context)
-                logger.log(context, null)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, null, false)
-                }
-                throw t
-            }
-            context.success()
+        blocking(DELETE, path, roles, basePath) { context ->
+            handler
+                .invoke(context)
+                .map(
+                    successMapper = { success.invoke(context).also { logger.log(context, null) } },
+                    handleFailure = { handleUnauthorizedException(it, logger, context) }
+                )
+        }
+    }
+
+    fun handleUnauthorizedException(
+        error: E,
+        logger: RequestLogger,
+        context: RoutingContext
+    ) {
+        if (error !is UnauthorizedException) {
+            logger.log(context, null, true)
         }
     }
 
@@ -633,27 +670,26 @@ abstract class WebVerticle : AbstractVerticle() {
         path: String,
         role: TockUserRole,
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Boolean
+        basePath: String = rootPath,
+        handler: RequestHandler<Boolean, E>
     ) {
-        blockingJsonDelete(path, setOf(role), logger, handler)
+        blockingJsonDelete(path, setOf(role), logger, basePath, handler)
     }
 
-    protected fun blockingJsonDelete(
+    fun blockingJsonDelete(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
         logger: RequestLogger = defaultRequestLogger,
-        handler: (RoutingContext) -> Boolean
+        basePath: String = rootPath,
+        handler: RequestHandler<Boolean, E>
     ) {
-        blockingWithoutBodyJson(DELETE, path, roles) { context ->
-            try {
-                BooleanResponse(handler.invoke(context))
-                logger.log(context, null)
-            } catch (t: Throwable) {
-                if (t !is UnauthorizedException) {
-                    logger.log(context, null, false)
-                }
-                throw t
-            }
+        blockingWithoutBodyJson(DELETE, path, roles, basePath) { context ->
+            handler
+                .invoke(context)
+                .map(
+                    successMapper = { BooleanResponse(it).also { logger.log(context, null) } },
+                    handleFailure = { handleUnauthorizedException(it, logger, context) }
+                )
         }
     }
 
@@ -662,23 +698,22 @@ abstract class WebVerticle : AbstractVerticle() {
         method: HttpMethod,
         path: String,
         roles: Set<TockUserRole>?,
-        crossinline handler: (RoutingContext, I, Handler<O>) -> Unit
+        crossinline handler: TriRequestHandler<I, Handler<O>, Unit, E>
     ) {
         register(method, path, roles) { context ->
-            try {
-                val input = context.readJson<I>()
-                handler.invoke(context, input, Handler { event -> context.endJson(event) })
-            } catch (e: Throwable) {
-                logger.error(e)
-                context.fail(e)
-            }
+            val input = context.readJson<I>()
+            handler.invoke(context, input, Handler { event -> context.endJson(event) })
+                .mapToSuccessUnit(handleFailure = {
+                    logger.error(it)
+                    context.fail(it)
+                })
         }
     }
 
     protected inline fun <reified I : Any, O> jsonPost(
         path: String,
         roles: Set<TockUserRole>? = defaultRoles(),
-        crossinline handler: (RoutingContext, I, Handler<O>) -> Unit
+        crossinline handler: TriRequestHandler<I, Handler<O>, Unit, E>
     ) {
         withBodyJson(POST, path, roles, handler)
     }
@@ -751,7 +786,7 @@ abstract class WebVerticle : AbstractVerticle() {
     }
 
     inline fun <reified T : Any> RoutingContext.readJson(): T {
-        return mapper.readValue(this.body().asString())
+        return mapper.readValue(this.bodyAsString)
     }
 
     inline fun <reified T : Any> readJson(upload: FileUpload): T {
@@ -767,15 +802,18 @@ abstract class WebVerticle : AbstractVerticle() {
     /**
      * Execute blocking code using [Vertx.executeBlocking].
      */
-    protected fun RoutingContext.executeBlocking(handler: (RoutingContext) -> Unit) {
+    protected fun <T : ToRestException> RoutingContext.executeBlocking(
+        handler: RequestHandler<Unit, T>
+    ) {
+
         sharedVertx.executeBlocking<Unit>(
             {
-                try {
-                    handler.invoke(this)
-                    it.tryComplete()
-                } catch (t: Throwable) {
-                    it.tryFail(t)
-                }
+                handler
+                    .invoke(this)
+                    .map(
+                        successMapper = { _ -> it.tryComplete() },
+                        handleFailure = { error -> it.tryFail(error.toRestException()) },
+                    )
             },
             false,
             {
@@ -783,8 +821,9 @@ abstract class WebVerticle : AbstractVerticle() {
                     it.cause().apply {
                         when {
                             this is RestException -> {
+                                response().statusCode = httpResponseStatus.code()
                                 response().statusMessage = message
-                                fail(code)
+                                response().endJson(httpResponseBody)
                             }
 
                             this != null -> {
@@ -801,6 +840,18 @@ abstract class WebVerticle : AbstractVerticle() {
                 }
             }
         )
+    }
+
+    private val successEmpty: RoutingContext.() -> Unit = {
+        this.successEmpty()
+    }
+
+    fun RoutingContext.successEmpty() {
+        this.endJson(null)
+    }
+
+    private val successTrue: RoutingContext.() -> Unit = {
+        this.success()
     }
 
     fun RoutingContext.success() {
@@ -838,7 +889,7 @@ abstract class WebVerticle : AbstractVerticle() {
     val RoutingContext.userLogin: String
         get() = user?.user ?: error("no user in session")
 
-    fun HttpServerResponse.endJson(result: Any?) {
+    private fun HttpServerResponse.endJson(result: Any?) {
         if (result == null) {
             statusCode = 204
         }
@@ -856,7 +907,7 @@ abstract class WebVerticle : AbstractVerticle() {
      * See https://vertx.io/docs/vertx-web/java/#_route_match_failures
      */
     open fun defaultErrorHandler(statusCode: Int): Handler<RoutingContext> = Handler<RoutingContext> { event ->
-        logger.info { "page not served ($statusCode): ${event.request().path()}" }
+        logger.error { "Error  $statusCode: ${event.request().path()}" }
         tockErrorHandler.handle(event)
     }
 }

--- a/shared/src/test/kotlin/security/auth/SSOTockAuthProviderTest.kt
+++ b/shared/src/test/kotlin/security/auth/SSOTockAuthProviderTest.kt
@@ -17,6 +17,8 @@
 package ai.tock.shared.security.auth
 
 import ai.tock.shared.VertxMock
+import ai.tock.shared.exception.admin.AdminException
+import ai.tock.shared.exception.rest.CommonException
 import ai.tock.shared.vertx.WebVerticle
 import io.mockk.mockk
 import io.vertx.core.AsyncResult
@@ -31,13 +33,13 @@ class SSOTockAuthProviderTest {
 
     @Test
     fun `excludedPaths match static files`() {
-        val sso = object : SSOTockAuthProvider(VertxMock()) {
+        val sso = object : SSOTockAuthProvider<AdminException>(VertxMock()) {
 
-            fun test(verticle: WebVerticle): Set<Regex> {
+            fun test(verticle: WebVerticle<AdminException>): Set<Regex> {
                 return super.excludedPaths(verticle)
             }
 
-            override fun createAuthHandler(verticle: WebVerticle): AuthenticationHandler {
+            override fun createAuthHandler(verticle: WebVerticle<AdminException>): AuthenticationHandler {
                 return mockk()
             }
 

--- a/shared/src/test/kotlin/vertx/WebVerticleTest.kt
+++ b/shared/src/test/kotlin/vertx/WebVerticleTest.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.shared.vertx
 
+import ai.tock.shared.exception.rest.CommonException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -26,7 +27,7 @@ import kotlin.test.Test
 class WebVerticleTest {
 
     // check that WebVerticleImpl does not need to implement healthcheck methods to compile
-    class WebVerticleImpl : WebVerticle() {
+    class WebVerticleImpl : WebVerticle<CommonException>() {
         override fun configure() {}
     }
 


### PR DESCRIPTION
From the work of @henriSedjame : 
Here is a proposal :
- fixes https://github.com/theopenconversationkit/tock/issues/1470
- add a new way of creating verticle for developers with better HTTP errors handling exception with a Generic ToRestException for the implementation of WebVerticles
- Create functionnal verticle with parent and child Verticle (ex : according to AdminVerticle <-> BotAdminVerticle) to begin the decoupling of Verticles per business like asked in #1471 