### PR TITLE
fix #1562 web_connector: add a response ID metadata field

### DIFF
--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -70,9 +70,9 @@ import io.vertx.core.http.HttpServerResponse
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.RoutingContext
 import io.vertx.ext.web.handler.CorsHandler
-import mu.KotlinLogging
 import java.time.Duration
 import java.util.UUID
+import mu.KotlinLogging
 
 internal const val WEB_CONNECTOR_ID = "web"
 
@@ -262,8 +262,12 @@ class WebConnector internal constructor(
                 context = context,
                 webMapper = webMapper,
                 eventId = event.id.toString(),
-                messageProcessor = messageProcessor
+                messageProcessor = messageProcessor,
             )
+            if (sseEnabled) {
+                // Uniquely identify each response, so they can be reconciliated between SSE and POST
+                callback.addMetadata(MetadataEvent.responseId(UUID.randomUUID(), applicationId))
+            }
             controller.handle(
                 event,
                 ConnectorData(

--- a/bot/engine/src/main/kotlin/engine/event/MetadataEvent.kt
+++ b/bot/engine/src/main/kotlin/engine/event/MetadataEvent.kt
@@ -17,10 +17,13 @@
 package ai.tock.bot.engine.event
 
 import ai.tock.bot.definition.Intent
+import java.util.UUID
 
 class MetadataEvent(val type: String, val value: String, applicationId: String) : Event(applicationId) {
     companion object {
         fun intent(intent: Intent, applicationId: String) = MetadataEvent(INTENT_METADATA, intent.name, applicationId)
+        fun responseId(uuid: UUID, applicationId: String) = MetadataEvent(RESPONSE_ID_METADATA, uuid.toString(), applicationId)
         const val INTENT_METADATA = "INTENT"
+        const val RESPONSE_ID_METADATA = "RESPONSE_ID"
     }
 }


### PR DESCRIPTION
Fixes #1562 by adding a `RESPONSE_ID` field in the metadata of each message. Since this field is presumed to be only useful when SSE is enabled, it is only added in that mode.