### PR TITLE
fixes #1676 bot test: add applicationId parameter

### DIFF
--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -75,9 +75,12 @@ interface BotBus : Bus<BotBus> {
     }
 
     /**
-     * The current application id.
+     * The current TOCK application id.
      *
-     * This id matches the identifier of the [underlyingConnector].
+     * This identifier matches the identifier of the [underlyingConnector], as defined in TOCK Studio.
+     *
+     * *This identifier is not to be confused with the chat platform's application id (this is not a Messenger/Whatsapp
+     * application ID).*
      *
      * @see ConnectorConfiguration.connectorId
      */

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -19,6 +19,7 @@ package ai.tock.bot.engine
 import ai.tock.bot.admin.indicators.metric.Metric
 import ai.tock.bot.admin.indicators.metric.MetricType
 import ai.tock.bot.connector.Connector
+import ai.tock.bot.connector.ConnectorConfiguration
 import ai.tock.bot.connector.ConnectorData
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
@@ -72,6 +73,15 @@ interface BotBus : Bus<BotBus> {
          */
         fun retrieveCurrentBus(): BotBus? = Bot.retrieveCurrentBus()
     }
+
+    /**
+     * The current application id.
+     *
+     * This id matches the identifier of the [underlyingConnector].
+     *
+     * @see ConnectorConfiguration.connectorId
+     */
+    override val applicationId: String
 
     /**
      * The bot definition of the current bot.
@@ -449,7 +459,6 @@ interface BotBus : Bus<BotBus> {
     fun handleAndSwitchStory(storyDefinition: StoryDefinition, starterIntent: Intent = storyDefinition.mainIntent()) {
         switchStory(storyDefinition, starterIntent)
         hasCurrentSwitchStoryProcess = false
-        @Suppress("UNCHECKED_CAST")
         storyDefinition.storyHandler.handle(this)
     }
 

--- a/bot/engine/src/main/kotlin/engine/Bus.kt
+++ b/bot/engine/src/main/kotlin/engine/Bus.kt
@@ -30,7 +30,7 @@ import ai.tock.bot.engine.user.PlayerId
 interface Bus<T : Bus<T>> : I18nTranslator {
 
     /**
-     * The current application id.
+     * The current TOCK application id.
      */
     val applicationId: String
 

--- a/bot/engine/src/main/kotlin/engine/action/Action.kt
+++ b/bot/engine/src/main/kotlin/engine/action/Action.kt
@@ -23,11 +23,13 @@ import ai.tock.bot.engine.message.Message
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.jackson.mapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.litote.kmongo.Id
 import java.time.Instant
+import org.litote.kmongo.Id
 
 /**
  * A user (or bot) action.
+ *
+ * @param applicationId the TOCK application id (matches the id of the connector)
  */
 abstract class Action(
     val playerId: PlayerId,

--- a/bot/engine/src/main/kotlin/engine/action/SendAttachment.kt
+++ b/bot/engine/src/main/kotlin/engine/action/SendAttachment.kt
@@ -20,12 +20,14 @@ import ai.tock.bot.engine.dialog.EventState
 import ai.tock.bot.engine.message.Attachment
 import ai.tock.bot.engine.message.Message
 import ai.tock.bot.engine.user.PlayerId
+import java.time.Instant
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
-import java.time.Instant
 
 /**
  * A simple attachment file sent.
+ *
+ * @param applicationId the TOCK application id (matches the id of the connector)
  */
 open class SendAttachment(
     playerId: PlayerId,

--- a/bot/engine/src/main/kotlin/engine/action/SendChoice.kt
+++ b/bot/engine/src/main/kotlin/engine/action/SendChoice.kt
@@ -26,15 +26,17 @@ import ai.tock.bot.engine.message.Choice
 import ai.tock.bot.engine.message.Message
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.mapNotNullValues
-import org.litote.kmongo.Id
-import org.litote.kmongo.newId
 import java.net.URLDecoder.decode
 import java.net.URLEncoder.encode
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.Instant
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
 
 /**
  * A user choice (click on a button or direct action).
+ *
+ * @param applicationId the TOCK application id (matches the id of the connector)
  */
 class SendChoice(
     playerId: PlayerId,

--- a/bot/engine/src/main/kotlin/engine/action/SendLocation.kt
+++ b/bot/engine/src/main/kotlin/engine/action/SendLocation.kt
@@ -21,12 +21,14 @@ import ai.tock.bot.engine.message.Location
 import ai.tock.bot.engine.message.Message
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.UserLocation
+import java.time.Instant
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
-import java.time.Instant
 
 /**
  * A user location transmission.
+ *
+ * @param applicationId the TOCK application id (matches the id of the connector)
  */
 class SendLocation(
     playerId: PlayerId,

--- a/bot/engine/src/main/kotlin/engine/action/SendSentence.kt
+++ b/bot/engine/src/main/kotlin/engine/action/SendSentence.kt
@@ -24,13 +24,15 @@ import ai.tock.bot.engine.message.Sentence
 import ai.tock.bot.engine.nlp.NlpCallStats
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.nlp.api.client.model.NlpResult
+import java.time.Instant
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
-import java.time.Instant
 
 /**
  * The most important [Action] class.
  * Could be a simple text, or a complex message using one or more [ConnectorMessage].
+ *
+ * @param applicationId the TOCK application id (matches the id of the connector)
  */
 open class SendSentence(
     playerId: PlayerId,

--- a/bot/engine/src/main/kotlin/engine/event/Event.kt
+++ b/bot/engine/src/main/kotlin/engine/event/Event.kt
@@ -16,19 +16,22 @@
 
 package ai.tock.bot.engine.event
 
+import ai.tock.bot.connector.ConnectorConfiguration
 import ai.tock.bot.engine.dialog.EventState
 import ai.tock.bot.engine.dialog.hasEntityPredefinedValue
 import ai.tock.bot.engine.dialog.hasSubEntity
+import java.time.Instant
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
-import java.time.Instant
 
 /**
  * The base class for all events or actions.
  */
 abstract class Event(
     /**
-     * The bot application id.
+     * The bot application id (corresponds to the connector identifier in the admin).
+     *
+     * @see ConnectorConfiguration.connectorId
      */
     val applicationId: String,
     /**

--- a/bot/engine/src/main/kotlin/engine/event/Event.kt
+++ b/bot/engine/src/main/kotlin/engine/event/Event.kt
@@ -29,7 +29,9 @@ import org.litote.kmongo.newId
  */
 abstract class Event(
     /**
-     * The bot application id (corresponds to the connector identifier in the admin).
+     * The TOCK application id.
+     *
+     * This ID should match the connector identifier in TOCK Studio.
      *
      * @see ConnectorConfiguration.connectorId
      */

--- a/bot/test-base/src/main/kotlin/BotBusMockInitializers.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMockInitializers.kt
@@ -61,7 +61,8 @@ fun BotDefinition.newBusMockContext(
     locale: Locale = testContext.defaultLocale(),
     userId: PlayerId = testContext.defaultPlayerId(),
     botId: PlayerId = PlayerId("bot", PlayerType.bot),
-    action: Action = SendSentence(userId, this.botId, botId, ""),
+    applicationId: String = this.botId,
+    action: Action = SendSentence(userId, applicationId, botId, ""),
     userInterfaceType: UserInterfaceType = UserInterfaceType.textChat,
     userPreferences: UserPreferences = UserPreferences(locale = locale),
     secondaryConnectorTypes: List<ConnectorType> = listOf(),
@@ -69,7 +70,7 @@ fun BotDefinition.newBusMockContext(
     BotBusMockContext(
         this,
         story,
-        this.botId,
+        applicationId,
         userId,
         botId,
         action,

--- a/bot/test-base/src/main/kotlin/junit/TockJUnit5ExtensionBase.kt
+++ b/bot/test-base/src/main/kotlin/junit/TockJUnit5ExtensionBase.kt
@@ -63,6 +63,17 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
 
     /**
      * Sends a choice and execute the tests.
+     *
+     * @param intent the intent triggered by the simulated button click
+     * @param parameters the extra parameters associated with the simulated button click
+     * @param connectorType the [ConnectorType] on which the simulated action happens
+     * @param userInterfaceType the [UserInterfaceType] through which the simulated action happens
+     * @param locale see [BotBusMock.userLocale]
+     * @param userId see [BotBusMock.userId]
+     * @param botId see [BotBusMock.botId]
+     * @param applicationId see [BotBusMock.applicationId]
+     * @param userPreferences see [BotBusMock.userPreferences]
+     * @param tests a callback defining the assertions to execute after sending the choice
      */
     fun sendChoice(
         intent: IntentAware = testContext.defaultStoryDefinition(botDefinition),
@@ -100,6 +111,17 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
 
     /**
      * Sends a message and execute the tests.
+     *
+     * @param intent the intent triggered by the simulated message
+     * @param message the user message - this message does not go through NLP
+     * @param connectorType the [ConnectorType] on which the simulated action happens
+     * @param userInterfaceType the [UserInterfaceType] through which the simulated action happens
+     * @param locale see [BotBusMock.userLocale]
+     * @param userId see [BotBusMock.userId]
+     * @param botId see [BotBusMock.botId]
+     * @param applicationId see [BotBusMock.applicationId]
+     * @param userPreferences see [BotBusMock.userPreferences]
+     * @param tests a callback containing the assertions to execute after sending the message
      */
     fun sendMessage(
         intent: IntentAware = testContext.defaultStoryDefinition(botDefinition),
@@ -160,6 +182,18 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
 
     /**
      * Sends a sentence and execute the tests.
+     *
+     * @param text the text sent by the user - this text does not go through NLP
+     * @param intent the intent triggered by the [text]
+     * @param entities the entities found in the [text]
+     * @param connectorType the [ConnectorType] on which the simulated action happens
+     * @param userInterfaceType the [UserInterfaceType] through which the simulated action happens
+     * @param locale see [BotBusMock.userLocale]
+     * @param userId see [BotBusMock.userId]
+     * @param botId see [BotBusMock.botId]
+     * @param applicationId see [BotBusMock.applicationId]
+     * @param userPreferences see [BotBusMock.userPreferences]
+     * @param tests a callback containing the assertions to execute after sending the text
      */
     fun send(
         text: String = "",
@@ -243,6 +277,17 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
 
     /**
      * Creates a new choice request (not yet sent).
+     *
+     * @param intent the intent triggered by the simulated button click
+     * @param parameters the extra parameters associated with the simulated button click
+     * @param connectorType the [ConnectorType] on which the simulated action happens
+     * @param userInterfaceType the [UserInterfaceType] through which the simulated action happens
+     * @param locale see [BotBusMock.userLocale]
+     * @param userId see [BotBusMock.userId]
+     * @param botId see [BotBusMock.botId]
+     * @param applicationId see [BotBusMock.applicationId]
+     * @param userPreferences see [BotBusMock.userPreferences]
+     * @param tests a callback containing the test code to execute in the context of the newly setup [BotBusMock]
      */
     fun newChoiceRequest(
         intent: IntentAware = testContext.defaultStoryDefinition(botDefinition),

--- a/bot/test-base/src/main/kotlin/junit/TockJUnit5ExtensionBase.kt
+++ b/bot/test-base/src/main/kotlin/junit/TockJUnit5ExtensionBase.kt
@@ -38,11 +38,11 @@ import ai.tock.bot.test.TestContext
 import ai.tock.bot.test.TestLifecycle
 import ai.tock.bot.test.newBusMockContext
 import ai.tock.translator.UserInterfaceType
+import java.util.Locale
 import mu.KotlinLogging
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import java.util.Locale
 
 /**
  * JUnit5 base extension.
@@ -72,6 +72,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
+        applicationId: String = botDefinition.botId,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         tests: BotBusMock.() -> Unit
     ): BotBusMock {
@@ -87,7 +88,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             {
                 SendChoice(
                     userId,
-                    botDefinition.botId,
+                    applicationId,
                     botId,
                     intent.wrappedIntent().name,
                     parameters.toMap()
@@ -108,6 +109,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
+        applicationId: String = botDefinition.botId,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         tests: BotBusMock.() -> Unit
     ): BotBusMock {
@@ -120,7 +122,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             botId,
             userPreferences,
             listOf(),
-            { message.toAction(userId, botDefinition.botId, botId) },
+            { message.toAction(userId, applicationId, botId) },
             tests
         )
     }
@@ -168,6 +170,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
+        applicationId: String = botDefinition.botId,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         secondaryConnectorTypes: List<ConnectorType> = listOf(),
         metadata: ActionMetadata = ActionMetadata(),
@@ -185,7 +188,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             {
                 SendSentence(
                     userId,
-                    botDefinition.botId,
+                    applicationId,
                     botId,
                     text,
                     state = EventState(
@@ -225,6 +228,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
                     locale,
                     userId,
                     botId,
+                    action.applicationId,
                     action,
                     userInterfaceType,
                     userPreferences,
@@ -248,6 +252,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
+        applicationId: String = botDefinition.botId,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         tests: BotBusMock.() -> Unit
     ) {
@@ -262,7 +267,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             {
                 SendChoice(
                     userId,
-                    botDefinition.botId,
+                    applicationId,
                     botId,
                     intent.wrappedIntent().name,
                     parameters.toMap()
@@ -284,6 +289,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
+        applicationId: String = botDefinition.botId,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         tests: BotBusMock.() -> Unit
     ) {
@@ -298,7 +304,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             {
                 SendSentence(
                     userId,
-                    botDefinition.botId,
+                    applicationId,
                     botId,
                     text,
                     state = EventState(
@@ -337,6 +343,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
                         locale,
                         userId,
                         botId,
+                        action.applicationId,
                         action,
                         userInterfaceType,
                         userPreferences
@@ -389,7 +396,8 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
         locale: Locale = testContext.defaultLocale(),
         userId: PlayerId = testContext.defaultPlayerId(),
         botId: PlayerId = PlayerId("bot", PlayerType.bot),
-        action: Action = SendSentence(userId, botDefinition.botId, botId, ""),
+        applicationId: String = botDefinition.botId,
+        action: Action = SendSentence(userId, applicationId, botId, ""),
         userInterfaceType: UserInterfaceType = UserInterfaceType.textChat,
         userPreferences: UserPreferences = UserPreferences(locale = locale),
         secondaryConnectorTypes: List<ConnectorType> = listOf(),
@@ -401,6 +409,7 @@ open class TockJUnit5ExtensionBase<out T : TestContext>(
             locale,
             userId,
             botId,
+            applicationId,
             action,
             userInterfaceType,
             userPreferences,


### PR DESCRIPTION
This PR resolves #1676 by adding the `applicationId` parameter to relevant test methods. **This is a breaking change**, both in source and binary, however:
- I was not able to find any bot that would actually suffer from the source incompatibility (they all use named arguments because of the already high argument count)
- the binary incompatibility has little impact as these methods are only used in test pipelines.

Therefore, although it would be possible to add deprecated overrides to eliminate the incompatibility, I considered the effort to be unnecessary.

This PR also adds documentation where relevant to make the link between applicationId and connectorId more explicit. Please correct me if said link is unintended.