### PR TITLE
fix #1658 translator: fix answer update from admin resetting defaultI18n

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -24,14 +24,34 @@ import ai.tock.bot.admin.BotAdminService.importStories
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotConfiguration
 import ai.tock.bot.admin.constants.Properties
-import ai.tock.bot.admin.model.*
+import ai.tock.bot.admin.model.BotAdminConfiguration
+import ai.tock.bot.admin.model.BotConnectorConfiguration
+import ai.tock.bot.admin.model.BotI18nLabel
+import ai.tock.bot.admin.model.BotI18nLabelUpdate
+import ai.tock.bot.admin.model.BotI18nLabels
+import ai.tock.bot.admin.model.BotRAGConfigurationDTO
+import ai.tock.bot.admin.model.BotSentenceGenerationConfigurationDTO
+import ai.tock.bot.admin.model.BotSentenceGenerationInfoDTO
+import ai.tock.bot.admin.model.BotStoryDefinitionConfiguration
+import ai.tock.bot.admin.model.BotSynchronization
+import ai.tock.bot.admin.model.CreateI18nLabelRequest
+import ai.tock.bot.admin.model.CreateStoryRequest
+import ai.tock.bot.admin.model.DialogFlowRequest
+import ai.tock.bot.admin.model.DialogsSearchQuery
+import ai.tock.bot.admin.model.FaqDefinitionRequest
+import ai.tock.bot.admin.model.FaqSearchRequest
+import ai.tock.bot.admin.model.Feature
+import ai.tock.bot.admin.model.I18LabelQuery
+import ai.tock.bot.admin.model.SentenceGenerationRequest
+import ai.tock.bot.admin.model.StorySearchRequest
+import ai.tock.bot.admin.model.SummaryStorySearchRequest
+import ai.tock.bot.admin.model.UserSearchQuery
 import ai.tock.bot.admin.module.satisfactionContentModule
 import ai.tock.bot.admin.service.CompletionService
-import ai.tock.bot.admin.service.SentenceGenerationService
 import ai.tock.bot.admin.service.RAGService
-import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDumpImport
+import ai.tock.bot.admin.service.SentenceGenerationService
 import ai.tock.bot.admin.service.SynchronizationService
-import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDump
+import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDumpImport
 import ai.tock.bot.admin.test.TestPlanService
 import ai.tock.bot.admin.test.findTestService
 import ai.tock.bot.admin.verticle.IndicatorVerticle
@@ -59,7 +79,11 @@ import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.provide
 import ai.tock.shared.security.NoEncryptionPassException
-import ai.tock.shared.security.TockUserRole.*
+import ai.tock.shared.security.TockUserRole.admin
+import ai.tock.shared.security.TockUserRole.botUser
+import ai.tock.shared.security.TockUserRole.faqBotUser
+import ai.tock.shared.security.TockUserRole.faqNlpUser
+import ai.tock.shared.security.TockUserRole.nlpUser
 import ai.tock.shared.vertx.ServerStatus
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
@@ -853,7 +877,7 @@ open class BotAdminVerticle : AdminVerticle() {
             "/i18n/saveAll",
             setOf(botUser, faqBotUser),
             simpleLogger("Save Responses Labels")
-        ) { context, labels: List<I18nLabel> ->
+        ) { context, labels: List<BotI18nLabelUpdate> ->
             i18n.save(labels.filter { it.namespace == context.organization })
         }
 
@@ -861,7 +885,7 @@ open class BotAdminVerticle : AdminVerticle() {
             "/i18n/save",
             setOf(botUser, faqBotUser),
             simpleLogger("Save Response Label")
-        ) { context, label: I18nLabel ->
+        ) { context, label: BotI18nLabelUpdate ->
             if (label.namespace == context.organization) {
                 i18n.save(label)
             } else {

--- a/bot/admin/server/src/main/kotlin/model/BotI18nLabelUpdate.kt
+++ b/bot/admin/server/src/main/kotlin/model/BotI18nLabelUpdate.kt
@@ -18,7 +18,7 @@ package ai.tock.bot.admin.model
 
 import ai.tock.shared.defaultNamespace
 import ai.tock.translator.I18nLabel
-import ai.tock.translator.I18nLabelPartial
+import ai.tock.translator.I18nLabelContract
 import ai.tock.translator.I18nLocalizedLabel
 import java.util.Locale
 import org.litote.kmongo.Id
@@ -34,7 +34,7 @@ data class BotI18nLabelUpdate(
     override val defaultLabel: String? = null,
     override val defaultLocale: Locale = ai.tock.shared.defaultLocale,
     override val version: Int?,
-) : I18nLabelPartial {
+) : I18nLabelContract {
     override val defaultI18n: Set<I18nLocalizedLabel>?
         get() = null
 

--- a/bot/admin/server/src/main/kotlin/model/BotI18nLabelUpdate.kt
+++ b/bot/admin/server/src/main/kotlin/model/BotI18nLabelUpdate.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.model
+
+import ai.tock.shared.defaultNamespace
+import ai.tock.translator.I18nLabel
+import ai.tock.translator.I18nLabelPartial
+import ai.tock.translator.I18nLocalizedLabel
+import java.util.Locale
+import org.litote.kmongo.Id
+
+/**
+ * Incoming [I18nLabel] update from the client (missing defaultI18n).
+ */
+data class BotI18nLabelUpdate(
+    override val _id: Id<I18nLabel>,
+    override val namespace: String = defaultNamespace,
+    override val category: String,
+    override val i18n: LinkedHashSet<I18nLocalizedLabel>,
+    override val defaultLabel: String? = null,
+    override val defaultLocale: Locale = ai.tock.shared.defaultLocale,
+    override val version: Int?,
+) : I18nLabelPartial {
+    override val defaultI18n: Set<I18nLocalizedLabel>?
+        get() = null
+
+    override fun withDefaultLabel(defaultLabel: String?) = copy(defaultLabel = defaultLabel)
+    override fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?) = copy(i18n = i18n, version = version)
+}

--- a/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
@@ -34,6 +34,7 @@ import ai.tock.shared.watch
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.I18nLabelFilter
+import ai.tock.translator.I18nLabelPartial
 import ai.tock.translator.I18nLabelStat
 import ai.tock.translator.I18nLabelStat_
 import ai.tock.translator.I18nLabelStateFilter.ALL
@@ -46,6 +47,9 @@ import ai.tock.translator.I18nLabel_.Companion._id
 import ai.tock.translator.I18nLocalizedLabel
 import com.mongodb.client.model.Filters.regex
 import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.UpdateOptions
+import java.time.Instant
+import java.util.concurrent.TimeUnit
 import mu.KotlinLogging
 import org.bson.BsonString
 import org.bson.Document
@@ -70,13 +74,11 @@ import org.litote.kmongo.or
 import org.litote.kmongo.projection
 import org.litote.kmongo.reactivestreams.getCollection
 import org.litote.kmongo.regex
-import org.litote.kmongo.save
 import org.litote.kmongo.setValue
 import org.litote.kmongo.toId
+import org.litote.kmongo.updateOneById
 import org.litote.kmongo.upsert
 import org.litote.kmongo.withDocumentClass
-import java.time.Instant
-import java.util.concurrent.TimeUnit
 
 /**
  *
@@ -112,8 +114,8 @@ internal object I18nMongoDAO : I18nDAO {
     private fun sortLocalizedLabels(list: MutableSet<I18nLocalizedLabel>): LinkedHashSet<I18nLocalizedLabel> =
         LinkedHashSet(list.sortedWith(compareBy({ it.locale.language }, { it.interfaceType }, { it.connectorId })))
 
-    private fun sortLocalizedLabels(label: I18nLabel): I18nLabel =
-        label.copy(i18n = sortLocalizedLabels(label.i18n), version = label.version + 1)
+    private fun sortLocalizedLabels(label: I18nLabelPartial): I18nLabelPartial =
+        label.withUpdatedI18n(sortLocalizedLabels(label.i18n), version = label.version?.apply(Int::inc))
 
     override fun listenI18n(listener: (Id<I18nLabel>) -> Unit) {
         asyncCol.watch {
@@ -155,20 +157,20 @@ internal object I18nMongoDAO : I18nDAO {
         return col.findOneById(id)
     }
 
-    override fun save(label: I18nLabel) {
+    override fun save(label: I18nLabelPartial) {
         val sortedLabel = sortLocalizedLabels(label)
         //update default label
         val defaultLabel = sortedLabel.run {
-            copy(defaultLabel = i18n.firstOrNull { it.locale == defaultLocale }?.label ?: defaultLabel)
+            withDefaultLabel(i18n.firstOrNull { it.locale == defaultLocale }?.label ?: defaultLabel)
         }
-        col.save(defaultLabel)
+        col.updateOneById(defaultLabel._id, defaultLabel, options = UpdateOptions().upsert(true), updateOnlyNotNullProperties = true)
     }
 
-    override fun save(i18n: List<I18nLabel>) {
+    override fun save(i18n: List<I18nLabelPartial>) {
         i18n.forEach { save(it) }
     }
 
-    override fun saveIfNotExist(i18n: List<I18nLabel>) {
+    override fun saveIfNotExist(i18n: List<I18nLabelPartial>) {
         val existingIds = sortLabels(col.find().toList()).map { it._id }.toSet()
         save(i18n.filterNot { existingIds.contains(it._id) })
     }

--- a/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/I18nMongoDAO.kt
@@ -33,8 +33,8 @@ import ai.tock.shared.longProperty
 import ai.tock.shared.watch
 import ai.tock.translator.I18nDAO
 import ai.tock.translator.I18nLabel
+import ai.tock.translator.I18nLabelContract
 import ai.tock.translator.I18nLabelFilter
-import ai.tock.translator.I18nLabelPartial
 import ai.tock.translator.I18nLabelStat
 import ai.tock.translator.I18nLabelStat_
 import ai.tock.translator.I18nLabelStateFilter.ALL
@@ -114,7 +114,7 @@ internal object I18nMongoDAO : I18nDAO {
     private fun sortLocalizedLabels(list: MutableSet<I18nLocalizedLabel>): LinkedHashSet<I18nLocalizedLabel> =
         LinkedHashSet(list.sortedWith(compareBy({ it.locale.language }, { it.interfaceType }, { it.connectorId })))
 
-    private fun sortLocalizedLabels(label: I18nLabelPartial): I18nLabelPartial =
+    private fun sortLocalizedLabels(label: I18nLabelContract): I18nLabelContract =
         label.withUpdatedI18n(sortLocalizedLabels(label.i18n), version = label.version?.apply(Int::inc))
 
     override fun listenI18n(listener: (Id<I18nLabel>) -> Unit) {
@@ -157,7 +157,7 @@ internal object I18nMongoDAO : I18nDAO {
         return col.findOneById(id)
     }
 
-    override fun save(label: I18nLabelPartial) {
+    override fun save(label: I18nLabelContract) {
         val sortedLabel = sortLocalizedLabels(label)
         //update default label
         val defaultLabel = sortedLabel.run {
@@ -166,11 +166,11 @@ internal object I18nMongoDAO : I18nDAO {
         col.updateOneById(defaultLabel._id, defaultLabel, options = UpdateOptions().upsert(true), updateOnlyNotNullProperties = true)
     }
 
-    override fun save(i18n: List<I18nLabelPartial>) {
+    override fun save(i18n: List<I18nLabelContract>) {
         i18n.forEach { save(it) }
     }
 
-    override fun saveIfNotExist(i18n: List<I18nLabelPartial>) {
+    override fun saveIfNotExist(i18n: List<I18nLabelContract>) {
         val existingIds = sortLabels(col.find().toList()).map { it._id }.toSet()
         save(i18n.filterNot { existingIds.contains(it._id) })
     }

--- a/docs/_en/dev/i18n.md
+++ b/docs/_en/dev/i18n.md
@@ -79,7 +79,7 @@ If you need to send "do not translate" responses, use the *BotBus.sendRaw*, *Bot
 ``` 
 
 ```kotlin
-    send("There are {0} files", nb) //FORMAT A SUIVRE 
+    send("There are {0} files", nb) //SEE FORMAT BELOW
 ```  
 
 * The collision risk between two labels is small as the story's main intent is made part of the key. 
@@ -89,7 +89,7 @@ If however you want to avoid any risk, you can use the *i18nKey* method:
     send(i18nKey("my_unique_key", "There are {0} files", nb)) 
 ```  
 
-### Specifying several localizations
+### Specifying localizations programmatically
 
 Default values can be defined for several locales in a bot's code:
 
@@ -98,7 +98,7 @@ Default values can be defined for several locales in a bot's code:
 ```
 
 By default, these default values will only be used when the key is used for the first time. To overwrite
-existing values (including those defined via TOCK Studio) when the default location is changed,
+existing values (including those defined via TOCK Studio) when the `defaultI18n` set is changed,
 set the configuration value `tock_i18n_reset_value_on_default_change` to `true` (either as an environment variable,
 or as a system property).
 

--- a/docs/_en/dev/i18n.md
+++ b/docs/_en/dev/i18n.md
@@ -79,7 +79,7 @@ If you need to send "do not translate" responses, use the *BotBus.sendRaw*, *Bot
 ``` 
 
 ```kotlin
-    send("There are {0} files", nb) //SEE FORMAT BELOW
+    send("There are {0} files", nb) //RECOMMENDED FORMAT
 ```  
 
 * The collision risk between two labels is small as the story's main intent is made part of the key. 

--- a/docs/_fr/dev/i18n.md
+++ b/docs/_fr/dev/i18n.md
@@ -72,7 +72,7 @@ Par exemple, ce code fonctionne parfaitement bien avec le module i18n désactiv�
 
 mais pose problème si il est activé. En effet, un nouveau libellé sera créé pour chaque valeur différente de la variable *nb* !
  
-Si il est nécessaire d'envoyer des réponses "à ne pas traduire", utilisez 
+S'il est nécessaire d'envoyer des réponses "à ne pas traduire", utilisez 
 les méthodes *BotBus.sendRaw*, *BotBus.endRaw* ou *String.raw*
 
 ```kotlin
@@ -90,7 +90,7 @@ Si vous souhaitez cependant éviter tout risque, vous pouvez utiliser la méthod
     send(i18nKey("my_unique_key", "There are {0} files", nb)) 
 ```  
 
-### Spécification de plusieurs localisations
+### Spécification des localisations programmatiquement
 
 Il est possible de définir des valeurs par défaut pour plusieurs localisations dans le code d'un bot :
 
@@ -99,7 +99,7 @@ Il est possible de définir des valeurs par défaut pour plusieurs localisations
 ```
 
 Par défaut, ces valeurs par défaut ne seront utilisées que lorsque la clé est utilisée pour la première fois. Pour écraser
-les valeurs existantes (y compris celles définies via TOCK Studio) lorsque la localisation par défaut est changée,
+les valeurs existantes (y compris celles définies via TOCK Studio) lorsque le paramètre `defaultI18n` est changé,
 mettez la valeur de configuration `tock_i18n_reset_value_on_default_change` à `true` (soit en variable d'environnement,
 soit en propriété système).
 

--- a/translator/core/src/main/kotlin/I18nDAO.kt
+++ b/translator/core/src/main/kotlin/I18nDAO.kt
@@ -40,22 +40,22 @@ interface I18nDAO {
     fun getLabelById(id: Id<I18nLabel>): I18nLabel?
 
     @Deprecated(message = "Replaced with more generic method", level = DeprecationLevel.HIDDEN)
-    fun save(label: I18nLabel) = save(label as I18nLabelPartial)
+    fun save(label: I18nLabel) = save(label as I18nLabelContract)
 
     /**
      * Saves label.
      */
-    fun save(label: I18nLabelPartial)
+    fun save(label: I18nLabelContract)
 
     /**
      * Saves all specified labels.
      */
-    fun save(i18n: List<I18nLabelPartial>)
+    fun save(i18n: List<I18nLabelContract>)
 
     /**
      * Saves all labels that does not exist yet.
      */
-    fun saveIfNotExist(i18n: List<I18nLabelPartial>)
+    fun saveIfNotExist(i18n: List<I18nLabelContract>)
 
     /**
      * Delete the label of specified id if and only if it has the specified namespace.

--- a/translator/core/src/main/kotlin/I18nDAO.kt
+++ b/translator/core/src/main/kotlin/I18nDAO.kt
@@ -16,8 +16,8 @@
 
 package ai.tock.translator
 
-import org.litote.kmongo.Id
 import java.time.Instant
+import org.litote.kmongo.Id
 
 /**
  * I18n storage.
@@ -39,20 +39,23 @@ interface I18nDAO {
      */
     fun getLabelById(id: Id<I18nLabel>): I18nLabel?
 
+    @Deprecated(message = "Replaced with more generic method", level = DeprecationLevel.HIDDEN)
+    fun save(label: I18nLabel) = save(label as I18nLabelPartial)
+
     /**
      * Saves label.
      */
-    fun save(label: I18nLabel)
+    fun save(label: I18nLabelPartial)
 
     /**
      * Saves all specified labels.
      */
-    fun save(i18n: List<I18nLabel>)
+    fun save(i18n: List<I18nLabelPartial>)
 
     /**
      * Saves all labels that does not exist yet.
      */
-    fun saveIfNotExist(i18n: List<I18nLabel>)
+    fun saveIfNotExist(i18n: List<I18nLabelPartial>)
 
     /**
      * Delete the label of specified id if and only if it has the specified namespace.

--- a/translator/core/src/main/kotlin/I18nLabel.kt
+++ b/translator/core/src/main/kotlin/I18nLabel.kt
@@ -33,7 +33,7 @@ data class I18nLabel(
     override val defaultLocale: Locale = findDefaultLabelLocale(defaultLabel, i18n),
     override val defaultI18n: Set<I18nLocalizedLabel> = emptySet(),
     override val version: Int = 0
-) : I18nLabelPartial {
+) : I18nLabelContract {
     override fun withDefaultLabel(defaultLabel: String?) = copy(defaultLabel = defaultLabel)
     override fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?) = copy(i18n = i18n, version = version ?: 0)
 

--- a/translator/core/src/main/kotlin/I18nLabel.kt
+++ b/translator/core/src/main/kotlin/I18nLabel.kt
@@ -25,15 +25,17 @@ import org.litote.kmongo.Id
  * The label persisted in database.
  */
 data class I18nLabel(
-    val _id: Id<I18nLabel>,
-    val namespace: String = defaultNamespace,
-    val category: String,
-    val i18n: LinkedHashSet<I18nLocalizedLabel>,
-    val defaultLabel: String? = null,
-    val defaultLocale: Locale = findDefaultLabelLocale(defaultLabel, i18n),
-    val defaultI18n: Set<I18nLocalizedLabel> = emptySet(),
-    val version: Int = 0
-) {
+    override val _id: Id<I18nLabel>,
+    override val namespace: String = defaultNamespace,
+    override val category: String,
+    override val i18n: LinkedHashSet<I18nLocalizedLabel>,
+    override val defaultLabel: String? = null,
+    override val defaultLocale: Locale = findDefaultLabelLocale(defaultLabel, i18n),
+    override val defaultI18n: Set<I18nLocalizedLabel> = emptySet(),
+    override val version: Int = 0
+) : I18nLabelPartial {
+    override fun withDefaultLabel(defaultLabel: String?) = copy(defaultLabel = defaultLabel)
+    override fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?) = copy(i18n = i18n, version = version ?: 0)
 
     companion object {
         fun findDefaultLabelLocale(defaultLabel: String?, i18n: MutableSet<I18nLocalizedLabel>): Locale =

--- a/translator/core/src/main/kotlin/I18nLabelContract.kt
+++ b/translator/core/src/main/kotlin/I18nLabelContract.kt
@@ -19,7 +19,7 @@ package ai.tock.translator
 import java.util.Locale
 import org.litote.kmongo.Id
 
-interface I18nLabelPartial {
+interface I18nLabelContract {
     val _id: Id<I18nLabel>
     val namespace: String?
     val category: String
@@ -29,6 +29,6 @@ interface I18nLabelPartial {
     val defaultI18n: Set<I18nLocalizedLabel>?
     val version: Int?
 
-    fun withDefaultLabel(defaultLabel: String?): I18nLabelPartial
-    fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?): I18nLabelPartial
+    fun withDefaultLabel(defaultLabel: String?): I18nLabelContract
+    fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?): I18nLabelContract
 }

--- a/translator/core/src/main/kotlin/I18nLabelPartial.kt
+++ b/translator/core/src/main/kotlin/I18nLabelPartial.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.translator
+
+import java.util.Locale
+import org.litote.kmongo.Id
+
+interface I18nLabelPartial {
+    val _id: Id<I18nLabel>
+    val namespace: String?
+    val category: String
+    val i18n: LinkedHashSet<I18nLocalizedLabel>
+    val defaultLabel: String?
+    val defaultLocale: Locale?
+    val defaultI18n: Set<I18nLocalizedLabel>?
+    val version: Int?
+
+    fun withDefaultLabel(defaultLabel: String?): I18nLabelPartial
+    fun withUpdatedI18n(i18n: LinkedHashSet<I18nLocalizedLabel>, version: Int?): I18nLabelPartial
+}

--- a/translator/core/src/main/kotlin/I18nLabelValue.kt
+++ b/translator/core/src/main/kotlin/I18nLabelValue.kt
@@ -56,7 +56,8 @@ class I18nLabelValue constructor(
             label._id.toString(),
             label.namespace,
             label.category,
-            label.defaultLabel ?: ""
+            label.defaultLabel ?: "",
+            defaultI18n = label.defaultI18n,
         )
 
     /**


### PR DESCRIPTION
fixes #1658 by making it so `checkDefaultConsistency` ignores `defaultLabel`, and so the "save" operation in the admin only updates the label instead of replacing it. For the update to avoid resetting the `defaultI18n` field, a new `I18nLabelPartial` type had to be introduced, which has nullable fields, allowing for partial updates.