### PR TITLE
[DERCBOT-1159] Immediate deletion of secrets in the secret manager

### DIFF
--- a/bot/admin/server/src/main/kotlin/service/VectorStoreService.kt
+++ b/bot/admin/server/src/main/kotlin/service/VectorStoreService.kt
@@ -20,6 +20,7 @@ import ai.tock.bot.admin.BotAdminService
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfiguration
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
 import ai.tock.bot.admin.model.BotVectorStoreConfigurationDTO
+import ai.tock.genai.orchestratorcore.utils.SecurityUtils
 import ai.tock.shared.exception.rest.BadRequestException
 import ai.tock.shared.injector
 import ai.tock.shared.provide
@@ -63,8 +64,12 @@ object VectorStoreService {
     fun deleteConfig(namespace: String, botId: String) {
         val vectorStoreConfig = vectorStoreConfigurationDAO.findByNamespaceAndBotId(namespace, botId)
             ?: WebVerticle.badRequest("No Vector Store configuration is defined yet [namespace: $namespace, botId: $botId]")
+
         logger.info { "Deleting the Vector Store Configuration [namespace: $namespace, botId: $botId]" }
-        return vectorStoreConfigurationDAO.delete(vectorStoreConfig._id)
+        vectorStoreConfigurationDAO.delete(vectorStoreConfig._id)
+
+        logger.info { "Deleting the database secret ..." }
+        SecurityUtils.deleteSecret(vectorStoreConfig.setting.password)
     }
 
     /**

--- a/gen-ai/orchestrator-core/src/main/kotlin/ai/tock/genai/orchestratorcore/models/observability/LangfuseObservabilitySetting.kt
+++ b/gen-ai/orchestrator-core/src/main/kotlin/ai/tock/genai/orchestratorcore/models/observability/LangfuseObservabilitySetting.kt
@@ -16,8 +16,10 @@
 
 package ai.tock.genai.orchestratorcore.models.observability
 
+import ai.tock.shared.security.key.HasSecretKey
+
 data class LangfuseObservabilitySetting<T>(
-    val secretKey: T,
+    override val secretKey: T,
     val publicKey: String,
     val url: String
-) : ObservabilitySettingBase<T>(ObservabilityProvider.Langfuse)
+) : ObservabilitySettingBase<T>(ObservabilityProvider.Langfuse), HasSecretKey<T>

--- a/gen-ai/orchestrator-core/src/main/kotlin/ai/tock/genai/orchestratorcore/models/vectorstore/VectorStoreSettingBase.kt
+++ b/gen-ai/orchestrator-core/src/main/kotlin/ai/tock/genai/orchestratorcore/models/vectorstore/VectorStoreSettingBase.kt
@@ -17,7 +17,6 @@
 package ai.tock.genai.orchestratorcore.models.vectorstore
 
 
-import ai.tock.genai.orchestratorcore.mappers.LLMSettingMapper
 import ai.tock.genai.orchestratorcore.mappers.VectorStoreSettingMapper
 import ai.tock.genai.orchestratorcore.models.Constants
 import ai.tock.shared.security.key.SecretKey

--- a/shared/src/main/kotlin/security/SecretManagerService.kt
+++ b/shared/src/main/kotlin/security/SecretManagerService.kt
@@ -20,7 +20,6 @@ import ai.tock.shared.property
 import ai.tock.shared.propertyOrNull
 import ai.tock.shared.security.credentials.AIProviderSecret
 import ai.tock.shared.security.credentials.Credentials
-import ai.tock.shared.security.key.AwsSecretKey
 import ai.tock.shared.security.key.SecretKey
 
 // The expected values correspond to the names of the SecretManagerProviderType elements
@@ -98,6 +97,11 @@ interface SecretManagerService {
      * @return true if supported. Else no.
      */
     fun isSecretTypeSupported(secret : SecretKey): Boolean
+
+    /**
+     * Delete a secret
+     */
+    fun deleteSecret(secretName: String)
 
 }
 

--- a/shared/src/main/kotlin/security/key/SecretKey.kt
+++ b/shared/src/main/kotlin/security/key/SecretKey.kt
@@ -38,3 +38,8 @@ abstract class SecretKey(
 interface NamedSecretKey {
     val secretName: String
 }
+
+interface HasSecretKey<T>{
+    val secretKey: T
+}
+

--- a/util/aws-tools/src/main/kotlin/ai/tock/aws/secretmanager/AwsSecretManagerService.kt
+++ b/util/aws-tools/src/main/kotlin/ai/tock/aws/secretmanager/AwsSecretManagerService.kt
@@ -193,4 +193,17 @@ class AwsSecretManagerService : SecretManagerService {
     override fun createSecretKeyInstance(secretName: String) = AwsSecretKey(secretName)
 
     override fun isSecretTypeSupported(secret: SecretKey): Boolean = secret is AwsSecretKey
+
+    override fun deleteSecret(secretName: String) {
+        try {
+            val deleteRequest = DeleteSecretRequest()
+                .withSecretId(secretName)
+                .withForceDeleteWithoutRecovery(true)
+            secretsManagerClient.deleteSecret(deleteRequest)
+            logger.info { "The secret '$secretName' has been successfully deleted." }
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to delete the secret '$secretName'." }
+            throw e
+        }
+    }
 }

--- a/util/env-tools/src/main/kotlin/ai/tock/env/secretmanager/EnvSecretManagerService.kt
+++ b/util/env-tools/src/main/kotlin/ai/tock/env/secretmanager/EnvSecretManagerService.kt
@@ -21,8 +21,6 @@ import ai.tock.shared.security.SecretManagerProviderType
 import ai.tock.shared.security.SecretManagerService
 import ai.tock.shared.security.credentials.AIProviderSecret
 import ai.tock.shared.security.credentials.Credentials
-import ai.tock.shared.security.genAISecretPrefix
-import ai.tock.shared.security.key.AwsSecretKey
 import ai.tock.shared.security.key.SecretKey
 import kotlinx.serialization.json.Json
 
@@ -56,4 +54,6 @@ class EnvSecretManagerService: SecretManagerService {
     override fun createSecretKeyInstance(secretName: String) = error("Not supported")
 
     override fun isSecretTypeSupported(secret: SecretKey) = error("Not supported")
+
+    override fun deleteSecret(secretName: String) = error("Not supported")
 }

--- a/util/gcp-tools/src/main/kotlin/ai/tock/gcp/secretmanager/GcpSecretManagerService.kt
+++ b/util/gcp-tools/src/main/kotlin/ai/tock/gcp/secretmanager/GcpSecretManagerService.kt
@@ -134,4 +134,14 @@ class GcpSecretManagerService: SecretManagerService {
     override fun createSecretKeyInstance(secretName: String) = GcpSecretKey(secretName)
 
     override fun isSecretTypeSupported(secret: SecretKey): Boolean = secret is GcpSecretKey
+
+    override fun deleteSecret(secretName: String) {
+        try {
+            client.deleteSecret(SecretName.of(EnvConfig.gcpProjectId, secretName))
+            logger.info { "The secret '$secretName' has been successfully deleted." }
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to delete the secret '$secretName'." }
+            throw e
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the security and observability features of the bot administration services. The most significant updates include the addition of secret deletion functionality and the integration of observability settings.

### Security Enhancements:

* Added `deleteSecret` method in `SecurityUtils` to handle secret deletion, with support for different secret types and providers (`gen-ai/orchestrator-core/src/main/kotlin/ai/tock/genai/orchestratorcore/utils/SecurityUtils.kt`).
* Implemented the `deleteSecret` method in `SecretManagerService` interface and its various implementations, including AWS, GCP, and environment-based secret managers (`shared/src/main/kotlin/security/SecretManagerService.kt`, `util/aws-tools/src/main/kotlin/ai/tock/aws/secretmanager/AwsSecretManagerService.kt`, `util/gcp-tools/src/main/kotlin/ai/tock/gcp/secretmanager/GcpSecretManagerService.kt`, `util/env-tools/src/main/kotlin/ai/tock/env/secretmanager/EnvSecretManagerService.kt`) [[1]](diffhunk://#diff-8a58a26a135632242cf9bb6da9cb5ca9db35527c5d98e259f2d39565eaea406fR101-R105) [[2]](diffhunk://#diff-ff91519f484b8d12a004c580c63b59184dc4b8b2e88a756481d48563ce21ae49R196-R208) [[3]](diffhunk://#diff-a924714744b82c48bb1b1c339af0d084b38754b5355ef34d817bc0acd48da36eR137-R146).

### Observability Integration:

* Added imports for `LangfuseObservabilitySetting` and `SecurityUtils` in `BotAdminService`, `ObservabilityService`, and `RAGService` to support observability settings and secret management (`bot/admin/server/src/main/kotlin/BotAdminService.kt`, `bot/admin/server/src/main/kotlin/service/ObservabilityService.kt`, `bot/admin/server/src/main/kotlin/service/RAGService.kt`) [[1]](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeR41-R42) [[2]](diffhunk://#diff-fbc899c246301bb38c0b2532f774260483a788be7bc481677d9891cb703bcc94R23-R24) [[3]](diffhunk://#diff-1a32c8cf0c275ddb0ad9e9515b485b4452395d5c0d156db82ae2c4c8c720486fR26).

### Configuration Deletion Updates:

* Enhanced configuration deletion methods across various services (`BotAdminService`, `ObservabilityService`, `RAGService`, `SentenceGenerationService`, `VectorStoreService`) to ensure associated secrets are also deleted (`bot/admin/server/src/main/kotlin/BotAdminService.kt`, `bot/admin/server/src/main/kotlin/service/ObservabilityService.kt`, `bot/admin/server/src/main/kotlin/service/RAGService.kt`, `bot/admin/server/src/main/kotlin/service/SentenceGenerationService.kt`, `bot/admin/server/src/main/kotlin/service/VectorStoreService.kt`) [[1]](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeL1144-R1171) [[2]](diffhunk://#diff-fbc899c246301bb38c0b2532f774260483a788be7bc481677d9891cb703bcc94R67-R75) [[3]](diffhunk://#diff-1a32c8cf0c275ddb0ad9e9515b485b4452395d5c0d156db82ae2c4c8c720486fR63-R70) [[4]](diffhunk://#diff-4d669fdbbff164a0c0a2b9b43c1b1ed1790431d905424cf25d71bea55a90ce26L55-R61) [[5]](diffhunk://#diff-c5f3084437f8670e52ae291382dadf5f76e0abb1902bbcaa921257d2c175a2bdR67-R72).

These changes collectively enhance the security and observability capabilities of the bot administration services by ensuring that secrets are properly managed and deleted when configurations are removed.