### PR TITLE
[DERCBOT-1158] Add footnotes to FAQ + I18n for answer

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -616,7 +616,7 @@ object BotAdminService {
             else -> error("unsupported type $this")
         }
 
-    private fun BotAnswerConfiguration.toStoryConfiguration(
+    private fun BotAnswerConfiguration.toAnswerConfiguration(
         botId: String,
         oldStory: StoryDefinitionConfiguration?
     ): AnswerConfiguration? =
@@ -744,7 +744,7 @@ object BotAdminService {
             category = story.category,
             currentType = story.currentType,
             intent = story.intent,
-            answers = story.answers.mapNotNull { it.toStoryConfiguration(botId, oldStory) },
+            answers = story.answers.mapNotNull { it.toAnswerConfiguration(botId, oldStory) },
             mandatoryEntities = story.mandatoryEntities.map {
                 it.toEntityConfiguration(
                     application,
@@ -860,7 +860,7 @@ object BotAdminService {
                         botId = story.botId,
                         intent = story.intent,
                         currentType = story.currentType,
-                        answers = story.answers.mapNotNull { it.toStoryConfiguration(botConf.botId, null) },
+                        answers = story.answers.mapNotNull { it.toAnswerConfiguration(botConf.botId, null) },
                         version = 0,
                         namespace = namespace,
                         mandatoryEntities = story.mandatoryEntities.map {

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -996,7 +996,7 @@ open class BotAdminVerticle : AdminVerticle() {
             setOf(botUser),
             logger<FaqDefinitionRequest>("Save FAQ")
         ) { context, query: FaqDefinitionRequest ->
-            if (query.utterances.isEmpty() && query.title.isBlank() && query.answer.isBlank()) {
+            if (query.utterances.isEmpty() && query.title.isBlank()) {
                 badRequest("Missing argument or trouble in query: $query")
             } else {
                 val applicationDefinition = front.getApplicationByNamespaceAndName(

--- a/bot/admin/server/src/main/kotlin/FaqAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/FaqAdminService.kt
@@ -106,33 +106,31 @@ object FaqAdminService {
         val existingFaqInCurrentApplication =
             faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(intent._id, query.applicationName)
 
-        val i18nLabel: I18nLabel = manageI18nLabelUpdate(query, application.namespace, existingFaqInCurrentApplication)
-
         val faqDefinition: FaqDefinition = prepareCreationOrUpdatingFaqDefinition(
-            query, application, intent, i18nLabel, existingFaqInCurrentApplication
+            query, application, intent, existingFaqInCurrentApplication
         )
         faqDefinitionDAO.save(faqDefinition)
 
         // create the story
         createOrUpdateStory(
-            query, intent, userLogin, i18nLabel, application, faqSettings
+            query, intent, userLogin, application, faqSettings
         )
 
         return FaqDefinitionRequest(
-            faqDefinition._id.toString(),
-            faqDefinition.intentId.toString(),
-            query.language,
-            query.applicationName,
-            faqDefinition.creationDate,
-            faqDefinition.updateDate,
-            intent.label.toString(),
-            intent.description.toString(),
-            query.utterances,
-            query.tags,
-            //get the only answer for the Faq
-            i18nLabel.i18n.first().label,
-            query.enabled,
-            intent.name
+            id = faqDefinition._id.toString(),
+            intentId = faqDefinition.intentId.toString(),
+            language = query.language,
+            applicationName = query.applicationName,
+            creationDate = faqDefinition.creationDate,
+            updateDate = faqDefinition.updateDate,
+            title = intent.label.toString(),
+            description = intent.description.toString(),
+            utterances = query.utterances,
+            tags = query.tags,
+            answer = query.answer,
+            enabled = query.enabled,
+            intentName = intent.name,
+            footnotes = query.footnotes
         )
     }
 
@@ -172,7 +170,6 @@ object FaqAdminService {
         query: FaqDefinitionRequest,
         application: ApplicationDefinition,
         intent: IntentDefinition,
-        i18nLabel: I18nLabel,
         existingFaq: FaqDefinition?
     ): FaqDefinition {
         //updating existing faq or creating faq
@@ -195,7 +192,7 @@ object FaqAdminService {
                 botId = application.name,
                 intentId = intent._id,
                 namespace = application.namespace,
-                i18nId = i18nLabel._id,
+                i18nId = query.answer._id,
                 tags = query.tags,
                 enabled = query.enabled,
                 creationDate = Instant.now(),
@@ -211,7 +208,6 @@ object FaqAdminService {
         query: FaqDefinitionRequest,
         intent: IntentDefinition,
         userLogin: UserLogin,
-        i18nLabel: I18nLabel,
         applicationDefinition: ApplicationDefinition,
         faqFaqSettingsQuery: FaqSettingsQuery?
     ) {
@@ -220,12 +216,12 @@ object FaqAdminService {
         )
 
         val storyDefinitionConfiguration = prepareStoryCreationOrUpdate(
-            query, intent, i18nLabel, applicationDefinition, existingStory, faqFaqSettingsQuery
+            query, intent, applicationDefinition, existingStory, faqFaqSettingsQuery
         )
 
         BotAdminService.saveStory(
             applicationDefinition.namespace,
-            BotStoryDefinitionConfiguration(storyDefinitionConfiguration, i18nLabel.defaultLocale, false),
+            BotStoryDefinitionConfiguration(storyDefinitionConfiguration, query.answer.defaultLocale, false),
             userLogin,
             intent
 
@@ -291,7 +287,6 @@ object FaqAdminService {
     private fun prepareStoryCreationOrUpdate(
         query: FaqDefinitionRequest,
         intent: IntentDefinition,
-        i18nLabel: I18nLabel,
         applicationDefinition: ApplicationDefinition,
         existingStory: StoryDefinitionConfiguration?,
         faqFaqSettingsQuery: FaqSettingsQuery?
@@ -303,7 +298,18 @@ object FaqAdminService {
                 applicationDefinition.name,
                 existingStory.intent,
                 AnswerConfigurationType.simple,
-                listOf(SimpleAnswerConfiguration(listOf(SimpleAnswer(I18nLabelValue(i18nLabel), -1, null)))),
+                listOf(
+                    SimpleAnswerConfiguration(
+                        listOf(
+                            SimpleAnswer(
+                                key = I18nLabelValue(query.answer),
+                                delay = -1,
+                                mediaMessage = null,
+                                footnotes = query.footnotes
+                            )
+                        )
+                    )
+                ),
                 1,
                 applicationDefinition.namespace,
                 existingStory.mandatoryEntities,
@@ -312,7 +318,7 @@ object FaqAdminService {
                 FAQ_CATEGORY,
                 query.description.trim(),
                 query.utterances.first(),
-                i18nLabel.defaultLocale,
+                query.answer.defaultLocale,
                 existingStory.configurationName,
                 features,
                 existingStory._id,
@@ -326,7 +332,18 @@ object FaqAdminService {
                 applicationDefinition.name,
                 IntentWithoutNamespace(intent.name),
                 AnswerConfigurationType.simple,
-                listOf(SimpleAnswerConfiguration(listOf(SimpleAnswer(I18nLabelValue(i18nLabel), -1, null)))),
+                listOf(
+                    SimpleAnswerConfiguration(
+                        listOf(
+                            SimpleAnswer(
+                                key = I18nLabelValue(query.answer),
+                                delay = -1,
+                                mediaMessage = null,
+                                footnotes = query.footnotes
+                            )
+                        )
+                    )
+                ),
                 1,
                 applicationDefinition.namespace,
                 emptyList(),
@@ -335,7 +352,7 @@ object FaqAdminService {
                 FAQ_CATEGORY,
                 intent.description!!,
                 query.utterances.first(),
-                i18nLabel.defaultLocale,
+                query.answer.defaultLocale,
                 features = features
             )
         }
@@ -500,22 +517,26 @@ object FaqAdminService {
 
         return faqs
             .filter(faqWithStoryIntentName)
-            .map { faq -> faq.updatedFaqSearchWithStoryNameAndDescription(faqStoriesByIntentName) }
+            .map { faq -> faq.updatedFaqSearch(faqStoriesByIntentName) }
             // give back all other elements
             .union(faqs.filterNot(faqWithStoryIntentName))
     }
 
     /**
-     * lambda to update Faq with story name and description
+     * lambda to update Faq with story name, description and footnotes
      * @param : faqStoriesByIntentName : Map<String, StoryDefinitionConfiguration>
      * @return : FaqDefinitionRequest
      * @see FaqDefinitionRequest
      */
-    private val updatedFaqSearchWithStoryNameAndDescription: FaqDefinitionRequest.(Map<String, StoryDefinitionConfiguration>) -> FaqDefinitionRequest =
+    private val updatedFaqSearch: FaqDefinitionRequest.(Map<String, StoryDefinitionConfiguration>) -> FaqDefinitionRequest =
         {
             // intentName is not empty since it is present in the map
             it[this.intentName]!!.let { story ->
-                this.copy(title = story.name, description = story.description)
+                val footnotes =
+                    (story.answers.find { answer -> answer is SimpleAnswerConfiguration } as? SimpleAnswerConfiguration)
+                        ?.answers?.firstOrNull()?.footnotes
+
+                this.copy(title = story.name, description = story.description, footnotes = footnotes)
             }
         }
 
@@ -642,22 +663,19 @@ object FaqAdminService {
                 )
                 val currentLanguage = currentUtterance.map { it.language }.first()
                 FaqDefinitionRequest(
-                    faqDefinition._id.toString(),
-                    faqDefinition.intentId.toString(),
-                    currentLanguage,
-                    applicationDefinition.name,
-                    faqDefinition.creationDate,
-                    faqDefinition.updateDate,
-                    faqDefinition.faq.label.orEmpty(),
-                    faqDefinition.faq.description.orEmpty(),
-                    currentUtterance.map { it.text },
-                    faqDefinition.tags,
-                    // find the label or replace it with a fake unknown answer
-                    faqDefinition.i18nLabel.i18n.map { it.label }.firstOrNull().orEmpty().ifEmpty {
-                        unknownI18n(applicationDefinition).i18n.map { it.label }.first()
-                    },
-                    faqDefinition.enabled,
-                    faqDefinition.faq.name
+                    id = faqDefinition._id.toString(),
+                    intentId = faqDefinition.intentId.toString(),
+                    language = currentLanguage,
+                    applicationName = applicationDefinition.name,
+                    creationDate = faqDefinition.creationDate,
+                    updateDate = faqDefinition.updateDate,
+                    title = faqDefinition.faq.label.orEmpty(),
+                    description = faqDefinition.faq.description.orEmpty(),
+                    utterances = currentUtterance.map { it.text },
+                    tags = faqDefinition.tags,
+                    answer = faqDefinition.i18nLabel,
+                    enabled = faqDefinition.enabled,
+                    intentName = faqDefinition.faq.name
                 )
             }.toSet()
 
@@ -708,35 +726,6 @@ object FaqAdminService {
         }
     }
 
-    /**
-     * Create or update I18nLabelUpdate
-     */
-    private fun manageI18nLabelUpdate(
-        query: FaqDefinitionRequest, namespace: String, existingFaq: FaqDefinition?
-    ): I18nLabel {
-        return if (existingFaq != null && existingFaq.i18nId.toString().isNotBlank()) {
-            //update existing label
-            val i18nLabel = I18nLabel(
-                existingFaq.i18nId,
-                namespace,
-                FAQ_CATEGORY,
-                linkedSetOf(I18nLocalizedLabel(query.language, UserInterfaceType.textChat, query.answer.trim())),
-                query.answer.trim(),
-                query.language
-            )
-            i18nDao.save(listOf(i18nLabel)).also { logger.info { "Updating I18n label : ${i18nLabel.defaultLabel}" } }
-            i18nLabel
-        } else {
-            BotAdminService.createI18nRequest(
-                namespace,
-                CreateI18nLabelRequest(
-                    query.answer.trim(),
-                    query.language,
-                    FAQ_CATEGORY
-                ).also { logger.info { "Creating I18n label : ${it.label}" } })
-        }
-    }
-
     fun deleteFaqDefinition(namespace: String, faqDefinitionId: String): Boolean {
         val faqDefinition = faqDefinitionDAO.getFaqDefinitionById(faqDefinitionId.toId())
         if (faqDefinition != null) {
@@ -770,7 +759,6 @@ object FaqAdminService {
 
         front.removeIntentFromApplication(application, faqDefinition.intentId)
         faqDefinitionDAO.deleteFaqDefinitionById(faqDefinition._id)
-        i18nDao.deleteByNamespaceAndId(namespace, faqDefinition.i18nId)
 
         storyDefinitionDAO.getConfiguredStoryDefinitionByNamespaceAndBotIdAndIntent(
             application.namespace, application.name, intentName

--- a/bot/admin/server/src/main/kotlin/content/SimpleAnswerContent.kt
+++ b/bot/admin/server/src/main/kotlin/content/SimpleAnswerContent.kt
@@ -21,15 +21,25 @@ import ai.tock.bot.admin.answer.AnswerConfigurationType
 import ai.tock.bot.admin.model.BotMediaMessageDescriptor
 import ai.tock.bot.admin.model.BotSimpleAnswer
 import ai.tock.bot.admin.model.CreateI18nLabelRequest
+import ai.tock.bot.engine.action.Footnote
 import java.util.Locale
 
-data class SimpleAnswerContent(val label: String, val delay: Long = 0, val mediaMessage: BotMediaMessageDescriptor? = null) {
+data class SimpleAnswerContent(
+        val label: String,
+        val delay: Long = 0,
+        val mediaMessage: BotMediaMessageDescriptor? = null,
+        val footnotes: List<Footnote>? = null
+) {
 
     fun toBotSimpleAnswer(namespace: String, locale: Locale): BotSimpleAnswer =
             BotSimpleAnswer(
-                    label = BotAdminService.createI18nRequest(namespace, CreateI18nLabelRequest(label, locale, AnswerConfigurationType.builtin.name)),
+                    label = BotAdminService.createI18nRequest(
+                            namespace,
+                            CreateI18nLabelRequest(label, locale, AnswerConfigurationType.builtin.name)
+                    ),
                     delay = delay,
-                    mediaMessage = mediaMessage
+                    mediaMessage = mediaMessage,
+                    footnotes = footnotes
             )
 }
 

--- a/bot/admin/server/src/main/kotlin/model/BotSimpleAnswer.kt
+++ b/bot/admin/server/src/main/kotlin/model/BotSimpleAnswer.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.admin.model
 
 import ai.tock.bot.admin.answer.SimpleAnswer
+import ai.tock.bot.engine.action.Footnote
 import ai.tock.translator.I18nLabel
 import ai.tock.translator.I18nLabelValue
 import ai.tock.translator.Translator
@@ -25,15 +26,21 @@ import java.util.Locale
 /**
  *
  */
-data class BotSimpleAnswer(val label: I18nLabel, val delay: Long, val mediaMessage: BotMediaMessageDescriptor? = null) {
+data class BotSimpleAnswer(
+    val label: I18nLabel,
+    val delay: Long,
+    val mediaMessage: BotMediaMessageDescriptor? = null,
+    val footnotes: List<Footnote>? = null
+) {
 
     constructor(answer: SimpleAnswer, locale: Locale?, readOnly: Boolean = false) :
         this(
             Translator.saveIfNotExist(answer.key, locale, readOnly),
             answer.delay,
-            answer.mediaMessage?.let { BotMediaMessageDescriptor.fromDescriptor(it, readOnly) }
+            answer.mediaMessage?.let { BotMediaMessageDescriptor.fromDescriptor(it, readOnly) },
+            answer.footnotes
         )
 
     fun toConfiguration(): SimpleAnswer =
-        SimpleAnswer(I18nLabelValue(label), delay, mediaMessage?.toDescriptor())
+        SimpleAnswer(I18nLabelValue(label), delay, mediaMessage?.toDescriptor(), footnotes)
 }

--- a/bot/admin/server/src/main/kotlin/model/FaqDefinitionRequest.kt
+++ b/bot/admin/server/src/main/kotlin/model/FaqDefinitionRequest.kt
@@ -16,6 +16,8 @@
 
 package ai.tock.bot.admin.model
 
+import ai.tock.bot.engine.action.Footnote
+import ai.tock.translator.I18nLabel
 import java.time.Instant
 import java.util.Locale
 
@@ -31,7 +33,8 @@ data class FaqDefinitionRequest(
     val description: String = "",
     val utterances: List<String>,
     val tags: List<String>,
-    val answer: String,
+    val answer: I18nLabel,
     val enabled: Boolean,
-    val intentName: String
+    val intentName: String,
+    val footnotes: List<Footnote>? = null,
 )

--- a/bot/engine/src/main/kotlin/admin/answer/SimpleAnswer.kt
+++ b/bot/engine/src/main/kotlin/admin/answer/SimpleAnswer.kt
@@ -17,9 +17,15 @@
 package ai.tock.bot.admin.answer
 
 import ai.tock.bot.connector.media.MediaMessageDescriptor
+import ai.tock.bot.engine.action.Footnote
 import ai.tock.translator.I18nLabelValue
 
 /**
  * Answer that contains only i18n label with an optional [delay] and [MediaMessageDescriptor].
  */
-data class SimpleAnswer(val key: I18nLabelValue, val delay: Long = 0, val mediaMessage: MediaMessageDescriptor? = null)
+data class SimpleAnswer(
+    val key: I18nLabelValue,
+    val delay: Long = 0,
+    val mediaMessage: MediaMessageDescriptor? = null,
+    val footnotes: List<Footnote>? = null
+)

--- a/bot/engine/src/main/kotlin/admin/story/dump/SimpleAnswerDump.kt
+++ b/bot/engine/src/main/kotlin/admin/story/dump/SimpleAnswerDump.kt
@@ -19,20 +19,32 @@ package ai.tock.bot.admin.story.dump
 import ai.tock.bot.admin.answer.SimpleAnswer
 import ai.tock.bot.admin.story.dump.MediaMessageDescriptorDump.Companion.toDump
 import ai.tock.bot.connector.media.MediaMessageDescriptor
+import ai.tock.bot.engine.action.Footnote
 import ai.tock.translator.I18nLabelValue
 
 /**
  * Answer that contains only i18n label with an optional [delay] and [MediaMessageDescriptor].
  */
-data class SimpleAnswerDump(val key: I18nLabelValue, val delay: Long, val mediaMessage: MediaMessageDescriptorDump? = null) {
+data class SimpleAnswerDump(
+    val key: I18nLabelValue,
+    val delay: Long,
+    val mediaMessage: MediaMessageDescriptorDump? = null,
+    val footnotes: List<Footnote>? = null
+) {
 
     constructor(answer: SimpleAnswer) :
         this(
-            answer.key,
-            answer.delay,
-            toDump(answer.mediaMessage)
+            key = answer.key,
+            delay = answer.delay,
+            mediaMessage = toDump(answer.mediaMessage),
+            footnotes = answer.footnotes
         )
 
     fun toAnswer(controller: StoryDefinitionConfigurationDumpController): SimpleAnswer =
-        SimpleAnswer(key.withNamespace(controller.targetNamespace), delay, mediaMessage?.toMedia(controller))
+        SimpleAnswer(
+            key = key.withNamespace(controller.targetNamespace),
+            delay = delay,
+            mediaMessage = mediaMessage?.toMedia(controller),
+            footnotes = footnotes
+        )
 }

--- a/bot/engine/src/main/kotlin/engine/config/ConfiguredStoryHandler.kt
+++ b/bot/engine/src/main/kotlin/engine/config/ConfiguredStoryHandler.kt
@@ -39,6 +39,7 @@ import ai.tock.bot.definition.StoryTag
 import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.BotRepository
 import ai.tock.bot.engine.action.SendSentence
+import ai.tock.bot.engine.action.SendSentenceWithFootnotes
 import ai.tock.bot.engine.dialog.NextUserActionState
 import ai.tock.bot.engine.message.ActionWrappedMessage
 import ai.tock.bot.engine.message.MessagesList
@@ -401,12 +402,22 @@ internal class ConfiguredStoryHandler(
             }
             .takeUnless { it.isEmpty() }
             ?: listOf(
-                SendSentence(
-                    botId,
-                    applicationId,
-                    userId,
-                    label
-                )
+                answer.footnotes?.takeIf{ it.isNotEmpty() }
+                ?.let {
+                    SendSentenceWithFootnotes(
+                        playerId = botId,
+                        applicationId = applicationId,
+                        recipientId = userId,
+                        text = label,
+                        footnotes = it.toMutableList()
+                    )
+                } ?:
+                    SendSentence(
+                        botId,
+                        applicationId,
+                        userId,
+                        label
+                    )
             )
 
         val messagesList = MessagesList(actions.map { ActionWrappedMessage(it, 0) })

--- a/nlp/front/storage-mongo/src/test/kotlin/FaqSettingsMongoDAOTest.kt
+++ b/nlp/front/storage-mongo/src/test/kotlin/FaqSettingsMongoDAOTest.kt
@@ -15,7 +15,6 @@
  */
 
 package ai.tock.nlp.front.storage.mongo
-
 import ai.tock.nlp.front.service.storage.FaqSettingsDAO
 import ai.tock.nlp.front.shared.config.ApplicationDefinition
 import ai.tock.nlp.front.shared.config.FaqSettings

--- a/shared/src/test/kotlin/SharedTestModule.kt
+++ b/shared/src/test/kotlin/SharedTestModule.kt
@@ -86,7 +86,7 @@ val sharedTestModule = Kodein.Module {
         bind<com.mongodb.reactivestreams.client.MongoClient>() with singleton {
             try {
                 // init kmongo configuration for persistence tests
-                TockKMongoConfiguration.configure()
+                TockKMongoConfiguration.configure(true)
                 KFlapdoodleReactiveStreams.mongoClient
             } catch (t: Throwable) {
                 logger.trace("error during KMongo configuration", t)


### PR DESCRIPTION
This pull request includes several changes to the `bot/admin/server/src/main/kotlin` files, focusing on refactoring methods and adding support for footnotes in FAQ definitions.

### Refactoring and Method Changes:

* [`BotAdminService.kt`](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeL619-R619): Renamed `toStoryConfiguration` to `toAnswerConfiguration` in multiple locations to better reflect its purpose. [[1]](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeL619-R619) [[2]](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeL747-R747) [[3]](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeL863-R863)

### FAQ Definition Enhancements:

* [`FaqAdminService.kt`](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL109-R133): Removed the `manageI18nLabelUpdate` method and updated the code to directly use `query.answer` instead of `i18nLabel` for various operations. This change simplifies the code and reduces dependencies on the `I18nLabel` class. [[1]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL109-R133) [[2]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL175) [[3]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL198-R195) [[4]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL214) [[5]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL223-R224) [[6]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL294) [[7]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL315-R321) [[8]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL329-R346) [[9]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL338-R355) [[10]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL503-R539) [[11]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL645-R678) [[12]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL711-L739) [[13]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL773)

### Footnotes Support:

* [`SimpleAnswerContent.kt`](diffhunk://#diff-58ea81076f23d3a893473bae10fcc30482e608f625500057caf8691e15aa4c3dR24-R42): Added a `footnotes` field to the `SimpleAnswerContent` data class to support footnotes in simple answers.
* [`BotSimpleAnswer.kt`](diffhunk://#diff-81e1f7254fc9d6041414ae65650f88c24912383babbf1582b10e6db32960dab5R20): Updated the `BotSimpleAnswer` data class to include a `footnotes` field and modified the constructor and `toConfiguration` method accordingly. [[1]](diffhunk://#diff-81e1f7254fc9d6041414ae65650f88c24912383babbf1582b10e6db32960dab5R20) [[2]](diffhunk://#diff-81e1f7254fc9d6041414ae65650f88c24912383babbf1582b10e6db32960dab5L28-R45)
* [`FaqDefinitionRequest.kt`](diffhunk://#diff-f38e8bd729a6c790bc988a58c36612dd14a6f30eb129c77c9e978d62564c06beR19-R20): Added a `footnotes` field to the `FaqDefinitionRequest` data class to store footnotes information. [[1]](diffhunk://#diff-f38e8bd729a6c790bc988a58c36612dd14a6f30eb129c77c9e978d62564c06beR19-R20) [[2]](diffhunk://#diff-f38e8bd729a6c790bc988a58c36612dd14a6f30eb129c77c9e978d62564c06beL34-R39)

### Test Updates:

* [`FaqAdminServiceTest.kt`](diffhunk://#diff-55ad3b58f7320a4b32aa67c8efa3ae6a2881a7f9efdfece5373ad979dd861b5aR45): Updated imports to include `defaultNamespace` for testing purposes.

Works with https://github.com/theopenconversationkit/tock/pull/1785