### PR TITLE
resolve #1564 translator: update API to allow defaults for other locales

### DIFF
--- a/bot/engine-jackson/src/test/kotlin/I18nLabelValueSerializationTest.kt
+++ b/bot/engine-jackson/src/test/kotlin/I18nLabelValueSerializationTest.kt
@@ -19,8 +19,8 @@ package ai.tock.bot.jackson
 import ai.tock.shared.jackson.mapper
 import ai.tock.translator.I18nLabelValue
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
 
 class I18nLabelValueSerializationTest {
 
@@ -31,7 +31,7 @@ class I18nLabelValueSerializationTest {
         val json = mapper.writeValueAsString(value)
 
         assertEquals(
-            """{"key":"key","namespace":"namespace","category":"category","defaultLabel":"defaultLabel","args":[]}""",
+            """{"key":"key","namespace":"namespace","category":"category","defaultLabel":"defaultLabel","args":[], "localizedDefaults":[]}""",
             json
         )
 

--- a/bot/engine/src/main/kotlin/definition/StoryHandlerBase.kt
+++ b/bot/engine/src/main/kotlin/definition/StoryHandlerBase.kt
@@ -24,6 +24,7 @@ import ai.tock.shared.defaultNamespace
 import ai.tock.translator.I18nKeyProvider
 import ai.tock.translator.I18nKeyProvider.Companion.generateKey
 import ai.tock.translator.I18nLabelValue
+import ai.tock.translator.I18nLocalizedLabel
 import mu.KotlinLogging
 
 /**
@@ -201,13 +202,21 @@ abstract class StoryHandlerBase<out T : StoryHandlerDefinition>(
      * Gets an i18n label with the specified key. Current namespace is used for the categorization.
      */
     fun i18nKey(key: String, defaultLabel: CharSequence, vararg args: Any?): I18nLabelValue {
+        return i18nKey(key, defaultLabel, emptySet(), *args)
+    }
+
+    /**
+     * Gets an i18n label with the specified key and defaults. Current namespace is used for the categorization.
+     */
+    fun i18nKey(key: String, defaultLabel: CharSequence, defaultI18n: Set<I18nLocalizedLabel>, vararg args: Any?): I18nLabelValue {
         val category = i18nKeyCategory()
         return I18nLabelValue(
             key,
             i18nNamespace,
             category,
             defaultLabel,
-            args.toList()
+            args.toList(),
+            defaultI18n,
         )
     }
 

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -56,6 +56,7 @@ import ai.tock.shared.injector
 import ai.tock.shared.provide
 import ai.tock.translator.I18nKeyProvider
 import ai.tock.translator.I18nLabelValue
+import ai.tock.translator.I18nLocalizedLabel
 
 /**
  * Bus implementation for Tock integrated mode.
@@ -510,6 +511,22 @@ interface BotBus : Bus<BotBus> {
                     botDefinition.botId,
                     defaultLabel,
                     args.toList()
+                )
+        }
+
+    /**
+     * Gets an i18n label with the specified key and defaults.
+     */
+    fun i18nKey(key: String, defaultLabel: CharSequence, localizedDefaults: Set<I18nLocalizedLabel>, vararg args: Any?): I18nLabelValue =
+        story.definition.storyHandler.let {
+            (it as? StoryHandlerBase<*>)?.i18nKey(key, defaultLabel, localizedDefaults, *args)
+                ?: I18nLabelValue(
+                    key,
+                    botDefinition.namespace,
+                    botDefinition.botId,
+                    defaultLabel,
+                    args.toList(),
+                    localizedDefaults,
                 )
         }
 

--- a/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_.kt
+++ b/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_.kt
@@ -7,6 +7,7 @@ import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.Collection
 import kotlin.collections.Map
+import kotlin.collections.Set
 import kotlin.reflect.KProperty1
 import org.litote.kmongo.Id
 import org.litote.kmongo.property.KCollectionPropertyPath
@@ -26,6 +27,8 @@ private val __DefaultLabel: KProperty1<I18nLabel, String?>
     get() = I18nLabel::defaultLabel
 private val __DefaultLocale: KProperty1<I18nLabel, Locale?>
     get() = I18nLabel::defaultLocale
+private val __DefaultI18n: KProperty1<I18nLabel, Set<I18nLocalizedLabel>?>
+    get() = I18nLabel::defaultI18n
 private val __Version: KProperty1<I18nLabel, Int?>
     get() = I18nLabel::version
 class I18nLabel_<T>(previous: KPropertyPath<T, *>?, property: KProperty1<*, I18nLabel?>) :
@@ -48,6 +51,9 @@ class I18nLabel_<T>(previous: KPropertyPath<T, *>?, property: KProperty1<*, I18n
     val defaultLocale: KPropertyPath<T, Locale?>
         get() = KPropertyPath(this,__DefaultLocale)
 
+    val defaultI18n: KCollectionSimplePropertyPath<T, I18nLocalizedLabel?>
+        get() = KCollectionSimplePropertyPath(this,I18nLabel::defaultI18n)
+
     val version: KPropertyPath<T, Int?>
         get() = KPropertyPath(this,__Version)
 
@@ -64,6 +70,8 @@ class I18nLabel_<T>(previous: KPropertyPath<T, *>?, property: KProperty1<*, I18n
             get() = __DefaultLabel
         val DefaultLocale: KProperty1<I18nLabel, Locale?>
             get() = __DefaultLocale
+        val DefaultI18n: KCollectionSimplePropertyPath<I18nLabel, I18nLocalizedLabel?>
+            get() = KCollectionSimplePropertyPath(null, __DefaultI18n)
         val Version: KProperty1<I18nLabel, Int?>
             get() = __Version}
 }
@@ -88,6 +96,9 @@ class I18nLabel_Col<T>(previous: KPropertyPath<T, *>?, property: KProperty1<*,
 
     val defaultLocale: KPropertyPath<T, Locale?>
         get() = KPropertyPath(this,__DefaultLocale)
+
+    val defaultI18n: KCollectionSimplePropertyPath<T, I18nLocalizedLabel?>
+        get() = KCollectionSimplePropertyPath(this,I18nLabel::defaultI18n)
 
     val version: KPropertyPath<T, Int?>
         get() = KPropertyPath(this,__Version)
@@ -115,6 +126,9 @@ class I18nLabel_Map<T, K>(previous: KPropertyPath<T, *>?, property: KProperty1<*
 
     val defaultLocale: KPropertyPath<T, Locale?>
         get() = KPropertyPath(this,__DefaultLocale)
+
+    val defaultI18n: KCollectionSimplePropertyPath<T, I18nLocalizedLabel?>
+        get() = KCollectionSimplePropertyPath(this,I18nLabel::defaultI18n)
 
     val version: KPropertyPath<T, Int?>
         get() = KPropertyPath(this,__Version)

--- a/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_Deserializer.kt
+++ b/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_Deserializer.kt
@@ -11,6 +11,8 @@ import java.util.Locale
 import kotlin.Int
 import kotlin.String
 import kotlin.collections.Map
+import kotlin.collections.MutableSet
+import kotlin.collections.Set
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.findParameterByName
@@ -35,6 +37,8 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
             var _defaultLabel_set : Boolean = false
             var _defaultLocale_: Locale? = null
             var _defaultLocale_set : Boolean = false
+            var _defaultI18n_: MutableSet<I18nLocalizedLabel>? = null
+            var _defaultI18n_set : Boolean = false
             var _version_: Int? = null
             var _version_set : Boolean = false
             var _token_ : JsonToken? = currentToken
@@ -77,6 +81,11 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
                              else p.readValueAs(Locale::class.java);
                             _defaultLocale_set = true
                             }
+                    "defaultI18n" -> {
+                            _defaultI18n_ = if(_token_ == JsonToken.VALUE_NULL) null
+                             else p.readValueAs(_defaultI18n__reference);
+                            _defaultI18n_set = true
+                            }
                     "version" -> {
                             _version_ = if(_token_ == JsonToken.VALUE_NULL) null
                              else p.intValue;
@@ -91,10 +100,10 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
                 _token_ = currentToken
                         } 
             return if(__id_set && _namespace_set && _category_set && _i18n_set && _defaultLabel_set
-                    && _defaultLocale_set && _version_set)
+                    && _defaultLocale_set && _defaultI18n_set && _version_set)
                     I18nLabel(_id = __id_!!, namespace = _namespace_!!, category = _category_!!,
                             i18n = _i18n_!!, defaultLabel = _defaultLabel_, defaultLocale =
-                            _defaultLocale_!!, version = _version_!!)
+                            _defaultLocale_!!, defaultI18n = _defaultI18n_!!, version = _version_!!)
                     else {
                     val map = mutableMapOf<KParameter, Any?>()
                     if(__id_set)
@@ -109,6 +118,8 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
                     map[parameters.getValue("defaultLabel")] = _defaultLabel_
                     if(_defaultLocale_set)
                     map[parameters.getValue("defaultLocale")] = _defaultLocale_
+                    if(_defaultI18n_set)
+                    map[parameters.getValue("defaultI18n")] = _defaultI18n_
                     if(_version_set)
                     map[parameters.getValue("version")] = _version_ 
                     primaryConstructor.callBy(map) 
@@ -126,7 +137,8 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
                 primaryConstructor.findParameterByName("category")!!, "i18n" to
                 primaryConstructor.findParameterByName("i18n")!!, "defaultLabel" to
                 primaryConstructor.findParameterByName("defaultLabel")!!, "defaultLocale" to
-                primaryConstructor.findParameterByName("defaultLocale")!!, "version" to
+                primaryConstructor.findParameterByName("defaultLocale")!!, "defaultI18n" to
+                primaryConstructor.findParameterByName("defaultI18n")!!, "version" to
                 primaryConstructor.findParameterByName("version")!!) }
 
         private val __id__reference: TypeReference<Id<I18nLabel>> = object :
@@ -134,5 +146,8 @@ internal class I18nLabel_Deserializer : JsonDeserializer<I18nLabel>(), JacksonMo
 
         private val _i18n__reference: TypeReference<LinkedHashSet<I18nLocalizedLabel>> = object :
                 TypeReference<LinkedHashSet<I18nLocalizedLabel>>() {}
+
+        private val _defaultI18n__reference: TypeReference<Set<I18nLocalizedLabel>> = object :
+                TypeReference<Set<I18nLocalizedLabel>>() {}
     }
 }

--- a/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_Serializer.kt
+++ b/bot/storage-mongo/target/generated-sources/kapt/compile/ai/tock/translator/I18nLabel_Serializer.kt
@@ -44,6 +44,17 @@ internal class I18nLabel_Serializer : StdSerializer<I18nLabel>(I18nLabel::class.
         gen.writeFieldName("defaultLocale")
         val _defaultLocale_ = value.defaultLocale
         serializers.defaultSerializeValue(_defaultLocale_, gen)
+        gen.writeFieldName("defaultI18n")
+        val _defaultI18n_ = value.defaultI18n
+        serializers.findTypedValueSerializer(
+                serializers.config.typeFactory.constructCollectionType(
+                kotlin.collections.Set::class.java,
+                serializers.config.typeFactory.constructType(ai.tock.translator.I18nLocalizedLabel::class.java)
+                ),
+                true,
+                null
+                )
+                .serialize(_defaultI18n_, gen, serializers)
         gen.writeFieldName("version")
         val _version_ = value.version
         gen.writeNumber(_version_)

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -22,3 +22,6 @@ gem "github-pages", group: :jekyll_plugins
 group :jekyll_plugins do
   gem 'jekyll-optional-front-matter'
 end
+
+# Required to run jekyll 3 on latest Ruby (see https://talk.jekyllrb.com/t/load-error-cannot-load-such-file-webrick/5417/13)
+gem "webrick", "~> 1.8"

--- a/docs/_data/tocs/en.yml
+++ b/docs/_data/tocs/en.yml
@@ -13,6 +13,12 @@ content:
         url: 'en/build-nlp-model'
       - title: 'Monitor NLP models'
         url: 'en/evaluate-the-model'
+  - title: 'Use Tock'
+    children:
+      - title: 'Guides'
+        children:
+          - title: 'Multilingual bot'
+            url: 'en/user/guides/i18n'
   - title: 'Develop Stories'
     children:
       - title: 'Bot API mode'
@@ -25,6 +31,8 @@ content:
         url: 'en/kdoc'
       - title: 'Code Samples'
         url: 'en/the-open-data-bot'
+      - title: 'i18n'
+        url: 'en/dev/i18n'
       - title: 'API documentation'
         url: 'en/api'
   - title: 'About'

--- a/docs/_en/dev/i18n.md
+++ b/docs/_en/dev/i18n.md
@@ -1,0 +1,127 @@
+---
+title: i18n - développement
+---
+
+# Developing a multilingual bot (i18n)
+
+The [Multilingual bot](../user/guides/i18n) page in the user documentation covers the basics of internationalization
+(_i18n_) for building bots with Tock: prerequisites, _Locale_, etc.
+
+This page completes the documentation with elements specific to development.
+
+## Prerequisites
+
+To enable _Internationalization_ in Tock, programmatically or not, see [Multilingual bot](../user/guides/i18n).
+
+## Principles
+
+The code does not change once internationalization is activated. For example:
+
+```kotlin
+     send("Arrival at {0}", time)
+```
+
+is valid whether the module is enabled or not. 
+
+At runtime, however, behavior differs significantly.
+
+If internationalization is enabled, the following operations will be performed:
+
+1. A key will be generated from the text passed in parameter, according to the namespace (the bot creator's organization)
+   and the story in which the text is requested. In the case above, this should look like `app_arrivals_Arrival at {0}` where *app* is the namespace and
+   *arrivals* is the story's main intent.
+
+2. Tock then checks whether this key is already present in the database.
+    * If so, it uses the wording present in the database for the requested language to find the most appropriate translation (the connector or interface type may also be taken into account).
+    * If not, a key is created in base with the default label (`"Arrival at {0}"` in our example) used for the current language.
+      * If the passed in text is an `I18nLabelValue` object which `defaultI18n` field holds a value for the current language, the latter is used instead
+
+3. This label can then be viewed and modified in the administration interface:
+
+![Internationalisation](../../img/i18n.png "Internationalisation")
+
+## Message Format
+
+The supported format is that of i18n support in java, specifically the one from [MessageFormat](https://docs.oracle.com/javase/10/docs/api/java/text/MessageFormat.html)
+in java. This includes support for [ChoiceFormat](https://docs.oracle.com/javase/10/docs/api/java/text/ChoiceFormat.html) :
+
+```kotlin
+    send("There {0,choice,0#are no files|1#is one file|1<are {0,number,integer} files}.", 2)  
+```
+
+Tock also provides a *by* extension for dates, allowing you to specify a format in the parameters:
+
+```kotlin
+    send("Departure at {0}", departureDateTime by timeFormat) 
+``` 
+
+## User locale
+
+See [Multilingual bot](../user/guides/i18n).
+
+## Points of attention
+
+Tock's internationalization module is efficient, but certain practices, however intuitive in Kotlin,
+should be avoided, or you'll be in for a nasty surprise.
+
+For example, this code works perfectly well with the i18n module deactivated.
+
+```kotlin
+send("There are $nb files") //DANGER!
+```
+
+but causes problems when activated. A new label will be created for each different value of the *nb* variable!
+ 
+If you need to send "do not translate" responses, use the *BotBus.sendRaw*, *BotBus.endRaw* or *String.raw* methods.
+
+```kotlin
+    send("There are $nb files".raw) //CORRECT 
+``` 
+
+```kotlin
+    send("There are {0} files", nb) //FORMAT A SUIVRE 
+```  
+
+* The collision risk between two labels is small as the story's main intent is made part of the key. 
+If however you want to avoid any risk, you can use the *i18nKey* method:
+
+```kotlin
+    send(i18nKey("my_unique_key", "There are {0} files", nb)) 
+```  
+
+### Specifying several localizations
+
+Default values can be defined for several locales in a bot's code:
+
+```kotlin
+    send(i18nKey("departure", "Departure at {0}", setOf(I18nLocalizedLabel(Locale.FRENCH, textChat, "Départ à {0}")), nb))
+```
+
+By default, these default values will only be used when the key is used for the first time. To overwrite
+existing values (including those defined via TOCK Studio) when the default location is changed,
+set the configuration value `tock_i18n_reset_value_on_default_change` to `true` (either as an environment variable,
+or as a system property).
+
+## Test internationalization
+
+An example of a test device is available in the
+[example bot source code](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/rule)
+It is necessary to extend the [test extension](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/rule/OpenDataJUnitExtension.kt)
+and then specify the [label match](https://github.com/theopenconversationkit/tock-bot-open-data/tree/master/src/test/kotlin/rule/TranslatorEngineMock.kt) to be tested.
+
+All that remains is to indicate the desired locale:
+
+```kotlin
+
+    @Test
+    fun `search story asks for departure date WHEN there is a destination and an origin but no departure date in context`() {
+        ext.newRequest("Recherche", search, locale = Locale.FRENCH) {
+            destination = lille
+            origin = paris
+
+            run()
+
+            firstAnswer.assertText("Quand souhaitez-vous partir?")
+        }
+    }
+```  

--- a/docs/_en/toc.md
+++ b/docs/_en/toc.md
@@ -9,13 +9,16 @@ title: Table of Contents
 
 * [Table of contents](../toc)
 
-* Try Tock Studio :
+* Try Tock Studio:
     * [Create your first bot with _Tock Studio_](../guide/studio)
     * [Configure your bot for _Messenger_](../guide/messenger)
     * [Build NLP models](../build-nlp-model)
     * [Monitor NLP models](../evaluate-the-model)
     * [Reducing the scope of intentions](../guide/intents-restrictions)
 
+* Use Tock:
+  - Guides:
+    - [Create a multilingual bot (internationalisation)](../user/guides/i18n)
 
 * Develop Stories :
     * [Bot API mode](../dev/bot-api)

--- a/docs/_en/user/guides/i18n.md
+++ b/docs/_en/user/guides/i18n.md
@@ -1,0 +1,80 @@
+---
+title: i18n - guide
+---
+
+# Building a multilingual bot with Tock
+
+The _Tock Studio_ interface allows translating and customizing a bot's answers based not only on the language,
+but also on the connector used.
+
+
+## Prerequisites
+
+Tock provides a full internationalisation framework. It is enabled by default in _Bot API_ mode
+ (e.g. on the [demo platform](https://demo.tock.ai/)).
+
+In the _integrated bot_ mode (see the [dev guide](../../dev/modes)), internationalisation 
+is disabled by default. To enable it, you must configure the platform at launch :
+
+* Either through the bot's init code (developer side) :
+```kotlin
+    Translator.enabled = true
+```
+* Or through a configuration value (administrator side), as the added property ```-Dtock_i18n_enabled=true``` at JVM launch,
+    or as an environment variable `export tock_i18n_enabled=true`
+
+## Enabling multiple languages for a bot
+
+It is possible to add and configure a bot's active languages in the _NLU Applications_ section
+(in _Tock Studio_) - see _the Settings menu_.
+
+At any time in _Tock Studio_, it is possible to change the selected language in the banner at the top of the page.
+This is particularly useful when conversing with a bot in the _Test the bot_ interface.
+
+When possible, the user's _locale_ (language/region) is imported from their account.
+
+> For example, if a Messenger user's account is set to French, French will be automatically
+selected by Tock.
+
+If no locale is specified, Tock's default locale is used.
+
+A developer can change the user's locale in the bot code itself:
+
+```kotlin
+userPreferences.locale = Locale.FRENCH
+```  
+
+Finally, the default locale can be modified by a platform administrator, by passing the _System_ property 
+```-Dtock_default_locale=en``` at JVM startup.
+
+## Translate and vary bot responses
+
+In _Tock Studio_, the _Stories & Answers_ > _Answers_ section lets you manage the wording of bot answers. 
+See [_The Stories & Answers menu_](../../studio/stories-and-answers).
+
+Each label has a default value for each bot language. 
+Different variants can be designed and configured:
+
+* language-dependent
+* Channel/connector-dependent
+> For example, some channels require specific labels, either because the channel owner requires it 
+>(on Alexa, polite conversation is required), or because the user experience differs from other channels (for example 
+>in voice, avoid long sentences).
+* Randomly (so that the bot doesn't always answer the same thing)
+
+## Mass translation of templates and responses
+
+Functionalities are being considered to enable more or less automated translation of numerous user phrases
+(corpus / conversational model) and responses (labels / i18n). To be continued...
+
+For the time being, if mass translation is required, you may for example:
+
+1. Export data as JSON or CSV with _Tock Studio_.
+2. Translate sentences/answers outside Tock (SaaS API, agency...)
+3. Import translations with _Tock Studio_.
+
+> Note: when importing, only wordings marked _validated_ are taken into account.
+
+## Developing with internationalization
+
+The [Tock developer manual](../../dev/i18n) gives more details on developing multilingual bots.

--- a/docs/_fr/dev/i18n.md
+++ b/docs/_fr/dev/i18n.md
@@ -4,7 +4,7 @@ title: i18n - développement
 
 # Développer un bot multilingue (i18n)
 
-La page [Bot multilingue](../user/guides/i18n) de la documentation utilisateur présente les bases de l'internationalisation
+La page [Bot multilingue](../../user/guides/i18n) de la documentation utilisateur présente les bases de l'internationalisation
 (_i18n_) pour construire des bots avec Tock : pré-requis, _Locale_, etc.
 
 Cette page vient compléter cette documentation avec des éléments propres au développement. 
@@ -34,6 +34,7 @@ Si l'internationalisation est activée, les opérations suivantes vont être eff
 2. Tock vérifie ensuite si cette clé est déjà présente en base. 
     * Si c'est le cas, il utilise le libellé présent en base pour la langue demandée afin de trouver la traduction la plus appropriée (le connecteur ou le type d'interface peuvent également être pris en compte)
     * Sinon, une clé est créée en base avec le libellé par défaut ("Arrival at {0}" dans notre exemple) utilisée pour la langue courante
+      * Si le texte passé en paramètre est un objet `I18nLabelValue` dont le champ `defaultI18n` contient une valeur pour la langue courante, celle-ci sera utilisée
   
 3. Il est ensuite possible de consulter et de modifier ce libellé dans l'interface d'administration :   
   
@@ -89,12 +90,25 @@ Si vous souhaitez cependant éviter tout risque, vous pouvez utiliser la méthod
     send(i18nKey("my_unique_key", "There are {0} files", nb)) 
 ```  
 
+### Spécification de plusieurs localisations
+
+Il est possible de définir des valeurs par défaut pour plusieurs localisations dans le code d'un bot :
+
+```kotlin
+    send(i18nKey("departure", "Departure at {0}", setOf(I18nLocalizedLabel(Locale.FRENCH, textChat, "Départ à {0}")), nb))
+```
+
+Par défaut, ces valeurs par défaut ne seront utilisées que lorsque la clé est utilisée pour la première fois. Pour écraser
+les valeurs existantes (y compris celles définies via TOCK Studio) lorsque la localisation par défaut est changée,
+mettez la valeur de configuration `tock_i18n_reset_value_on_default_change` à `true` (soit en variable d'environnement,
+soit en propriété système).
+
 ## Tester l'internationalisation
 
 Un exemple de dispositif de test est disponible dans le
-[code source du bot d'exemple](https://github.com/theopenconversationkit/tock-bot-open-data/tree/master/src/test/kotlin/ai.tock/bot/open/data/rule)
-Il est nécessaire d'étendre [l'extension de test](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/ai.tock/bot/open/data/rule/OpenDataJUnitExtension.kt)
-pour ensuite indiquer la [correspondance des libellés](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/ai.tock/bot/open/data/rule/TranslatorEngineMock.kt) à tester.
+[code source du bot d'exemple](https://github.com/theopenconversationkit/tock-bot-open-data/tree/master/src/test/kotlin/rule)
+Il est nécessaire d'étendre [l'extension de test](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/rule/OpenDataJUnitExtension.kt)
+pour ensuite indiquer la [correspondance des libellés](https://github.com/theopenconversationkit/tock-bot-open-data/blob/master/src/test/kotlin/rule/TranslatorEngineMock.kt) à tester.
 
 Il ne reste plus qu'à indiquer la locale souhaitée : 
 

--- a/docs/_fr/user/guides/i18n.md
+++ b/docs/_fr/user/guides/i18n.md
@@ -78,4 +78,4 @@ Pour le moment, pour envisager une traduction de masse, on peut par exemple :
 
 ## Développer avec l'internationalisation
 
-Le [manuel développeur Tock](../../../dev/modes) donne plus de détails sur le développement des bots multilingues.
+Le [manuel développeur Tock](../../../dev/i18n) donne plus de détails sur le développement des bots multilingues.

--- a/translator/core/src/main/kotlin/I18nLabel.kt
+++ b/translator/core/src/main/kotlin/I18nLabel.kt
@@ -18,8 +18,8 @@ package ai.tock.translator
 
 import ai.tock.shared.defaultLocale
 import ai.tock.shared.defaultNamespace
-import org.litote.kmongo.Id
 import java.util.Locale
+import org.litote.kmongo.Id
 
 /**
  * The label persisted in database.
@@ -31,6 +31,7 @@ data class I18nLabel(
     val i18n: LinkedHashSet<I18nLocalizedLabel>,
     val defaultLabel: String? = null,
     val defaultLocale: Locale = findDefaultLabelLocale(defaultLabel, i18n),
+    val defaultI18n: Set<I18nLocalizedLabel> = emptySet(),
     val version: Int = 0
 ) {
 

--- a/translator/core/src/main/kotlin/I18nLabelValue.kt
+++ b/translator/core/src/main/kotlin/I18nLabelValue.kt
@@ -36,13 +36,19 @@ class I18nLabelValue constructor(
      */
     category: String,
     /**
-     * The default label if no translation is found.
+     * The fallback value if none is found for the requested locale and interface type.
+     *
+     * If a [TranslatorEngine] is configured, this default label will also be used for automated translation.
      */
     val defaultLabel: CharSequence,
     /**
      * The optional format pattern arguments.
      */
-    val args: List<Any?> = emptyList()
+    val args: List<Any?> = emptyList(),
+    /**
+     * Default values for various languages and interface types.
+     */
+    val defaultI18n: Set<I18nLocalizedLabel> = emptySet(),
 ) : CharSequence by defaultLabel {
 
     constructor(label: I18nLabel) :
@@ -83,6 +89,7 @@ class I18nLabelValue constructor(
         if (key != other.key) return false
         if (namespace != other.namespace) return false
         if (category != other.category) return false
+        if (defaultI18n != other.defaultI18n) return false
 
         return true
     }
@@ -93,6 +100,7 @@ class I18nLabelValue constructor(
         result = 31 * result + key.hashCode()
         result = 31 * result + namespace.hashCode()
         result = 31 * result + category.hashCode()
+        result = 31 * result + defaultI18n.hashCode()
         return result
     }
 }


### PR DESCRIPTION
Resolves #1564 by adding a set of default labels to the `I18nLabelValue` class. A new `tock_i18n_reset_value_on_default_change` property was also added to allow updating labels from the app's source.

I ended up storing the full set of default labels in the database rather than simply the hash, as I suspect in the future we may want to add some kind of "reset to default" feature in the TOCK Studio interface.

## Shortcomings

The code localization API is quite basic at the moment, so it could be a bit cumbersome to use in real apps.
Future efforts could focus on providing improvements in the form of e.g. a fluent builder API for the labels, or a `ResourceBundle` compatibility layer.

## Documentation Update

I updated the existing documentation to mention the new system property. I also took the opportunity to add an English version for the I18n articles.

Rendered version on my branch:
- French dev guide: https://fabilin.github.io/tock/fr/dev/i18n/
- English dev guide: https://fabilin.github.io/tock/en/dev/i18n/
- English user guide: https://fabilin.github.io/tock/en/user/guides/i18n/

When I tried testing locally on latest Ruby I also ran into [this issue](https://talk.jekyllrb.com/t/load-error-cannot-load-such-file-webrick/5417/2), so I applied the suggested fix of adding the webrick package. 