### PR TITLE
fix #1564 translator: fix test API when using named args in localizations

### DIFF
--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -461,6 +461,7 @@ open class BotBusMock(
             key.args.map { arg ->
                 when (arg) {
                     is I18nLabelValue -> translate(arg)
+                    is Pair<*, *> -> if (arg.second is I18nLabelValue) Pair(arg.first, translate(arg.second as I18nLabelValue)) else arg
                     else -> arg
                 }
             }

--- a/bot/test-base/src/test/kotlin/BotBusMockTest.kt
+++ b/bot/test-base/src/test/kotlin/BotBusMockTest.kt
@@ -73,7 +73,7 @@ class BotBusMockTest {
         every { storyHandler.i18nKey(key = any(), defaultLabel =  any(), any() )} answers {
             I18nLabelValue(arg<String>(0), defaultNamespace, "test", arg<CharSequence>(1), arg<Array<Any?>>(3).toList(), arg<Set<I18nLocalizedLabel>>(2))
         }
-        every { storyHandler.i18nKey(any(), any(), any(), any())} answers {
+        every { storyHandler.i18nKey(any(), any(), any(), any(), any())} answers {
             I18nLabelValue(arg<String>(0), defaultNamespace, "test", arg<CharSequence>(1), arg<Array<Any?>>(3).toList(), arg<Set<I18nLocalizedLabel>>(2))
         }
 
@@ -215,11 +215,14 @@ class BotBusMockTest {
         val inner = botBus.i18nKey("inner", "this is inner text default", localizedDefaults = setOf(
             I18nLocalizedLabel(defaultLocale, UserInterfaceType.textChat, "this is inner text")
         ))
-        val outer = botBus.i18nKey("outer", "I have a default message: {0}", localizedDefaults = setOf(
-            I18nLocalizedLabel(defaultLocale, UserInterfaceType.textChat, "I have a message: “{0}”")
-        ), inner)
+        val innerNamed = botBus.i18nKey("inner-named", "this is named inner text default", localizedDefaults = setOf(
+            I18nLocalizedLabel(defaultLocale, UserInterfaceType.textChat, "this is named inner text")
+        ))
+        val outer = botBus.i18nKey("outer", "I have a default message: {0} and {:named}", localizedDefaults = setOf(
+            I18nLocalizedLabel(defaultLocale, UserInterfaceType.textChat, "I have a message: “{0}” and “{:named}”")
+        ), "named" to innerNamed, inner)
         val translated = botBus.translate(outer)
         assertIs<TranslatedSequence>(translated)
-        assertEquals("I have a message: “this is inner text”", translated.toString())
+        assertEquals("I have a message: “this is inner text” and “this is named inner text”", translated.toString())
     }
 }

--- a/translator/core/src/main/kotlin/I18nLabelValue.kt
+++ b/translator/core/src/main/kotlin/I18nLabelValue.kt
@@ -72,7 +72,13 @@ class I18nLabelValue constructor(
      * Returns the value with the given namespace.
      */
     fun withNamespace(newNamespace: String): I18nLabelValue =
-        I18nLabelValue(key.replaceBefore("_", newNamespace), newNamespace, category, defaultLabel, args)
+        I18nLabelValue(key.replaceBefore("_", newNamespace), newNamespace, category, defaultLabel, args, defaultI18n)
+
+    /**
+     * Returns the value with the given args.
+     */
+    fun withArgs(newArgs: List<Any?>): I18nLabelValue =
+        I18nLabelValue(key, namespace, category, defaultLabel, newArgs, defaultI18n)
 
     override fun toString(): String {
         return defaultLabel.toString()


### PR DESCRIPTION
Sequel of #1595: named args. I believe this time every case of recursivity should be covered, please correct me if I missed some.

This PR also fixes default i18n being cleared when copying a label for a new namespace, and introduces a new convenience method to copy a label with a new argument list.