### PR TITLE
:technologist: add retrofit logging environment variable and update existing TockNlpClient.kt

### DIFF
--- a/docs/_fr/admin/supervision.md
+++ b/docs/_fr/admin/supervision.md
@@ -262,12 +262,13 @@ Celle-ci configure [Logback](http://logback.qos.ch/) programmatiquement, avec le
 Des variables d'environnement permettent de configurer ces différents modes de journalisation. 
 Elles peuvent être définies indépendamment sur chaque composant produisant des logs.
 
-| Variable d'environnement      | Valeur par défaut                            | Description |
-|-------------------------------|----------------------------------------------|-------------|
-| `tock_env`                    | `dev`                                        | Environnement (attention : contrôle d'autres mécanismes que les logs). |
-| `tock_logback_enabled`        | `true`                                       | Activation des logs. |
-| `tock_default_log_level`      | `DEBUG` si `tock_env=dev` (autrement `INFO`) | Niveau de log général (hors exceptions, voir plus haut). |
-| `tock_logback_file_appender`  | `false`                                      | Logs fichiers (voir détails plus haut) à la place des logs console (sortie standard). |
+| Variable d'environnement     | Valeur par défaut                            | Description                                                                                                                                                   |
+|------------------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `tock_env`                   | `dev`                                        | Environnement (attention : contrôle d'autres mécanismes que les logs).                                                                                        |
+| `tock_logback_enabled`       | `true`                                       | Activation des logs.                                                                                                                                          |
+| `tock_default_log_level`     | `DEBUG` si `tock_env=dev` (autrement `INFO`) | Niveau de log général (hors exceptions, voir plus haut).                                                                                                      |
+| `tock_retrofit_log_level`                       | `BASIC` si `tock_env=dev` (autrement `NONE`) | Niveau de logs (requêtes et réponses) pour les services clients applicatifs utilisant Retrofit (TockNlpClient, BotApiClient, et bon nombre de connecteurs...) |
+| `tock_logback_file_appender` | `false`                                      | Logs fichiers (voir détails plus haut) à la place des logs console (sortie standard).                                                                         |
 
 Selon le mode de déploiement utilisé, ces variables d'environnement peuvent être ajoutées soit 
 directement en ligne de commande, soit dans un descripteur type `docker-compose.yml`, `dockerrun.aws.json` ou autre.

--- a/nlp/api/client/pom.xml
+++ b/nlp/api/client/pom.xml
@@ -29,6 +29,19 @@
     <description>Client interface for Tock NLP API</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>ai.tock</groupId>
+            <artifactId>tock-shared</artifactId>
+            <scope>provided</scope>
+            <!-- Just need to import some code from Retrofit.kt not the dependencies-->
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>

--- a/nlp/api/client/src/main/kotlin/TockNlpClient.kt
+++ b/nlp/api/client/src/main/kotlin/TockNlpClient.kt
@@ -28,6 +28,8 @@ import ai.tock.nlp.api.client.model.evaluation.EntityEvaluationResult
 import ai.tock.nlp.api.client.model.merge.ValuesMergeQuery
 import ai.tock.nlp.api.client.model.merge.ValuesMergeResult
 import ai.tock.nlp.api.client.model.monitoring.MarkAsUnknownQuery
+import ai.tock.shared.retrofitDefaultLogLevel
+import ai.tock.shared.retrofitLogLevel
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationFeature
@@ -77,7 +79,16 @@ class TockNlpClient(baseUrl: String = System.getenv("tock_nlp_service_url") ?: "
                     .readTimeout(timeout, TimeUnit.MILLISECONDS)
                     .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                     .writeTimeout(timeout, TimeUnit.MILLISECONDS)
-                    .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+                    .addInterceptor(
+                        // adapt log level to use specific log interceptors
+                        HttpLoggingInterceptor().setLevel(
+                            HttpLoggingInterceptor.Level.valueOf(
+                                retrofitLogLevel(
+                                    retrofitDefaultLogLevel
+                                ).toString()
+                            )
+                        )
+                    )
                     .build()
             )
             .build()
@@ -110,7 +121,8 @@ class TockNlpClient(baseUrl: String = System.getenv("tock_nlp_service_url") ?: "
     }
 
     override fun createApplication(namespace: String, name: String, locale: Locale): ApplicationDefinition? {
-        return nlpService.createApplication(CreateApplicationQuery(name, namespace = namespace, locale = locale)).execute().body()
+        return nlpService.createApplication(CreateApplicationQuery(name, namespace = namespace, locale = locale))
+            .execute().body()
     }
 
     private fun createMultipart(stream: InputStream): MultipartBody.Part {


### PR DESCRIPTION
Manage Retrofit okhttp3 logs levels for production or development according to `tock_env`
`NONE` in production