### PR TITLE
resolves #1763 web_connector: add windowFeatures parameter to URL button

### DIFF
--- a/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/UrlButton.kt
+++ b/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/UrlButton.kt
@@ -25,5 +25,6 @@ data class UrlButton(
     val url: String,
     val imageUrl: String? = null,
     val target: String? = HrefTargetType._blank.name,
-    val style: String? = ButtonStyle.primary.name
+    val style: String? = ButtonStyle.primary.name,
+    val windowFeatures: String? = null,
 ) : Button(ButtonType.web_url)

--- a/bot/connector-web/src/main/kotlin/WebBuilders.kt
+++ b/bot/connector-web/src/main/kotlin/WebBuilders.kt
@@ -98,7 +98,13 @@ fun <T : Bus<T>> T.webButton(
     )
 
 /**
- * Creates a url button
+ * Creates a URL button
+ *
+ * @param title the text that should appear on the button
+ * @param url the URL of the page that should be opened when clicking on the button
+ * @param imageUrl the URL of an image file to display as an icon inside the button
+ * @param target the link's target, typically either _self or _blank
+ * @param style the style of the button - the specific appearance for a given style is defined by the frontend
  */
 fun <T : Bus<T>> T.webUrlButton(
     title: CharSequence,
@@ -107,22 +113,40 @@ fun <T : Bus<T>> T.webUrlButton(
     target: HrefTargetType,
     style: ButtonStyle
 ): Button =
-    webUrlButton(title, url, imageUrl, target.name, style.name)
+    webUrlButton(title, url, imageUrl, target.name, style.name, null)
 
 /**
- * Creates a url button
+ * Creates a URL button
+ *
+ * @param title the text that should appear on the button
+ * @param url the URL of the page that should be opened when clicking on the button
+ * @param imageUrl the URL of an image file to display as an icon inside the button
+ * @param target the link's [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
+ *   If [windowFeatures] is also specified, this parameter is used for the
+ *   [window's target](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#target) instead
+ * @param style the style of the button - the specific appearance for a given style is defined by the frontend
+ * @param windowFeatures if specified, the button will open the URL in a popup window configured using the
+ *   [windowFeatures](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#windowfeatures) argument
  */
+@JvmOverloads // binary backward compatibility
 fun <T : Bus<T>> T.webUrlButton(
     title: CharSequence,
     url: String,
     imageUrl: String? = null,
     target: String? = HrefTargetType._blank.name,
-    style: ButtonStyle
+    style: ButtonStyle,
+    windowFeatures: String? = null,
 ): Button =
-    webUrlButton(title, url, imageUrl, target, style.name)
+    webUrlButton(title, url, imageUrl, target, style.name, windowFeatures)
 
 /**
- * Creates a url button
+ * Creates a URL button
+ *
+ * @param title the text that should appear on the button
+ * @param url the URL of the page that should be opened when clicking on the button
+ * @param imageUrl the URL of an image file to display as an icon inside the button
+ * @param target the link's target, typically either _self or _blank
+ * @param style the style of the button - the specific appearance for a given style is defined by the frontend
  */
 fun <T : Bus<T>> T.webUrlButton(
     title: CharSequence,
@@ -131,24 +155,37 @@ fun <T : Bus<T>> T.webUrlButton(
     target: HrefTargetType,
     style: String? = ButtonStyle.primary.name
 ): Button =
-    webUrlButton(title, url, imageUrl, target.name, style)
+    webUrlButton(title, url, imageUrl, target.name, style, null)
 
 /**
- * Creates a url button
+ * Creates a URL button
+ *
+ * @param title the text that should appear on the button
+ * @param url the URL of the page that should be opened when clicking on the button
+ * @param imageUrl the URL of an image file to display as an icon inside the button
+ * @param target the link's [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target).
+ *   If [windowFeatures] is also specified, this parameter is used for the
+ *   [window's target](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#target) instead
+ * @param style the style of the button - the specific appearance for a given style is defined by the frontend
+ * @param windowFeatures if specified, the button will open the URL in a popup window configured using the
+ *   [windowFeatures](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#windowfeatures) argument
  */
+@JvmOverloads // binary backward compatibility
 fun <T : Bus<T>> T.webUrlButton(
     title: CharSequence,
     url: String,
     imageUrl: String? = null,
     target: String? = HrefTargetType._blank.name,
-    style: String? = ButtonStyle.primary.name
+    style: String? = ButtonStyle.primary.name,
+    windowFeatures: String? = null,
 ): Button =
     UrlButton(
         translate(title).toString(),
         url,
         imageUrl,
         target,
-        style
+        style,
+        windowFeatures,
     )
 
 /**

--- a/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
+++ b/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
@@ -17,7 +17,14 @@
 import ai.tock.bot.connector.web.HrefTargetType
 import ai.tock.bot.connector.web.WebConnectorResponseContent
 import ai.tock.bot.connector.web.WebMediaFile
-import ai.tock.bot.connector.web.send.*
+import ai.tock.bot.connector.web.send.Footnote
+import ai.tock.bot.connector.web.send.PostbackButton
+import ai.tock.bot.connector.web.send.QuickReply
+import ai.tock.bot.connector.web.send.UrlButton
+import ai.tock.bot.connector.web.send.WebCard
+import ai.tock.bot.connector.web.send.WebCarousel
+import ai.tock.bot.connector.web.send.WebDeepLink
+import ai.tock.bot.connector.web.send.WebMessageContent
 import ai.tock.bot.engine.action.SendAttachment
 import ai.tock.shared.jackson.mapper
 import ai.tock.shared.resourceAsStream
@@ -112,6 +119,27 @@ internal class WebConnectorResponseTest {
         )
         val deserializedEvent =
             mapper.readValue<WebConnectorResponseContent>(resourceAsStream("/card_with_url_button_opened_same_window.json"))
+        Assertions.assertThat(deserializedEvent).isEqualTo(expected)
+    }
+
+    @Test
+    fun `text with url button opened in a popup window`() {
+        val expected = WebConnectorResponseContent(
+            responses = listOf(
+                WebMessageContent(
+                    text = "Text with UrlButton",
+                    buttons = listOf(
+                        UrlButton(
+                            title = "title",
+                            url = "http://www.sncf.com",
+                            windowFeatures = "width=400,height=500",
+                        )
+                    )
+                )
+            )
+        )
+        val deserializedEvent =
+            mapper.readValue<WebConnectorResponseContent>(resourceAsStream("/card_with_url_button_opened_popup_window.json"))
         Assertions.assertThat(deserializedEvent).isEqualTo(expected)
     }
 

--- a/bot/connector-web/src/test/resources/card_with_url_button_opened_popup_window.json
+++ b/bot/connector-web/src/test/resources/card_with_url_button_opened_popup_window.json
@@ -1,0 +1,20 @@
+{
+  "responses": [
+    {
+      "text": "Text with UrlButton",
+      "buttons": [
+        {
+          "title": "title",
+          "url": "http://www.sncf.com",
+          "target": "_blank",
+          "windowFeatures": "width=400,height=500",
+          "type": "web_url",
+          "style": "primary",
+          "clazz": "url_button"
+        }
+      ],
+      "version": "1",
+      "type": "WebMessage"
+    }
+  ]
+}


### PR DESCRIPTION
resolves #1763 by adding a new `windowFeatures` parameter to the `UrlButton` interface.

> [!NOTE]
> This new parameter will require an update of the tock-react-kit and tock-vue-kit to be effective.

I did not add the `windowFeatures` argument to the two overloads of `webUrlButton` that take an `HrefTargetType` enum, as it would seem contradictory to try to open a popup window with a predefined `HrefTargetType` that is not `_blank` (the default).
The `@JvmOverloads` annotation is here to preserve binary compatibility with previous versions of the web connector.

Associated PRs:
- theopenconversationkit/tock-react-kit#171