### PR TITLE
fix #1662 Bot Api: add standard way to change user locale from BotBus

### DIFF
--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -57,6 +57,7 @@ import ai.tock.shared.provide
 import ai.tock.translator.I18nKeyProvider
 import ai.tock.translator.I18nLabelValue
 import ai.tock.translator.I18nLocalizedLabel
+import java.util.Locale
 
 /**
  * Bus implementation for Tock integrated mode.
@@ -298,6 +299,12 @@ interface BotBus : Bus<BotBus> {
     fun resetDialogState() {
         dialog.state.resetState()
     }
+
+    /**
+     * Sets the user's [current locale][UserPreferences.locale], and updates this bus
+     * so that following translations use the same locale
+     */
+    fun changeUserLocale(locale: Locale)
 
     /**
      * Returns the persistent current context value.

--- a/bot/engine/src/test/kotlin/engine/BotBusTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotBusTest.kt
@@ -37,13 +37,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import java.util.Locale
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  *
@@ -87,6 +87,14 @@ class BotBusTest : BotEngineTest() {
         bus.reloadProfile()
         assertNull(bus.userPreferences.firstName)
         assertNull(bus.userPreferences.lastName)
+    }
+
+    @Test
+    fun `reloadProfile should use new user locale when connectorLoadProfile returns valid value`() {
+        every { connector.loadProfile(any(), any()) } returns UserPreferences(locale = Locale.FRENCH)
+        assertEquals(Locale.ENGLISH, bus.userLocale)
+        bus.reloadProfile()
+        assertEquals(Locale.FRENCH, bus.userLocale)
     }
 
     @Test

--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -361,6 +361,10 @@ open class BotBusMock(
         context.snapshots.add(Snapshot(dialog))
     }
 
+    override fun changeUserLocale(locale: Locale) {
+        userPreferences.locale = locale
+    }
+
     /**
      * Returns the non persistent current value.
      */


### PR DESCRIPTION
resolves #1662 by adding a new `changeUserLocale` method to BotBus. As suggested in the issue this could be replaced with a passthrough property, but I figured the optimization was easy enough to just do anyway.