### PR TITLE
fixes #1768 whatsapp_connector: switch to UUIDs for whatsapp userId generation

### DIFF
--- a/bot/connector-whatsapp-cloud/src/main/kotlin/UserHashedIdCache.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/UserHashedIdCache.kt
@@ -16,7 +16,7 @@
 
 package ai.tock.bot.connector.whatsapp.cloud
 
-import ai.tock.shared.security.shaS256
+import ai.tock.shared.security.sha256Uuid
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import java.util.concurrent.TimeUnit
@@ -28,7 +28,7 @@ object UserHashedIdCache {
             .expireAfterAccess(60, TimeUnit.MINUTES)
             .build()
 
-    fun createHashedId(id: String): String = shaS256(id).apply { idCache.put(this, id) }
+    fun createHashedId(id: String): String = sha256Uuid(id).toString().apply { idCache.put(this, id) }
 
     fun getRealId(hashedId: String): String = idCache.getIfPresent(hashedId)
         ?: throw CacheExpiredException("Cache expired or real ID not found for hashedId: $hashedId")

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -38,13 +38,16 @@ import ai.tock.bot.engine.event.Event
 import ai.tock.bot.engine.monitoring.logError
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.PlayerType.bot
-import ai.tock.shared.*
+import ai.tock.shared.Executor
+import ai.tock.shared.error
+import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
+import ai.tock.shared.listProperty
 import ai.tock.shared.security.RequestFilter
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.salomonbrys.kodein.instance
-import mu.KotlinLogging
 import java.time.Duration
+import mu.KotlinLogging
 
 class WhatsAppConnectorCloudConnector internal constructor(
     val connectorId: String,
@@ -196,28 +199,18 @@ class WhatsAppConnectorCloudConnector internal constructor(
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit
     ) {
-        val copyRecipientId = recipientId.copy(
-            id = encodeRecipientId(recipientId.id),
-        )
         controller.handle(
-
             SendChoice(
-                copyRecipientId,
+                recipientId,
                 connectorId,
                 PlayerId(connectorId, bot),
                 intent.wrappedIntent().name,
                 step,
-                parameters
+                parameters,
             ),
             ConnectorData(
                 WhatsAppConnectorCloudCallback(connectorId)
             )
         )
-    }
-
-    private fun encodeRecipientId(input: String): String {
-        return input.replace(" ", "+").let {
-            if (it.endsWith("\r\n")) it else "$it\r\n"
-        }
     }
 }

--- a/shared/src/main/kotlin/security/Encryptors.kt
+++ b/shared/src/main/kotlin/security/Encryptors.kt
@@ -61,19 +61,22 @@ fun shaS256(s: String): String =
         )
     )
 
-private const val TOCK_UUID_NAMESPACE = "d47dd856-920a-11ef-955b-325096b39f47"
-private val tockUuidNamespaceBytes = TOCK_UUID_NAMESPACE.toByteArray()
+/**
+ * The OID namespace identifier, as defined in RFC-4122
+ */
+private const val UUID_OID_NAMESPACE = "6ba7b812-9dad-11d1-80b4-00c04fd430c8"
+private val oidNamespaceBytes = UUID_OID_NAMESPACE.toByteArray()
 
 /**
  * Generates a UUID based on a sha256 hash of the given string.
  */
 fun sha256Uuid(s: String, namespace: UUID? = null): UUID {
     val digest = MessageDigest.getInstance("SHA-256").apply {
-        update(namespace?.toString()?.toByteArray() ?: tockUuidNamespaceBytes)
+        update(namespace?.toString()?.toByteArray() ?: oidNamespaceBytes)
         update(s.toByteArray())
     }.digest()
     digest[6] = (digest[6].toInt() and 0x0f).toByte() /* clear version        */
-    digest[6] = (digest[6].toInt() or  0x50).toByte() /* set to version 5     */
+    digest[6] = (digest[6].toInt() or  0x80).toByte() /* set to version 8     */
     digest[8] = (digest[8].toInt() and 0x3f).toByte() /* clear variant        */
     digest[8] = (digest[8].toInt() or  0x80).toByte() /* set to IETF variant  */
     return uuidFromBytes(digest)

--- a/shared/src/main/kotlin/security/Encryptors.kt
+++ b/shared/src/main/kotlin/security/Encryptors.kt
@@ -61,11 +61,17 @@ fun shaS256(s: String): String =
         )
     )
 
+private const val TOCK_UUID_NAMESPACE = "d47dd856-920a-11ef-955b-325096b39f47"
+private val tockUuidNamespaceBytes = TOCK_UUID_NAMESPACE.toByteArray()
+
 /**
  * Generates a UUID based on a sha256 hash of the given string.
  */
-fun sha256Uuid(s: String): UUID {
-    val digest = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(StandardCharsets.UTF_8))
+fun sha256Uuid(s: String, namespace: UUID? = null): UUID {
+    val digest = MessageDigest.getInstance("SHA-256").apply {
+        update(namespace?.toString()?.toByteArray() ?: tockUuidNamespaceBytes)
+        update(s.toByteArray())
+    }.digest()
     digest[6] = (digest[6].toInt() and 0x0f).toByte() /* clear version        */
     digest[6] = (digest[6].toInt() or  0x50).toByte() /* set to version 5     */
     digest[8] = (digest[8].toInt() and 0x3f).toByte() /* clear variant        */

--- a/shared/src/test/kotlin/security/EncryptorsTest.kt
+++ b/shared/src/test/kotlin/security/EncryptorsTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.shared.security
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class EncryptorsTest {
+    @Test
+    fun `sha256Uuid should preserve hash properties`() {
+        val values = listOf("+33611111111", "+33611111112", "abcdef", "x", "y", "1", "11")
+        val uuids = values.map { sha256Uuid(it) }
+        assertEquals(values.size, uuids.distinct().size, "No collision")
+        assertEquals(uuids, values.map { sha256Uuid(it) }, "Determinism")
+        assertNotEquals(uuids, uuids.map { sha256Uuid(it.toString()) }, "No idempotence")
+    }
+}

--- a/shared/src/test/kotlin/security/EncryptorsTest.kt
+++ b/shared/src/test/kotlin/security/EncryptorsTest.kt
@@ -22,6 +22,14 @@ import org.junit.jupiter.api.Test
 
 class EncryptorsTest {
     @Test
+    fun `sha256Uuid should produce valid UUIDs`() {
+        val result = sha256Uuid("+33601234567")
+        assertEquals(2, result.variant())
+        assertEquals(5, result.version())
+        assertEquals("a6db4f9b-e00f-5328-9e91-5b8d560cc4b9", result.toString(), "result should not change between versions")
+    }
+
+    @Test
     fun `sha256Uuid should preserve hash properties`() {
         val values = listOf("+33611111111", "+33611111112", "abcdef", "x", "y", "1", "11")
         val uuids = values.map { sha256Uuid(it) }

--- a/shared/src/test/kotlin/security/EncryptorsTest.kt
+++ b/shared/src/test/kotlin/security/EncryptorsTest.kt
@@ -25,8 +25,8 @@ class EncryptorsTest {
     fun `sha256Uuid should produce valid UUIDs`() {
         val result = sha256Uuid("+33601234567")
         assertEquals(2, result.variant())
-        assertEquals(5, result.version())
-        assertEquals("a6db4f9b-e00f-5328-9e91-5b8d560cc4b9", result.toString(), "result should not change between versions")
+        assertEquals(8, result.version())
+        assertEquals("d58d7b07-94f8-8d6a-bcbe-c9745ec6e6da", result.toString(), "result should not change between versions")
     }
 
     @Test


### PR DESCRIPTION
fixes #1768 by adding a new `UUID` factory using a SHA-256 digest. The new factory method's implementation is based on `UUID#nameUUIDFromBytes`, but replaces the now deprecated MD5 with SHA-256. As per the [latest UUID specification](https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-5), the resulting name-based UUIDs are within the UUIDv8 space (vendor-specific).

Reverts some temporary workarounds made in #1770 
Also closes #1769 