### PR TITLE
 Interpret Links on the WEB Connector

### DIFF
--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -119,7 +119,8 @@ class WebConnector internal constructor(
         private val messageProcessor = WebMessageProcessor(
             processMarkdown = propertyOrNull("tock_web_enable_markdown")?.toBoolean()
             // Fallback to previous property name for backward compatibility
-            ?: propertyOrNull("allow_markdown").toBoolean()
+                ?: propertyOrNull("allow_markdown").toBoolean(),
+            interpretLink = booleanProperty ("tock_web_enable_interpret_link", true)
         )
         private val channels by lazy { Channels() }
     }

--- a/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
+++ b/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
@@ -20,8 +20,9 @@ import ai.tock.bot.connector.web.send.Footnote
 import ai.tock.bot.engine.action.Action
 import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.action.SendSentenceWithFootnotes
+import ai.tock.shared.detectAndWrapLinks
 
-internal class WebMessageProcessor(private val processMarkdown: Boolean) {
+internal class WebMessageProcessor(private val processMarkdown: Boolean, private val interpretLink: Boolean) {
 
     fun process(action: Action): WebMessage? {
         return when(action){
@@ -62,6 +63,9 @@ internal class WebMessageProcessor(private val processMarkdown: Boolean) {
     private fun postProcess(text: String): String {
         if (processMarkdown) {
             return WebMarkdown.markdown(text)
+        }
+        else if (interpretLink) {
+            return detectAndWrapLinks(text)
         }
 
         return text

--- a/shared/src/main/kotlin/Strings.kt
+++ b/shared/src/main/kotlin/Strings.kt
@@ -79,6 +79,7 @@ fun concat(s1: String?, s2: String?): String {
 
 private val trailingRegexp = "[.,:;?!]+$".toRegex()
 private val accentsRegexp = "[\\p{InCombiningDiacriticalMarks}]".toRegex()
+private val urlRegex = "(https?://\\S+)".toRegex()
 
 private fun String.removeTrailingPunctuation() = this.replace(trailingRegexp, "").trim()
 
@@ -88,11 +89,18 @@ fun String.stripAccents(): String =
 fun String.normalize(locale: Locale): String =
     this.lowercase(locale).removeTrailingPunctuation().stripAccents()
 
-fun allowDiacriticsInRegexp(s: String) : String = s.replace("e", "[eéèêë]", ignoreCase = true)
-        .replace("a", "[aàáâãä]", ignoreCase = true)
-        .replace("i", "[iìíîï]", ignoreCase = true)
-        .replace("o", "[oòóôõöø]", ignoreCase = true)
-        .replace("u", "[uùúûü]", ignoreCase = true)
-        .replace("n", "[nñ]", ignoreCase = true)
-        .replace(" ", "['-_ ]")
-        .replace("c", "[cç]", ignoreCase = true)
+fun allowDiacriticsInRegexp(s: String): String = s.replace("e", "[eéèêë]", ignoreCase = true)
+    .replace("a", "[aàáâãä]", ignoreCase = true)
+    .replace("i", "[iìíîï]", ignoreCase = true)
+    .replace("o", "[oòóôõöø]", ignoreCase = true)
+    .replace("u", "[uùúûü]", ignoreCase = true)
+    .replace("n", "[nñ]", ignoreCase = true)
+    .replace(" ", "['-_ ]")
+    .replace("c", "[cç]", ignoreCase = true)
+
+fun detectAndWrapLinks(text: String): String {
+    return text.replace(urlRegex) { matchResult ->
+        val url = matchResult.value
+        "<a href=\"$url\" target=\"_blank\">$url</a>"
+    }
+}

--- a/shared/src/test/kotlin/StringsTest.kt
+++ b/shared/src/test/kotlin/StringsTest.kt
@@ -35,4 +35,10 @@ class StringsTest {
         assertEquals(allowDiacriticsInRegexp("demo"), "d[eéèêë]m[oòóôõöø]")
         assertEquals(allowDiacriticsInRegexp("c est une mise a jour"), "[cç]['-_ ][eéèêë]st['-_ ][uùúûü][nñ][eéèêë]['-_ ]m[iìíîï]s[eéèêë]['-_ ][aàáâãä]['-_ ]j[oòóôõöø][uùúûü]r")
     }
+
+    @Test
+    fun `Test Regex for interpret links`() {
+        val rawText = "Visitez https://doc.tock.ai/ pour plus d'informations. Vous pouvez aussi aller sur http://doc.tock.ai/"
+        assertEquals(detectAndWrapLinks(rawText), "Visitez <a href=\"https://doc.tock.ai/\" target=\"_blank\">https://doc.tock.ai/</a> pour plus d'informations. Vous pouvez aussi aller sur <a href=\"http://doc.tock.ai/\" target=\"_blank\">http://doc.tock.ai/</a>")
+    }
 }


### PR DESCRIPTION
This pull request introduces a new feature for interpreting and wrapping URLs in messages, along with some minor refactoring. The most important changes include adding a new property to the `WebConnector` class, updating the `WebMessageProcessor` to handle URL interpretation, and adding a utility function for detecting and wrapping links.

### Feature Enhancements:

* [`bot/connector-web/src/main/kotlin/WebConnector.kt`](diffhunk://#diff-943b2608454f8da608e5ef3dad28854016662d8fbb5e4b553ac8963c60266827L122-R123): Added a new property `interpretLink` to the `WebMessageProcessor` initialization to enable URL interpretation.
* [`bot/connector-web/src/main/kotlin/WebMessageProcessor.kt`](diffhunk://#diff-c333f2deab24ed95ceb6a66a9a84f286c4821695dc18825bdc33854a96301e1eR23-R25): Updated the `WebMessageProcessor` to include the `interpretLink` property and added logic to detect and wrap URLs in the text. [[1]](diffhunk://#diff-c333f2deab24ed95ceb6a66a9a84f286c4821695dc18825bdc33854a96301e1eR23-R25) [[2]](diffhunk://#diff-c333f2deab24ed95ceb6a66a9a84f286c4821695dc18825bdc33854a96301e1eR67-R69)

### Utility Functions:

* [`shared/src/main/kotlin/Strings.kt`](diffhunk://#diff-f390b3c0bb9ccedca2d6105de5e3d262f6cbc058ec358b954aab287aea38373aR100-R106): Introduced a new function `detectAndWrapLinks` to detect URLs in a string and wrap them in HTML anchor tags.

### Testing:

* [`shared/src/test/kotlin/StringsTest.kt`](diffhunk://#diff-252052823b3f39bfbefabd189cdff8d032e40fc7e7f9468e6d80228b13e2e8b2R38-R43): Added a test case to validate the `detectAndWrapLinks` function.