### PR TITLE
[FAQ] Fix - Import with same application name / shared data with same name

### DIFF
--- a/bot/admin/server/src/main/kotlin/FaqAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/FaqAdminService.kt
@@ -84,11 +84,11 @@ object FaqAdminService {
 
     /**
      * Make migration:
-     * replace applicationId attribute (referred to Application's _id) by botId attribute (referred to Application's name)
+     * add namespace attribute (referred to Intent's _id) by namespace attribute (referred to Intent's namespace)
      */
     fun makeMigration() {
         faqDefinitionDAO.makeMigration {
-            applicationDAO.getApplicationById(it)?.name
+            intentDAO.getIntentById(it)?.namespace
         }
     }
 
@@ -181,6 +181,7 @@ object FaqAdminService {
             FaqDefinition(
                 _id = existingFaq._id,
                 botId = existingFaq.botId,
+                namespace = existingFaq.namespace,
                 intentId = existingFaq.intentId,
                 i18nId = existingFaq.i18nId,
                 tags = query.tags,
@@ -193,6 +194,7 @@ object FaqAdminService {
             FaqDefinition(
                 botId = application.name,
                 intentId = intent._id,
+                namespace = application.namespace,
                 i18nId = i18nLabel._id,
                 tags = query.tags,
                 enabled = query.enabled,

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
@@ -112,6 +112,7 @@ class FaqAdminServiceSettingsTest : AbstractTest() {
         return FaqDefinition(
             _id = faqId.toId(),
             "botId",
+            namespace,
             intentId = intent._id,
             i18nId = "i18nId-$faqId".toId(),
             emptyList(), true, Instant.now(), Instant.now()

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
@@ -128,7 +128,7 @@ class FaqAdminServiceTest : AbstractTest() {
 
         private const val userLogin: UserLogin = "userLogin"
 
-        private val faqDefinition = FaqDefinition(faqId, botId, intentId, i18nId, tagList, true, now, now)
+        private val faqDefinition = FaqDefinition(faqId, botId, namespace, intentId, i18nId, tagList, true, now, now)
 
         val applicationDefinition =
             ApplicationDefinition(botId, namespace = namespace, supportedLocales = setOf(Locale.FRENCH))
@@ -362,7 +362,7 @@ class FaqAdminServiceTest : AbstractTest() {
                 fun `GIVEN save faq WHEN and saving the same story THEN update the story`() {
                     val faqAdminService = spyk<FaqAdminService>(recordPrivateCalls = true)
                     val savedFaqDefinition =
-                        FaqDefinition(faqId, botId, intentId, i18nId, listOf("NEW TAG"), true, now, now)
+                        FaqDefinition(faqId, botId, namespace, intentId, i18nId, listOf("NEW TAG"), true, now, now)
 
                     every {
                         faqAdminService["createOrUpdateFaqIntent"](
@@ -699,6 +699,7 @@ class FaqAdminServiceTest : AbstractTest() {
             val existingFaqSharedIntentDefinition = FaqDefinition(
                 faqId2,
                 OTHER_APP_NAME,
+                namespace,
                 intentId,
                 i18nId,
                 existingSecondBotFaqSharedIntentRequest.tags,
@@ -790,6 +791,7 @@ class FaqAdminServiceTest : AbstractTest() {
             val existingFaqSharedIntentDefinition = FaqDefinition(
                 faqId2,
                 OTHER_APP_NAME,
+                namespace,
                 intentId,
                 i18nId,
                 existingSecondBotFaqSharedIntentRequest.tags,
@@ -1195,6 +1197,7 @@ class FaqAdminServiceTest : AbstractTest() {
             return FaqQueryResult(
                 faqId,
                 botId,
+                namespace,
                 intentId,
                 i18nId,
                 tagList,

--- a/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
+++ b/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
@@ -51,6 +51,7 @@ import ai.tock.shared.provide
 import ai.tock.shared.security.TockObfuscatorService.obfuscate
 import ai.tock.shared.supportedLanguages
 import ai.tock.shared.withoutNamespace
+import ai.tock.translator.I18nLabel
 import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
@@ -297,11 +298,15 @@ internal object ApplicationCodecService : ApplicationCodec {
                 val intentDB = config.getIntentByNamespaceAndName(namespace, intentDump.name)!!
                 val faq = config.getFaqDefinitionByIntentId(intentDB._id)
                 if(faq == null) {
+                    // update i18nId namespace for import current namespace
+                    val i18nOldNamespace = it.i18nId.namespace()
+                    val newI18nId = it.i18nId.toString().replaceFirst(i18nOldNamespace,namespace)
                     val newFaq = it.copy(
                         _id = newId(),
                         botId =  botId,
                         namespace = namespace,
-                        intentId = intentDB._id
+                        intentId = intentDB._id,
+                        i18nId = newI18nId.toId()
                     )
                     report.add(newFaq)
                     config.save(newFaq)
@@ -325,6 +330,11 @@ internal object ApplicationCodecService : ApplicationCodec {
 
         return report
     }
+
+    /**
+     * Retrieve namespace from i18nLabel
+     */
+    fun Id<I18nLabel>.namespace() : String = this.toString().substringBefore('_')
 
     override fun importSentences(namespace: String, dump: SentencesDump): ImportReport {
         logger.info { "Import Sentences dump..." }

--- a/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
+++ b/nlp/front/service/src/main/kotlin/ApplicationCodecService.kt
@@ -300,6 +300,7 @@ internal object ApplicationCodecService : ApplicationCodec {
                     val newFaq = it.copy(
                         _id = newId(),
                         botId =  botId,
+                        namespace = namespace,
                         intentId = intentDB._id
                     )
                     report.add(newFaq)

--- a/nlp/front/service/src/main/kotlin/ApplicationConfigurationService.kt
+++ b/nlp/front/service/src/main/kotlin/ApplicationConfigurationService.kt
@@ -99,7 +99,8 @@ object ApplicationConfigurationService :
         intentDAO.getIntentsByApplicationId(id).forEach { intent ->
             removeIntentFromApplication(app, intent._id)
         }
-        faqDefinitionDAO.deleteFaqDefinitionByBotId(app.name)
+
+        faqDefinitionDAO.deleteFaqDefinitionByBotIdAndNamespace(app.name, app.namespace)
         applicationDAO.deleteApplicationById(id)
     }
 

--- a/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
+++ b/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
@@ -75,7 +75,7 @@ interface FaqDefinitionDAO {
 
     /**
      * Make migration
-     * @param botIdSupplier : function that return a string (the botId) with a given Id<>
+     * @param intentIdSupplier : function that return a string (the botId) with a given Id<>
      */
-    fun makeMigration(botIdSupplier: (Id<ApplicationDefinition>) -> String?)
+    fun makeMigration(intentIdSupplier: (Id<IntentDefinition>) -> String?)
 }

--- a/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
+++ b/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
@@ -28,7 +28,11 @@ interface FaqDefinitionDAO {
 
     fun deleteFaqDefinitionById(id: Id<FaqDefinition>)
 
-    fun deleteFaqDefinitionByBotId(id: String)
+    /**
+     * Delete the FaqDefinition by filtering on the application [id][ApplicationDefinition]
+     * @param id the application name [ApplicationDefinition]
+     */
+    fun deleteFaqDefinitionByBotIdAndNamespace(id: String, namespace: String)
 
     fun save(faqDefinition: FaqDefinition)
 

--- a/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
+++ b/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
@@ -79,7 +79,7 @@ interface FaqDefinitionDAO {
 
     /**
      * Make migration
-     * @param intentIdSupplier : function that return a string (the botId) with a given Id<>
+     * @param intentIdSupplier : function that return a namespace with a given Id<>
      */
     fun makeMigration(intentIdSupplier: (Id<IntentDefinition>) -> String?)
 }

--- a/nlp/front/shared/src/main/kotlin/config/FaqDefinition.kt
+++ b/nlp/front/shared/src/main/kotlin/config/FaqDefinition.kt
@@ -24,7 +24,7 @@ import java.time.Instant
 data class FaqDefinition(
 
     /**
-     * The unique [Id] of the intent.
+     * The unique [Id] of the faq.
      */
     val _id: Id<FaqDefinition> = newId(),
 
@@ -32,6 +32,11 @@ data class FaqDefinition(
      * The bot id (that corresponds to the application name).
      */
     val botId: String,
+
+    /**
+     * The bot namespace
+     */
+    val namespace: String,
 
     /**
      * The intent id.

--- a/nlp/front/shared/src/main/kotlin/config/FaqDefinitionDetailed.kt
+++ b/nlp/front/shared/src/main/kotlin/config/FaqDefinitionDetailed.kt
@@ -25,7 +25,7 @@ import java.time.Instant
  */
 data class FaqDefinitionDetailed(
     /**
-     * The unique [Id] of the intent.
+     * The unique [Id] of the faq.
      */
     val _id: Id<FaqDefinition>?,
 
@@ -33,6 +33,11 @@ data class FaqDefinitionDetailed(
      * The bot id (that corresponds to the application name).
      */
     val botId: String,
+
+    /**
+     * The bot namespace
+     */
+    val namespace: String,
 
     /**
      * The intent id.

--- a/nlp/front/shared/src/main/kotlin/config/FaqQueryResult.kt
+++ b/nlp/front/shared/src/main/kotlin/config/FaqQueryResult.kt
@@ -25,7 +25,7 @@ import java.time.Instant
  */
 data class FaqQueryResult(
     /**
-     * The unique [Id] of the intent.
+     * The unique [Id] of the faq.
      */
     val _id: Id<FaqDefinition>?,
 
@@ -33,6 +33,11 @@ data class FaqQueryResult(
      * The bot id (that corresponds to the application name).
      */
     val botId: String,
+
+    /**
+     * The bot namespace
+     */
+    val namespace: String,
 
     /**
      * The intent id.
@@ -87,6 +92,7 @@ data class FaqQueryResult(
         return FaqDefinitionDetailed(
             faqQueryResult._id,
             faqQueryResult.botId,
+            faqQueryResult.namespace,
             faqQueryResult.intentId,
             faqQueryResult.i18nId,
             faqQueryResult.tags,

--- a/nlp/front/shared/src/main/kotlin/config/FaqQueryResult.kt
+++ b/nlp/front/shared/src/main/kotlin/config/FaqQueryResult.kt
@@ -22,6 +22,7 @@ import java.time.Instant
 
 /**
  * Faq result after queried
+ * Please note when updating the model, consider to update the group pipeline result in [FaqDefintionMongoDAO] in DocumentDb Mode
  */
 data class FaqQueryResult(
     /**

--- a/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
@@ -16,7 +16,6 @@
 
 package ai.tock.nlp.front.storage.mongo
 
-import ai.tock.nlp.front.service.faqDefinitionDAO
 import ai.tock.nlp.front.service.storage.FaqDefinitionDAO
 import ai.tock.nlp.front.shared.config.ApplicationDefinition
 import ai.tock.nlp.front.shared.config.Classification
@@ -29,7 +28,6 @@ import ai.tock.nlp.front.shared.config.FaqQueryResult
 import ai.tock.nlp.front.shared.config.IntentDefinition
 import ai.tock.shared.ensureIndex
 import ai.tock.shared.isDocumentDB
-import ai.tock.shared.vertx.BadRequestException
 import ai.tock.shared.watch
 import ai.tock.translator.I18nLabel
 import com.mongodb.client.MongoCollection

--- a/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
@@ -16,7 +16,9 @@
 
 package ai.tock.nlp.front.storage.mongo
 
+import ai.tock.nlp.front.service.faqDefinitionDAO
 import ai.tock.nlp.front.service.storage.FaqDefinitionDAO
+import ai.tock.nlp.front.shared.config.ApplicationDefinition
 import ai.tock.nlp.front.shared.config.Classification
 import ai.tock.nlp.front.shared.config.ClassifiedSentence
 import ai.tock.nlp.front.shared.config.ClassifiedSentenceStatus
@@ -25,9 +27,9 @@ import ai.tock.nlp.front.shared.config.FaqDefinitionTag
 import ai.tock.nlp.front.shared.config.FaqQuery
 import ai.tock.nlp.front.shared.config.FaqQueryResult
 import ai.tock.nlp.front.shared.config.IntentDefinition
-import ai.tock.nlp.front.shared.config.ApplicationDefinition
 import ai.tock.shared.ensureIndex
 import ai.tock.shared.isDocumentDB
+import ai.tock.shared.vertx.BadRequestException
 import ai.tock.shared.watch
 import ai.tock.translator.I18nLabel
 import com.mongodb.client.MongoCollection
@@ -47,11 +49,9 @@ import org.litote.kmongo.descending
 import org.litote.kmongo.div
 import org.litote.kmongo.document
 import org.litote.kmongo.ensureUniqueIndex
-import org.litote.kmongo.newId
-import org.litote.kmongo.exists
-import org.litote.kmongo.save
 import org.litote.kmongo.eq
 import org.litote.kmongo.excludeId
+import org.litote.kmongo.exists
 import org.litote.kmongo.expr
 import org.litote.kmongo.findOne
 import org.litote.kmongo.findOneById
@@ -65,11 +65,13 @@ import org.litote.kmongo.limit
 import org.litote.kmongo.lookup
 import org.litote.kmongo.match
 import org.litote.kmongo.ne
+import org.litote.kmongo.newId
 import org.litote.kmongo.or
 import org.litote.kmongo.project
 import org.litote.kmongo.reactivestreams.getCollection
 import org.litote.kmongo.regex
 import org.litote.kmongo.replaceOneWithFilter
+import org.litote.kmongo.save
 import org.litote.kmongo.skip
 import org.litote.kmongo.sort
 import org.litote.kmongo.unwind
@@ -108,8 +110,8 @@ object FaqDefinitionMongoDAO : FaqDefinitionDAO {
         col.deleteOneById(id)
     }
 
-    override fun deleteFaqDefinitionByBotId(id: String) {
-        col.deleteMany(FaqDefinition::botId eq id)
+    override fun deleteFaqDefinitionByBotIdAndNamespace(id: String, namespace: String) {
+        col.deleteMany(and(FaqDefinition::botId eq id, FaqDefinition::namespace eq namespace))
     }
 
     override fun getFaqDefinitionById(id: Id<FaqDefinition>): FaqDefinition? {
@@ -234,8 +236,8 @@ object FaqDefinitionMongoDAO : FaqDefinitionDAO {
             thread(true) {
 
                 with(projection) {
-                    logger.info { "Migrate FaqDefinition with namespace ${FaqDefinition::namespace} and intendId $intentId" }
 
+                   logger.info { "Migrate FaqDefinition ${projection._id} with namespace "}
                     val namespace = intentIdSupplier.invoke(intentId)
                         ?: throw Exception("Fail to migrate Faq with intent $intentId  due to namespace not found with id $intentId")
 

--- a/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
+++ b/nlp/front/storage-mongo/src/main/kotlin/FaqDefinitionMongoDAO.kt
@@ -418,6 +418,7 @@ object FaqDefinitionMongoDAO : FaqDefinitionDAO {
             listOf(
                 FaqQueryResult::botId first FaqQueryResult::botId,
                 FaqQueryResult::intentId first FaqQueryResult::intentId,
+                FaqQueryResult::namespace first FaqQueryResult::namespace,
                 FaqQueryResult::i18nId first FaqQueryResult::i18nId,
                 FaqQueryResult::tags first FaqQueryResult::tags,
                 FaqQueryResult::enabled first FaqQueryResult::enabled,

--- a/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
+++ b/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
@@ -74,9 +74,9 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
 
     private val mockedApplicationDefinition = ApplicationDefinition(_id= applicationId, name = botId,label=botId, namespace = namespace)
 
-    private val faqDefinition = FaqDefinition(faqId, botId, intentId, i18nId, tagList, true, now, now)
-    private val faq2Definition = FaqDefinition(faqId2,  botId, intentId2, i18nId2, tagList, true, now, now)
-    private val faq3Definition = FaqDefinition(faqId3,botId2, intentId3, i18nId3, tagList, true, now, now)
+    private val faqDefinition = FaqDefinition(faqId, botId, namespace, intentId, i18nId, tagList, true, now, now)
+    private val faq2Definition = FaqDefinition(faqId2,  botId,namespace, intentId2, i18nId2, tagList, true, now, now)
+    private val faq3Definition = FaqDefinition(faqId3,botId2,namespace, intentId3, i18nId3, tagList, true, now, now)
 
     private val col: MongoCollection<FaqDefinition> by lazy { FaqDefinitionMongoDAO.col }
 
@@ -195,6 +195,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
             FaqDefinition(
                 faqId2,
                 botId,
+                namespace,
                 intentId2,
                 i18nId2,
                 tagList2,
@@ -212,6 +213,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
             FaqDefinition(
                 faqId3,
                 botId,
+                namespace,
                 intentId3,
                 i18nId3,
                 tagList3,
@@ -271,6 +273,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
             FaqDefinition(
                 faqId3,
                 botId,
+                namespace,
                 intentId3,
                 i18nId,
                 otherTagList,
@@ -613,7 +616,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
     ): FaqDefinition {
 
         val faqDefinition =
-            FaqDefinition(faqId,  botId, intentId, i18nId, tagList, enabled, instant, instant)
+            FaqDefinition(faqId,  botId, namespace, intentId, i18nId, tagList, enabled, instant, instant)
 
         val createdIntent = IntentDefinition(
             faqName,

--- a/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
+++ b/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
@@ -243,7 +243,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
 
         assertEquals(2, faqDefinitionDao.getFaqDefinitionByBotId(botId1).size)
 
-        faqDefinitionDao.deleteFaqDefinitionByBotId(botId1)
+        faqDefinitionDao.deleteFaqDefinitionByBotIdAndNamespace(botId1,namespace)
 
         assertEquals(0, faqDefinitionDao.getFaqDefinitionByBotId(botId1).size)
         assertEquals(1, faqDefinitionDao.getFaqDefinitionByBotId(botId2).size)

--- a/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
+++ b/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
@@ -542,17 +542,57 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
             message = "There should be three faq"
         )
 
+        //The last faq in the search list should be the first created because of the creation date order
         assertEquals(
             //compare list of faq
             searchFound.first.last()._id,
             firstFaq._id,
             "The last faq in the list should be the first created because of the creation date order"
         )
+
+        assertEquals(
+            searchFound.first.last().botId,
+            firstFaq.botId,
+            "botId is different than expected"
+        )
+
+        assertEquals(
+            searchFound.first.last().intentId,
+            firstFaq.intentId,
+            "intentId is different than expected"
+        )
+
+        assertEquals(
+            searchFound.first.last().namespace,
+            firstFaq.namespace,
+            "namespace is different than expected"
+        )
+
+        //The first faq in the list should be the last created because of the creation date order
         assertEquals(
             searchFound.first.first()._id,
             lastFaq._id,
             "The first faq in the list should be the last created because of the creation date order"
         )
+
+        assertEquals(
+            searchFound.first.first().intentId,
+            lastFaq.intentId,
+            "intentId is different than expected"
+        )
+
+        assertEquals(
+            searchFound.first.first().botId,
+            lastFaq.botId,
+            "The first faq in the list should be the last created because of the creation date order"
+        )
+
+        assertEquals(
+            searchFound.first.first().namespace,
+            lastFaq.namespace,
+            "namespace is different than expected"
+        )
+
     }
 
     private fun `A faqDefinition search with empty utterance`() {


### PR DESCRIPTION
- update faq import to manage i18nIds on expected import namespace
- add namespace parameter on FaqDefinition in database and DTOs
- update deletion request to delete with a filter on botId (applicationName) and namespace
- update migration faq request when using `tock_faq_migration_enabled` to new model