### PR TITLE
fix #1556 web_connector: add metadata to SSE messages

### DIFF
--- a/bot/connector-web/src/main/kotlin/WebConnectorCallback.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnectorCallback.kt
@@ -44,11 +44,15 @@ internal class WebConnectorCallback(
         this.metadata[metadata.type] = metadata.value
     }
 
+    fun createResponse(actions: List<Action>): WebConnectorResponse {
+        val messages = actions.mapNotNull(messageProcessor::process)
+        return WebConnectorResponse(messages, metadata)
+    }
+
     fun sendResponse() {
         WebRequestInfosByEvent.invalidate(eventId)
-        val messages = actions.mapNotNull(messageProcessor::process)
         context.response()
             .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-            .end(webMapper.writeValueAsString(WebConnectorResponse(messages, metadata)))
+            .end(webMapper.writeValueAsString(createResponse(actions)))
     }
 }

--- a/bot/connector-web/src/main/kotlin/channel/Channels.kt
+++ b/bot/connector-web/src/main/kotlin/channel/Channels.kt
@@ -16,13 +16,12 @@
 package ai.tock.bot.connector.web.channel
 
 import ai.tock.bot.connector.web.WebConnectorResponse
-import ai.tock.bot.connector.web.WebMessageProcessor
-import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.user.PlayerId
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
-internal class Channels(private val channelDAO: ChannelDAO, private val messageProcessor: WebMessageProcessor) {
+internal class Channels(private val channelDAO: ChannelDAO) {
 
     private val channelsByUser = ConcurrentHashMap<String, CopyOnWriteArrayList<Channel>>()
 
@@ -51,8 +50,7 @@ internal class Channels(private val channelDAO: ChannelDAO, private val messageP
         }
     }
 
-    fun send(action: Action) {
-        val messages = listOfNotNull(messageProcessor.process(action))
-        channelDAO.save(ChannelEvent(action.applicationId, action.recipientId.id, WebConnectorResponse(messages)))
+    fun send(applicationId: String, recipientId: PlayerId, response: WebConnectorResponse) {
+        channelDAO.save(ChannelEvent(applicationId, recipientId.id, response))
     }
 }


### PR DESCRIPTION
This PR fixes #1556 by delegating the message creation to the web connector callback, which in turn appends metadata to each message.

I also took the opportunity to clean up usage of the deprecated `CorsHandler.create(pattern)` Vert.x API (this change should not have any visible effect).
