### PR TITLE
[DERCBOT-1071] Prevent duplication of namespaces

### DIFF
--- a/nlp/front/service/src/main/kotlin/AdminTockUserListener.kt
+++ b/nlp/front/service/src/main/kotlin/AdminTockUserListener.kt
@@ -42,7 +42,7 @@ object AdminTockUserListener : TockUserListener {
 
             // if existing: take it
             do {
-                selected = existingNamespaces.find { it.namespace == namespace }?.copy(current = true)
+                selected = existingNamespaces.find { it.namespace.equals(namespace, ignoreCase = true) }?.copy(current = true)
                 if (selected == null && (joinNamespace || namespaceDAO.getUsers(namespace).isEmpty())) {
                     selected = UserNamespace(user.user, namespace, true, true)
                 } else {


### PR DESCRIPTION
After authentication on Tock, when registering the user, if the namespace we are trying to create already exists (comparison now case insensitive), I take what is already in the database, so that the name is not duplicated.

At the time of registration via Studio/Settings/Namespace, the namespace existence check was modified to ignore case when comparing.