### PR TITLE
Fix - unprovided maven dependencies

### DIFF
--- a/nlp/api/service/pom.xml
+++ b/nlp/api/service/pom.xml
@@ -46,6 +46,10 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jasypt</groupId>
+            <artifactId>jasypt</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
After updating Tock (24.3.0), the maven compilation is correct, but at runtime, org.jasypt is not provided, so I forced it