### PR TITLE
fix #1564 translator: fix test API when setting nested default localizations

### DIFF
--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -519,7 +519,7 @@ interface BotBus : Bus<BotBus> {
      */
     fun i18nKey(key: String, defaultLabel: CharSequence, localizedDefaults: Set<I18nLocalizedLabel>, vararg args: Any?): I18nLabelValue =
         story.definition.storyHandler.let {
-            (it as? StoryHandlerBase<*>)?.i18nKey(key, defaultLabel, localizedDefaults, *args)
+            (it as? StoryHandlerBase<*>)?.i18nKey(key, defaultLabel, defaultI18n = localizedDefaults, args = args)
                 ?: I18nLabelValue(
                     key,
                     botDefinition.namespace,

--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -452,7 +452,12 @@ open class BotBusMock(
                 targetConnectorType.id,
                 dialog.id.toString()
             ),
-            key.args
+            key.args.map { arg ->
+                when (arg) {
+                    is I18nLabelValue -> translate(arg)
+                    else -> arg
+                }
+            }
         ).raw
 
     override fun markAsUnknown() {


### PR DESCRIPTION
#1566 #1575 both missed the case where a label uses another label as argument. This PR addresses this by making `BotBusMock` recursively translate label arguments before the main `Translator` does. It also adds the relevant test case.