### PR TITLE
fix #1564 translator: fix test API when setting default localizations

### DIFF
--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -49,14 +49,15 @@ import ai.tock.shared.provide
 import ai.tock.translator.EMPTY_TRANSLATED_STRING
 import ai.tock.translator.I18nContext
 import ai.tock.translator.I18nKeyProvider
+import ai.tock.translator.I18nLabel
 import ai.tock.translator.I18nLabelValue
 import ai.tock.translator.TranslatedSequence
 import ai.tock.translator.Translator
 import ai.tock.translator.TranslatorEngine
 import ai.tock.translator.UserInterfaceType
 import ai.tock.translator.raw
-import mu.KotlinLogging
 import java.util.Locale
+import mu.KotlinLogging
 
 /**
  * A Bus mock used in unit tests.
@@ -439,11 +440,12 @@ open class BotBusMock(
     override fun translate(key: I18nLabelValue?): TranslatedSequence =
         if (key == null) EMPTY_TRANSLATED_STRING
         else Translator.formatMessage(
-            translator.translate(
-                key.defaultLabel.toString(),
-                defaultLocale,
-                userLocale
-            ),
+            I18nLabel.findLabel(key.defaultI18n, userLocale, userInterfaceType, targetConnectorType.id)?.label
+                ?: translator.translate(
+                    key.defaultLabel.toString(),
+                    defaultLocale,
+                    userLocale
+                ),
             I18nContext(
                 userLocale,
                 userInterfaceType,

--- a/translator/core/src/main/kotlin/I18nLabel.kt
+++ b/translator/core/src/main/kotlin/I18nLabel.kt
@@ -42,13 +42,16 @@ data class I18nLabel(
             } else {
                 i18n.firstOrNull { defaultLabel == it.label }?.locale ?: defaultLocale
             }
+
+        fun findLabel(i18n: Set<I18nLocalizedLabel>, locale: Locale, userInterfaceType: UserInterfaceType, connectorId: String?): I18nLocalizedLabel? =
+            i18n.firstOrNull { it.locale == locale && it.interfaceType == userInterfaceType && it.connectorId == connectorId }
+                ?: i18n.firstOrNull { it.locale == locale && it.interfaceType == userInterfaceType && it.connectorId == null }
+                ?: i18n.firstOrNull { it.locale.language == locale.language && it.interfaceType == userInterfaceType && it.connectorId == connectorId }
+                ?: i18n.firstOrNull { it.locale.language == locale.language && it.interfaceType == userInterfaceType && it.connectorId == null }
     }
 
     fun findLabel(locale: Locale, userInterfaceType: UserInterfaceType, connectorId: String?): I18nLocalizedLabel? =
-        i18n.firstOrNull { it.locale == locale && it.interfaceType == userInterfaceType && it.connectorId == connectorId }
-            ?: i18n.firstOrNull { it.locale == locale && it.interfaceType == userInterfaceType && it.connectorId == null }
-            ?: i18n.firstOrNull { it.locale.language == locale.language && it.interfaceType == userInterfaceType && it.connectorId == connectorId }
-            ?: i18n.firstOrNull { it.locale.language == locale.language && it.interfaceType == userInterfaceType && it.connectorId == null }
+        findLabel(i18n, locale, userInterfaceType, connectorId)
 
     fun findLabel(locale: Locale, connectorId: String? = null): I18nLocalizedLabel? =
         i18n.firstOrNull { it.locale == locale && it.label.isNotBlank() && it.connectorId == connectorId }


### PR DESCRIPTION
#1566 had an oversight which prevented proper testing of multilingual bots making use of the new default label feature. This PR addresses this by making `BotBusMock#translate` use the same `findLabel` behaviour as a real environment.