### PR TITLE
[Tock Studio] Filter dialogs with rag responses + Create new Faq from rag response

### DIFF
--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -1,7 +1,7 @@
 <nb-card class="mb-2">
-  <nb-card-body class="d-flex flew-wrap gap-1 align-items-center">
+  <nb-card-body class="d-flex flex-wrap gap-1 align-items-center">
     <ng-container *ngIf="!ratingFilter">
-      <div class="flex-grow-1 min-width-10 d-flex gap-1 align-items-center">
+      <div class="flex-grow-1 min-width-15 w-100 d-flex gap-1 align-items-center">
         <input
           nbInput
           fullWidth
@@ -17,75 +17,93 @@
         </nb-checkbox>
       </div>
 
-      <nb-select
-        fullWidth
-        placeholder="Connector type"
-        [(ngModel)]="filter.connectorType"
-        (selectedChange)="refresh()"
-      >
-        <nb-option
-          *ngFor="let c of connectorTypes"
-          [value]="c"
-          >{{ c.id }}</nb-option
+      <div class="d-flex gap-1">
+        <nb-select
+          fullWidth
+          placeholder="Connector type"
+          class="min-width-15"
+          [(ngModel)]="filter.connectorType"
+          (selectedChange)="refresh()"
         >
-      </nb-select>
+          <nb-option
+            *ngFor="let c of connectorTypes"
+            [value]="c"
+            >{{ c.id }}</nb-option
+          >
+        </nb-select>
 
-      <nb-select
-        fullWidth
-        placeholder="Intent"
-        [(ngModel)]="filter.intentName"
-        (selectedChange)="refresh()"
-      >
-        <nb-option value="">All</nb-option>
-        <nb-option
-          *ngFor="let intent of state.currentApplication.intents"
-          [value]="intent.name"
+        <nb-select
+          fullWidth
+          placeholder="Intent"
+          class="min-width-15"
+          [(ngModel)]="filter.intentName"
+          (selectedChange)="refresh()"
         >
-          {{ intent.name }}
-        </nb-option>
-        <nb-option value="unknown">Unknown</nb-option>
-      </nb-select>
+          <nb-option value="">All</nb-option>
+          <nb-option
+            *ngFor="let intent of state.currentApplication.intents"
+            [value]="intent.name"
+          >
+            {{ intent.name }}
+          </nb-option>
+          <nb-option value="unknown">Unknown</nb-option>
+        </nb-select>
+      </div>
     </ng-container>
 
     <ng-container *ngIf="ratingFilter">
-      <nb-select
-        fullWidth
-        placeholder="Configuration"
-        [(ngModel)]="filter.configuration"
-        (selectedChange)="refresh()"
-      >
-        <nb-option value="">All</nb-option>
-        <nb-option
-          *ngFor="let config of configurationNameList"
-          [value]="config"
+      <div class="d-flex gap-1">
+        <nb-select
+          fullWidth
+          placeholder="Configuration"
+          [(ngModel)]="filter.configuration"
+          (selectedChange)="refresh()"
+          class="min-width-15"
         >
-          {{ config }}
-        </nb-option>
-      </nb-select>
+          <nb-option value="">All</nb-option>
+          <nb-option
+            *ngFor="let config of configurationNameList"
+            [value]="config"
+          >
+            {{ config }}
+          </nb-option>
+        </nb-select>
 
-      <nb-select
-        fullWidth
-        multiple
-        placeholder="Intents"
-        [(ngModel)]="filter.intentsToHide"
-        (selectedChange)="refresh()"
-      >
-        <nb-option>Clear selection</nb-option>
-        <nb-option
-          *ngFor="let intent of intents"
-          [value]="intent"
+        <nb-select
+          fullWidth
+          multiple
+          placeholder="Intents"
+          [(ngModel)]="filter.intentsToHide"
+          (selectedChange)="refresh()"
+          class="min-width-15"
         >
-          {{ intent }}
-        </nb-option>
-      </nb-select>
+          <nb-option>Clear selection</nb-option>
+          <nb-option
+            *ngFor="let intent of intents"
+            [value]="intent"
+          >
+            {{ intent }}
+          </nb-option>
+        </nb-select>
+      </div>
     </ng-container>
 
-    <nb-toggle
-      class="nb-toggle-reset-label-margin text-nowrap"
+    <nb-checkbox
+      *ngIf="!ratingFilter"
+      nbTooltip="Display only dialogs containing Rag responses"
+      class="text-nowrap"
+      [(ngModel)]="filter.isGenAiRagDialog"
+      (change)="waitAndRefresh()"
+      >Rag responses only
+    </nb-checkbox>
+
+    <nb-checkbox
+      nbTooltip="Display dialogues held from the studio test view"
+      class="text-nowrap"
       [(ngModel)]="filter.displayTests"
       (change)="waitAndRefresh()"
-      >Display tests</nb-toggle
-    >
+      >Display tests
+    </nb-checkbox>
   </nb-card-body>
 </nb-card>
 
@@ -111,16 +129,32 @@
       <nb-card>
         <nb-card-body class="p-1 pt-2">
           <tock-chat-ui>
-            <tock-chat-ui-message
-              *ngFor="let action of dialog.actions"
-              [message]="action.message"
-              [date]="action.date"
-              [reply]="action.isBot()"
-              [replay]="true"
-              [sender]="getUserName(action)"
-              [avatar]="getUserAvatar(action)"
-            >
-            </tock-chat-ui-message>
+            <ng-container *ngFor="let action of dialog.actions">
+              <tock-chat-ui-message
+                [message]="action.message"
+                [date]="action.date"
+                [reply]="action.isBot()"
+                [replay]="true"
+                [sender]="getUserName(action)"
+                [avatar]="getUserAvatar(action)"
+              >
+                <div
+                  *ngIf="action.metadata.isGenAiRagAnswer"
+                  class="mt-3 text-right"
+                >
+                  <button
+                    nbButton
+                    size="tiny"
+                    status="warning"
+                    type="button"
+                    (click)="createFaq(action, dialog.actions)"
+                  >
+                    <nb-icon icon="message-square-outline"></nb-icon>
+                    Create a FAQ with this question/answer pair
+                  </button>
+                </div>
+              </tock-chat-ui-message>
+            </ng-container>
           </tock-chat-ui>
         </nb-card-body>
       </nb-card>

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
@@ -13,7 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-.min-width-10 {
-  min-width: 25rem;
-}

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { ActionReport, BotMessage, DialogReport, SentenceWithFootnotes } from '../../../shared/model/dialog-data';
+import { ActionReport, Debug, DialogReport, SentenceWithFootnotes } from '../../../shared/model/dialog-data';
 import { ConnectorType } from '../../../core/model/configuration';
 import { StateService } from '../../../core-nlp/state.service';
 import { DialogReportQuery } from '../dialogs';
@@ -224,12 +224,21 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
   createFaq(action: ActionReport, actionsStack: ActionReport[]) {
     const actionIndex = actionsStack.findIndex((act) => act === action);
     if (actionIndex > 0) {
+      const answerSentence = action.message as unknown as SentenceWithFootnotes;
+      const answer = answerSentence.text;
+
+      let question;
       const questionAction = actionsStack[actionIndex - 1];
-      if (!questionAction.isBot()) {
+
+      if (questionAction.message.isDebug()) {
+        const actionDebug = questionAction.message as unknown as Debug;
+        question = actionDebug.data.condense_question || actionDebug.data.user_question;
+      } else if (!questionAction.isBot()) {
         const questionSentence = questionAction.message as unknown as Sentence;
-        const question = questionSentence.text;
-        const answerSentence = action.message as unknown as SentenceWithFootnotes;
-        const answer = answerSentence.text;
+        question = questionSentence.text;
+      }
+
+      if (question && answer) {
         this.router.navigate(['faq/management'], { state: { question, answer } });
       }
     }

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
@@ -1,15 +1,15 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { ActionReport, DialogReport } from '../../../shared/model/dialog-data';
+import { ActionReport, BotMessage, DialogReport, SentenceWithFootnotes } from '../../../shared/model/dialog-data';
 import { ConnectorType } from '../../../core/model/configuration';
 import { StateService } from '../../../core-nlp/state.service';
 import { DialogReportQuery } from '../dialogs';
 import { AnalyticsService } from '../../analytics.service';
 import { BotConfigurationService } from '../../../core/bot-configuration.service';
-import { ActivatedRoute, UrlSegment } from '@angular/router';
+import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { BotSharedService } from '../../../shared/bot-shared.service';
 import { PaginatedQuery, SearchMark } from '../../../model/commons';
 import { BehaviorSubject, Observable, Subject, filter, mergeMap, take, takeUntil } from 'rxjs';
-import { PaginatedResult } from '../../../model/nlp';
+import { PaginatedResult, Sentence } from '../../../model/nlp';
 import { saveAs } from 'file-saver-es';
 import { getDialogMessageUserAvatar, getDialogMessageUserQualifier } from '../../../shared/utils';
 
@@ -23,8 +23,8 @@ export class DialogFilter {
     public connectorType?: ConnectorType,
     public ratings?: number[],
     public configuration?: string,
-
-    public intentsToHide?: string[]
+    public intentsToHide?: string[],
+    public isGenAiRagDialog?: boolean
   ) {}
 }
 
@@ -67,7 +67,8 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
     private analytics: AnalyticsService,
     private botConfiguration: BotConfigurationService,
     private route: ActivatedRoute,
-    public botSharedService: BotSharedService
+    public botSharedService: BotSharedService,
+    private router: Router
   ) {
     this.state = state;
 
@@ -143,7 +144,8 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
       this.filter.displayTests,
       this.ratingFilter,
       this.filter.configuration,
-      this.filter.intentsToHide
+      this.filter.intentsToHide,
+      this.filter.isGenAiRagDialog
     );
 
     return this.route.queryParams.pipe(
@@ -217,6 +219,20 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
 
   getUserAvatar(action: ActionReport): string {
     return getDialogMessageUserAvatar(action.isBot());
+  }
+
+  createFaq(action: ActionReport, actionsStack: ActionReport[]) {
+    const actionIndex = actionsStack.findIndex((act) => act === action);
+    if (actionIndex > 0) {
+      const questionAction = actionsStack[actionIndex - 1];
+      if (!questionAction.isBot()) {
+        const questionSentence = questionAction.message as unknown as Sentence;
+        const question = questionSentence.text;
+        const answerSentence = action.message as unknown as SentenceWithFootnotes;
+        const answer = answerSentence.text;
+        this.router.navigate(['faq/management'], { state: { question, answer } });
+      }
+    }
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs.ts
@@ -34,8 +34,8 @@ export class DialogReportQuery extends PaginatedQuery {
     public displayTests?: boolean,
     public ratings?: number[],
     public applicationId?: string,
-
-    public intentsToHide? : string[]
+    public intentsToHide?: string[],
+    public isGenAiRagDialog?: boolean
   ) {
     super(namespace, applicationName, language, start, size);
   }

--- a/bot/admin/web/src/app/analytics/users/users.component.ts
+++ b/bot/admin/web/src/app/analytics/users/users.component.ts
@@ -30,6 +30,10 @@ import { BotApplicationConfiguration, ConnectorType } from '../../core/model/con
 import { TestPlan } from '../../test/model/test';
 import { getDialogMessageUserAvatar, getDialogMessageUserQualifier } from '../../shared/utils';
 
+export class UserFilter {
+  constructor(public flags: string[], public displayTests: boolean, public from?: Date, public to?: Date, public intent: string = '') {}
+}
+
 @Component({
   selector: 'tock-users',
   templateUrl: './users.component.html',
@@ -174,8 +178,4 @@ export class UsersComponent extends ScrollComponent<UserReport> {
   getUserPicture(user: UserReport): string {
     return user.userPreferences.picture ? user.userPreferences.picture : getDialogMessageUserAvatar(false);
   }
-}
-
-export class UserFilter {
-  constructor(public flags: string[], public displayTests: boolean, public from?: Date, public to?: Date, public intent: string = '') {}
 }

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.spec.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.spec.ts
@@ -230,7 +230,7 @@ describe('FaqManagementEditComponent', () => {
         enabled: true,
         applicationName: 'app',
         language: 'fr',
-        _initUtterance: 'test'
+        _initQuestion: 'test'
       };
       component.ngOnChanges({ faq: new SimpleChange(null, faq, true) });
       fixture.detectChanges();

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
@@ -1,10 +1,9 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { AbstractControl, FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
 import { NbDialogService, NbTabComponent, NbTagComponent, NbTagInputAddEvent } from '@nebular/theme';
-import { Observable, Subscription, of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { DialogService } from '../../../core-nlp/dialog.service';
 import { StateService } from '../../../core-nlp/state.service';
 import { PaginatedQuery } from '../../../model/commons';
 import { Intent, SearchQuery, SentenceStatus } from '../../../model/nlp';
@@ -199,7 +198,7 @@ export class FaqManagementEditComponent implements OnChanges {
     this.intentNameExistInApp = undefined;
   }
 
-  addUtterance(utt?) {
+  addUtterance(utt?: string) {
     this.resetAlerts();
 
     let utterance = utt || this.addUtteranceInput.nativeElement.value.trim();

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
@@ -120,20 +120,20 @@ export class FaqManagementEditComponent implements OnChanges {
           this.utterances.push(new FormControl(utterance));
         });
 
-        if (faq._initUtterance) {
+        if (faq._initQuestion) {
           this.form.markAsDirty();
           this.form.markAsTouched();
 
           this.setCurrentTab({ tabTitle: FaqTabs.QUESTION } as NbTabComponent);
 
           setTimeout(() => {
-            this.addUtterance(faq._initUtterance);
-            delete faq._initUtterance;
+            this.addUtterance(faq._initQuestion);
+            delete faq._initQuestion;
           });
         }
       }
 
-      if (!faq.id && !faq._initUtterance) {
+      if (!faq.id && !faq._initQuestion) {
         this.setCurrentTab({ tabTitle: FaqTabs.INFO } as NbTabComponent);
       }
     }

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.html
@@ -34,6 +34,15 @@
               First question (out of {{ faq.utterances.length }})
             </small>
             {{ faq.utterances[0] }}
+            <button
+              nbButton
+              ghost
+              size="tiny"
+              nbTooltip="Copy question"
+              (click)="copyString(faq.utterances[0])"
+            >
+              <nb-icon icon="copy-outline"></nb-icon>
+            </button>
           </div>
         </div>
 

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.ts
@@ -5,6 +5,8 @@ import { FaqDefinitionExtended } from '../faq-management.component';
 import { StateService } from '../../../core-nlp/state.service';
 import { DialogService } from '../../../core-nlp/dialog.service';
 import { ConfirmDialogComponent } from '../../../shared-nlp/confirm-dialog/confirm-dialog.component';
+import { copyToClipboard } from '../../../shared/utils';
+import { NbToastrService } from '@nebular/theme';
 
 @Component({
   selector: 'tock-faq-management-list',
@@ -19,7 +21,7 @@ export class FaqManagementListComponent {
   @Output() onDelete = new EventEmitter<FaqDefinitionExtended>();
   @Output() onEnable = new EventEmitter<FaqDefinitionExtended>();
 
-  constructor(private state: StateService, private dialogService: DialogService) {}
+  constructor(private state: StateService, private dialogService: DialogService, private toastrService: NbToastrService) {}
 
   toggleEnabled(faq: FaqDefinitionExtended) {
     let action = 'Enable';
@@ -67,5 +69,10 @@ export class FaqManagementListComponent {
     });
 
     saveAs(jsonBlob, `${this.state.currentApplication.name}_${this.state.currentLocale}_faq_${faq.title}.json`);
+  }
+
+  copyString(str: string) {
+    copyToClipboard(str);
+    this.toastrService.success(`String copied to clipboard`, 'Clipboard');
   }
 }

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
@@ -15,7 +15,7 @@ import { FaqManagementEditComponent } from './faq-management-edit/faq-management
 import { FaqManagementSettingsComponent } from './faq-management-settings/faq-management-settings.component';
 import { Pagination } from '../../shared/components';
 
-export type FaqDefinitionExtended = FaqDefinition & { _initUtterance?: string };
+export type FaqDefinitionExtended = FaqDefinition & { _initQuestion?: string };
 
 @Component({
   selector: 'tock-faq-management',
@@ -44,7 +44,8 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
     list: false
   };
 
-  initUtterance: string;
+  initQuestion: string;
+  initAnswer: string;
 
   constructor(
     private botConfiguration: BotConfigurationService,
@@ -53,7 +54,8 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
     private toastrService: NbToastrService,
     private router: Router
   ) {
-    this.initUtterance = this.router.getCurrentNavigation().extras?.state?.question;
+    this.initQuestion = this.router.getCurrentNavigation().extras?.state?.question;
+    this.initAnswer = this.router.getCurrentNavigation().extras?.state?.answer;
   }
 
   ngOnInit(): void {
@@ -64,10 +66,20 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
         this.search();
         this.closeSidePanel();
 
-        if (this.initUtterance) {
-          let initUtterance = this.initUtterance;
-          this.initUtterance = undefined;
-          this.addFaq(initUtterance);
+        let initQuestion;
+        if (this.initQuestion) {
+          initQuestion = this.initQuestion;
+          this.initQuestion = undefined;
+        }
+
+        let initAnswer;
+        if (this.initAnswer) {
+          initAnswer = this.initAnswer;
+          this.initAnswer = undefined;
+        }
+
+        if (initQuestion || initAnswer) {
+          this.addFaq(initQuestion, initAnswer);
         }
       }
     });
@@ -201,22 +213,22 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
     }
   }
 
-  addFaq(initUtterance?: string) {
+  addFaq(initQuestion?: string, initAnswer?: string) {
     this.faqEdit = {
       id: undefined,
       intentId: undefined,
-      title: initUtterance ? initUtterance : '',
+      title: initQuestion || '',
       description: '',
       utterances: [],
       tags: [],
-      answer: '',
+      answer: initAnswer || '',
       enabled: true,
       applicationName: this.stateService.currentApplication.name,
       language: this.stateService.currentLocale
     };
 
-    if (initUtterance) {
-      this.faqEdit._initUtterance = initUtterance;
+    if (initQuestion) {
+      this.faqEdit._initQuestion = initQuestion;
     }
 
     this.isSidePanelOpen.edit = true;

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-debug/chat-ui-message-debug.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-debug/chat-ui-message-debug.component.ts
@@ -8,13 +8,9 @@ import { DebugViewerDialogComponent } from '../../../debug-viewer-dialog/debug-v
   templateUrl: './chat-ui-message-debug.component.html',
   styleUrls: ['./chat-ui-message-debug.component.scss']
 })
-export class ChatUiMessageDebugComponent implements OnInit {
+export class ChatUiMessageDebugComponent {
   @Input() message: Debug;
   constructor(private nbDialogService: NbDialogService) {}
-
-  ngOnInit(): void {
-    console.log(this.message);
-  }
 
   showDebug() {
     this.nbDialogService.open(DebugViewerDialogComponent, {

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -189,3 +189,19 @@ nb-menu {
     }
   }
 }
+
+.min-width-5 {
+  min-width: 5em;
+}
+
+.min-width-10 {
+  min-width: 10em;
+}
+
+.min-width-15 {
+  min-width: 15em;
+}
+
+.min-width-20 {
+  min-width: 20em;
+}


### PR DESCRIPTION
This PR adds :
- An option on analytics/search to list only dialogs containing Rag responses
- An option on analytics/search to create a new Faq entry based on a question/answer pair from a Rag response

Depends on https://github.com/theopenconversationkit/tock/pull/1649

![tock-faq-from-rag](https://github.com/theopenconversationkit/tock/assets/101799433/85e5083a-5a49-4ab5-956b-32ffedc73e73)
