### PR TITLE
fix #1557 web_connector: retry sending messages after SSE disconnection

### DIFF
--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -141,6 +141,12 @@ This feature can be enabled by setting the `tock_web_sse` optional property to `
 When SSE is enabled, bot answers will be sent both as POST responses and as new events in the event stream -
 the [tock-react-kit](https://github.com/theopenconversationkit/tock-react-kit#sse) is configured to ignore the former
 while it is listening to server-sent events.
+This is typically useful in scenarios where the bot has to perform
+web API calls or expensive computations between messages of a single response,
+as it allows users to see the first messages immediately.
+
+Additionally, the web connector persists messages that fail to send immediately through the SSE stream,
+and attempts to send them if and when the SSE connection is re-established.
 
 The `tock_web_sse_keepalive_delay` optional property can be used to configure the number of seconds between
 two SSE pings (default: 10).

--- a/bot/connector-web/src/main/kotlin/Ioc.kt
+++ b/bot/connector-web/src/main/kotlin/Ioc.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.connector.web
+
+import ai.tock.bot.connector.web.channel.ChannelDAO
+import ai.tock.bot.connector.web.channel.ChannelMongoDAO
+import ai.tock.shared.service.BotAdditionalModulesService
+import com.github.salomonbrys.kodein.Kodein
+import com.github.salomonbrys.kodein.bind
+import com.github.salomonbrys.kodein.singleton
+
+val webConnectorModule = Kodein.Module {
+    bind<ChannelDAO>() with singleton { ChannelMongoDAO }
+}
+
+// used in file META-INF/services/ai.tock.shared.service.BotAdditionalModulesService
+class IOCModulesService : BotAdditionalModulesService {
+    override fun modules() = setOf(webConnectorModule)
+}

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -112,7 +112,7 @@ class WebConnector internal constructor(
             // Fallback to previous property name for backward compatibility
             ?: propertyOrNull("allow_markdown").toBoolean()
         )
-        private val channels by lazy { Channels(ChannelMongoDAO) }
+        private val channels by lazy { Channels() }
     }
 
     private val executor: Executor get() = injector.provide()

--- a/bot/connector-web/src/main/kotlin/channel/ChannelDAO.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelDAO.kt
@@ -16,6 +16,7 @@
 package ai.tock.bot.connector.web.channel
 
 internal interface ChannelDAO {
-    fun listenChanges(listener: (channelEvent: ChannelEvent) -> Unit)
+    fun listenChanges(listener: ChannelEvent.Handler)
+    fun handleMissedEvents(appId: String, recipientId: String, handler: ChannelEvent.Handler)
     fun save(channelEvent: ChannelEvent)
 }

--- a/bot/connector-web/src/main/kotlin/channel/ChannelEvent.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelEvent.kt
@@ -16,9 +16,32 @@
 package ai.tock.bot.connector.web.channel
 
 import ai.tock.bot.connector.web.WebConnectorResponse
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.Instant
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
 
+/**
+ *  Event that will be retrieved by the bot and sent to the recipient if SSE is activated
+ */
 internal data class ChannelEvent(
     val appId: String = "unknown",
     val recipientId: String,
-    val webConnectorResponse: WebConnectorResponse
-)
+    val webConnectorResponse: WebConnectorResponse,
+    val status: Status = Status.ENQUEUED,
+    val enqueuedAt: Instant = Instant.now(),
+    val _id: Id<ChannelEvent> = newId(),
+) {
+    enum class Status(@JsonValue val id: Int) {
+        /* Capped MongoDB collections cannot update a document's size after insertion.
+           Therefore, we have to serialize this enum as a fixed-size value */
+        ENQUEUED(0), PROCESSED(1)
+    }
+
+    fun interface Handler {
+        /**
+         * @return `true` if the event has been handled successfully
+         */
+        operator fun invoke(event: ChannelEvent): Boolean
+    }
+}

--- a/bot/connector-web/src/main/resources/META-INF/services/ai.tock.shared.service.BotAdditionalModulesService
+++ b/bot/connector-web/src/main/resources/META-INF/services/ai.tock.shared.service.BotAdditionalModulesService
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-ai.tock.bot.connector.web.WebConnectorProviderService
+ai.tock.bot.connector.web.IOCModulesService

--- a/bot/connector-web/src/main/resources/META-INF/services/org.litote.jackson.JacksonModuleServiceLoader
+++ b/bot/connector-web/src/main/resources/META-INF/services/org.litote.jackson.JacksonModuleServiceLoader
@@ -14,20 +14,4 @@
 # limitations under the License.
 #
 
-#
-# Copyright (C) 2017/2021 e-voyageurs technologies
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 ai.tock.bot.connector.web.WebOrchestrationJacksonModuleServiceLoader

--- a/bot/connector-web/src/test/kotlin/ChannelsTest.kt
+++ b/bot/connector-web/src/test/kotlin/ChannelsTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ai.tock.bot.connector.web.WebConnectorResponse
+import ai.tock.bot.connector.web.WebMessage
+import ai.tock.bot.connector.web.channel.ChannelDAO
+import ai.tock.bot.connector.web.channel.ChannelEvent
+import ai.tock.bot.connector.web.channel.Channels
+import ai.tock.shared.injector
+import com.github.salomonbrys.kodein.Kodein
+import com.github.salomonbrys.kodein.bind
+import com.github.salomonbrys.kodein.singleton
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+
+internal class ChannelsTest {
+    private val channelDaoMock: ChannelDAO = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        injector.inject(Kodein {
+            bind<ChannelDAO>() with singleton { channelDaoMock }
+        })
+    }
+
+    @Test
+    fun `Channels process both missed and new events`() {
+        val listenerSlot = slot<ChannelEvent.Handler>()
+        val appId = "my-app"
+        val recipientId = "user1"
+        val expectedMissedResponses = listOf(
+            WebConnectorResponse(listOf(WebMessage("Hello, are you still there?"))),
+            WebConnectorResponse(listOf(WebMessage("I think the connection broke")))
+        )
+        val expectedNewResponses = listOf(
+            WebConnectorResponse(listOf(WebMessage("Welcome back")))
+        )
+        every { channelDaoMock.listenChanges(capture(listenerSlot)) } just runs
+        every { channelDaoMock.handleMissedEvents(appId, recipientId, any()) } answers {
+            val handler = thirdArg<ChannelEvent.Handler>()
+            expectedMissedResponses.forEach {
+                handler(ChannelEvent(appId, recipientId, it))
+            }
+        }
+        val channels = Channels()
+        val responses = mutableListOf<WebConnectorResponse>()
+        channels.register(appId, recipientId) {
+            responses.add(it)
+        }
+        assertEquals(expectedMissedResponses, responses)
+        expectedNewResponses.forEach {
+            listenerSlot.captured.invoke(ChannelEvent(appId, recipientId, it))
+        }
+        assertEquals(expectedMissedResponses + expectedNewResponses, responses)
+    }
+}


### PR DESCRIPTION
This PR resolves #1557 by adding a MongoDB query whenever a new SSE connection is established to handle any unprocessed message for the recipient. Since the `ChannelEvent` collection is [capped](https://www.mongodb.com/docs/manual/core/capped-collections/), it is not possible to delete event documents or change their size once inserted. Therefore, events are marked as processed using a `status` field, modeled by an enum but stored as an `int32` in the database.

## Sequence diagrams (with pseudocode)

### SSE (re-)connection
```mermaid
sequenceDiagram
    participant UA as User Agent
    participant TOCK as TOCK Backend
    participant DB as Database
    UA->>TOCK: Connection
    TOCK->>DB: events.find(status=ENQUEUED)
    opt has missed events
      DB-->>TOCK: List[ChannelEvent(_id, message)]
      loop each event
        TOCK->>UA: message
        TOCK->>DB: events.update(_id, status=PROCESSED)
      end
    end
```

### Message sending
```mermaid
sequenceDiagram
    participant UA as User Agent
    participant TOCK as TOCK Backend
    participant DB as Database
    TOCK-)DB: events.insert(message, status=ENQUEUED)
    DB->>TOCK: ChannelEvent(_id, message)
    opt connection alive
      TOCK->>UA: message
      TOCK->>DB: events.update(_id, status=PROCESSED)
    end
```

### Example flow
```mermaid
sequenceDiagram
    participant UA as User Agent
    participant TOCK as TOCK Backend
    participant DB as Database
    rect rgb(162, 155, 254)
    note right of UA: First connection
    UA->>TOCK: connection
    TOCK->>DB: events.find(status=ENQUEUED)
    DB-->>TOCK: <no missed events>
    end
    rect rgb(0, 184, 148)
    note right of UA: successful message
    TOCK-)DB: events.insert("First message", status=ENQUEUED)
    DB->>TOCK: ChannelEvent(24, "First message")
    TOCK->>UA: "First message"
    TOCK->>DB: events.update(24, status=PROCESSED)
    end
    rect rgb(255, 118, 117)
    note right of UA: failed message
    TOCK-)DB: events.insert("Second message", status=ENQUEUED)
    UA->>TOCK: Disconnection
    DB->>TOCK: ChannelEvent(42, "Second message")
    TOCK-xUA: "Second message"
    end
    rect rgb(162, 155, 254)
    note right of UA: Second connection
    UA->>TOCK: connection
    TOCK->>DB: events.find(status=ENQUEUED)
    DB-->>TOCK: [Event(42, "Second message")]
    TOCK->>UA: "Second message"
    TOCK->>DB: events.update(42, status=PROCESSED)
    end
```

## Cleanup

I took the opportunity to refactor `ChannelDAO` to use dependency injection, as implemented in the rest of the project. I also cleaned up duplicate license headers in service declaration files, and made the `collectionName` constant into a proper `const`.

## Backward compatibility

Event documents that were inserted before this update have an undefined `status`, and are therefore not selected by the "missed events" query.


## Future improvements

Once MongoDB adds TTL indexes to capped collections ([relevant issue](https://jira.mongodb.org/browse/SERVER-77586)), we should add one to the `ChannelEvent` collection to ensure events are not kept for too long (especially since they are susceptible to holding personal data based on the chatbot). The `enqueuedAt` field has been added in this PR to help this future endeavor.