### PR TITLE
fix #1598 web_connector: add configuration option for CORS

### DIFF
--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -129,6 +129,11 @@ response:
 
 A simple [Swagger descriptor](./Swagger_TOCKWebConnector.yaml) of the rest service is provided¬.
 
+### CORS Configuration
+
+By default, the web connector accepts requests from any origin. If a stricter CORS configuration is required, the
+`tock_web_cors_pattern` property can be set to any Regex pattern, against which origin hosts get matched.
+
 ## Additional features
 
 Several features can be optionally used with the Web Connector. Some require specific properties to be set, either
@@ -214,6 +219,11 @@ makes it so the server stores users' identifiers in a secure, HTTP-only cookie, 
 Additionally, setting the `tock_web_cookie_auth_max_age` property to any positive number will configure
 the cookie's `Max-Age` property to the specified number of seconds. If left to the default or set to a negative value,
 the cookie will not have a `Max-Age` and will expire at the end of the user's browsing session.
+
+The cookie does not have a [Path](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#path_attribute) set by default,
+which potentially allows per-connector user identifiers if the connector paths are sufficiently distinct.
+If sharing the cookie between connectors is the preferred behavior, the `tock_web_cookie_auth_path` property can be used
+to set a fixed `Path` shared by all web connectors.
 
 ### Markdown processing
 


### PR DESCRIPTION
Fixes #1598 by adding a regular expression pattern property for the web connector.

I also noticed the auth cookie's `Path` was kept to the [default value](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#path_default_value). This made me consider the following possibilities:
1. change the `Path` to `/` - this ensures consistent access, but prevents having different user identifiers per connector
2. Change the `Path` to the connector path configured in TOCK Studio - this ensures the user identifier is scoped to a single connector, but it becomes incompatible with reverse proxies and other route-rewriting middleware
3. Keep the current behaviour, but add a configuration option for a fixed path - this allows per-connector scoped user identifiers (although requiring sufficiently distinct connector paths), while allowing sharing when appropriate

I figured 3. was the most useful behaviour, but this could be a miscalculation. Feedback appreciated.