### PR TITLE
[Gen-Ai-Orchestrator] Add title to embedded documents for better retrieval

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -122,7 +122,7 @@ async def execute_qa_chain(query: RagQuery, debug: bool) -> RagResponse:
                         identifier=f'{doc.metadata["id"]}',
                         title=doc.metadata['title'],
                         url=doc.metadata['url'],
-                        content=doc.page_content,
+                        content=doc.metadata['original_text'],
                     ),
                     response['source_documents'],
                 )

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -122,7 +122,9 @@ async def execute_qa_chain(query: RagQuery, debug: bool) -> RagResponse:
                         identifier=f'{doc.metadata["id"]}',
                         title=doc.metadata['title'],
                         url=doc.metadata['url'],
-                        content=doc.metadata['original_text'],
+                        content=doc.metadata['original_text']
+                        if 'original_text' in doc.metadata
+                        else doc.page_content,
                     ),
                     response['source_documents'],
                 )


### PR DESCRIPTION
Adds the 'Title' entry of input CSV to embedded documents:
- during retrieval, the list of retrieved documents is more deterministic
- (seems to) slightly improves the quality of the generated answer
- fix the 'Text: ' préfix present in first chunks of source documents.

Fixes #1638 