### PR TITLE
fixes #1636 Whatsapp Clound Connector: postback button with many parameters in template message

### DIFF
--- a/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
@@ -42,7 +42,6 @@ import ai.tock.shared.cache.getOrCache
 import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.provide
-import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -153,10 +152,10 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         messageRequest: WhatsAppCloudSendBotTemplateMessage
     ) {
         val updatedComponents = messageRequest.template.components.map { component ->
-            if (component is Component.Carousel) {
-                updateCarouselPayloads(component)
-            } else {
-                component
+            when (component) {
+                is Component.Carousel -> updateCarouselPayloads(component)
+                is Component.Button -> updateTemplateButton(component)
+                else -> component
             }
         }
 
@@ -173,28 +172,11 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         return payloadParameter.copy(type = payloadParameter.type, payload = newPayload, text = payloadParameter.text)
     }
 
-    fun updateCarouselPayloads(carousel: Component.Carousel): Component.Carousel {
+    private fun updateCarouselPayloads(carousel: Component.Carousel): Component.Carousel {
         val updatedCards = carousel.cards.map { card ->
             val updatedComponents = card.components.map { component ->
                 if (component is Component.Button) {
-                    val updatedParameters = component.parameters.map { param ->
-                        if ((param.payload?.length ?: 0) > 128) {
-                            val newPayload = UUID.randomUUID().toString()
-                            executor.executeBlocking {
-                                payloadWhatsApp.save(
-                                    PayloadWhatsAppCloud(
-                                        newPayload,
-                                        param.payload!!,
-                                        Date.from(Instant.now())
-                                    )
-                                )
-                            }
-                            updatePayloadParameter(param, newPayload)
-                        } else {
-                            param
-                        }
-                    }
-                    component.copy(parameters = updatedParameters)
+                    updateTemplateButton(component)
                 } else {
                     component
                 }


### PR DESCRIPTION
Uses the PayloadWhatsAppCloudDAO to save full SendChoice id and replace it with UUID