### PR TITLE
[Tock Studio] Handle namespaces in state service + refresh dialogs on app change + misc

### DIFF
--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -137,17 +137,18 @@
   </nb-card-body>
 </nb-card>
 
+<nb-card
+  [nbSpinner]="loading"
+  *ngIf="loading"
+>
+  <nb-card-body class="loader"></nb-card-body>
+</nb-card>
+
 <div *ngIf="total !== -1">
-  <h1 *ngIf="total === 0">
-    No dialogs found!
-    <button
-      nbButton
-      ghost
-      (click)="refresh()"
-    >
-      <nb-icon icon="arrow-clockwise"></nb-icon>
-    </button>
-  </h1>
+  <tock-no-data-found
+    *ngIf="total === 0"
+    title="No dialogs found"
+  ></tock-no-data-found>
 
   <div
     infinite-scroll
@@ -191,11 +192,3 @@
     </div>
   </div>
 </div>
-
-<nb-card
-  [nbSpinner]="loading"
-  nbSpinnerStatus="primary"
-  *ngIf="loading"
->
-  <nb-card-body></nb-card-body>
-</nb-card>

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
@@ -13,3 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.loader {
+  min-height: 20vh;
+}

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
@@ -69,32 +69,27 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
     private route: ActivatedRoute,
     public botSharedService: BotSharedService,
     private router: Router
-  ) {
-    this.state = state;
+  ) {}
 
-    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((configs) => {
-      this.isSatisfactionRoute().subscribe((res) => {
-        this.botSharedService.getIntentsByApplication(this.state.currentApplication._id).subscribe((intents) => (this.intents = intents));
-
-        this.configurationNameList = configs.filter((item) => item.targetConfigurationId == null).map((item) => item.applicationId);
-
-        if (res) {
-          this.ratingFilter = [1, 2, 3, 4, 5];
-        }
-        this.refresh();
-      });
-    });
-
+  ngOnInit() {
     this.botSharedService
       .getConnectorTypes()
       .pipe(take(1))
       .subscribe((confConf) => {
         this.connectorTypes = confConf.map((it) => it.connectorType);
       });
-  }
 
-  ngOnInit() {
-    this.load();
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((configs) => {
+      this.botSharedService.getIntentsByApplication(this.state.currentApplication._id).subscribe((intents) => (this.intents = intents));
+
+      this.configurationNameList = configs
+        .filter((item) => item.targetConfigurationId == null)
+        .map((item) => {
+          return item.applicationId;
+        });
+
+      this.refresh();
+    });
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/bot/admin/web/src/app/analytics/satisfaction/satisfaction.component.html
+++ b/bot/admin/web/src/app/analytics/satisfaction/satisfaction.component.html
@@ -1,11 +1,19 @@
-<div *ngIf="loaded">
+<ng-container *ngIf="!loading && configurations?.length === 0">
+  <div class="d-flex flex-wrap align-items-center">
+    <h1 class="flex-grow-1">Satisfaction</h1>
+  </div>
+
+  <tock-no-data-found title="No bot configuration detected"></tock-no-data-found>
+</ng-container>
+
+<div *ngIf="configurations?.length">
   <div *ngIf="isStatisfactionActivated">
     <tock-satisfaction-details></tock-satisfaction-details>
   </div>
+
   <div *ngIf="!isStatisfactionActivated && !errorMsg">
     <tock-activate-satisfaction (enableSatisfaction)="isStatisfactionActivated = $event"></tock-activate-satisfaction>
   </div>
+
+  <h2 *ngIf="errorMsg">{{ errorMsg }}</h2>
 </div>
-
-
-<h2 *ngIf="errorMsg">{{errorMsg}}</h2>

--- a/bot/admin/web/src/app/applications/namespace/namespaces.component.html
+++ b/bot/admin/web/src/app/applications/namespace/namespaces.component.html
@@ -34,7 +34,7 @@
 </div>
 
 <nb-card
-  *ngFor="let n of namespaces"
+  *ngFor="let n of state.namespaces"
   class="mb-2"
 >
   <nb-card-body>

--- a/bot/admin/web/src/app/applications/namespace/namespaces.component.ts
+++ b/bot/admin/web/src/app/applications/namespace/namespaces.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { StateService } from '../../core-nlp/state.service';
 import { ApplicationService } from '../../core-nlp/applications.service';
 import { NamespaceConfiguration, NamespaceSharingConfiguration, UserNamespace } from '../../model/application';
@@ -30,9 +30,8 @@ import { Subject, takeUntil } from 'rxjs';
   templateUrl: 'namespaces.component.html',
   styleUrls: ['namespaces.component.scss']
 })
-export class NamespacesComponent implements OnInit, OnDestroy {
+export class NamespacesComponent implements OnDestroy {
   destroy = new Subject();
-  namespaces: UserNamespace[];
 
   managedNamespace: string;
   managedUsers: UserNamespace[];
@@ -53,22 +52,10 @@ export class NamespacesComponent implements OnInit, OnDestroy {
     private nbDialogService: NbDialogService
   ) {}
 
-  ngOnInit(): void {
-    this.state.currentApplicationEmitter.pipe(takeUntil(this.destroy)).subscribe((arg) => {
-      this.grabNamespaces();
-    });
-    this.grabNamespaces();
-  }
-
-  grabNamespaces(): void {
-    this.applicationService.getNamespaces().subscribe((n) => (this.namespaces = n));
-  }
-
   selectNamespace(namespace: string): void {
     this.applicationService.selectNamespace(namespace).subscribe((_) =>
       this.authService.loadUser().subscribe((_) => {
-        this.applicationService.resetConfiguration;
-        this.grabNamespaces();
+        this.applicationService.resetConfiguration();
       })
     );
   }
@@ -85,7 +72,7 @@ export class NamespacesComponent implements OnInit, OnDestroy {
     const modal = this.nbDialogService.open(CreateNamespaceComponent);
     const validate = modal.componentRef.instance.validate.pipe(takeUntil(this.destroy)).subscribe((result) => {
       this.applicationService.createNamespace(result.name.trim()).subscribe((b) => {
-        this.ngOnInit();
+        this.applicationService.resetConfiguration();
       });
       this.closeEdition();
       modal.close();

--- a/bot/admin/web/src/app/bot/i18n/i18n-filters/i18n-filters.component.ts
+++ b/bot/admin/web/src/app/bot/i18n/i18n-filters/i18n-filters.component.ts
@@ -38,7 +38,7 @@ export class I18nFiltersComponent implements OnInit {
   constructor(public state: StateService) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(250)).subscribe(() => this.submitFiltersChange());
+    this.form.valueChanges.pipe(debounceTime(250), takeUntil(this.destroy$)).subscribe(() => this.submitFiltersChange());
   }
 
   form = new FormGroup<I18nFiltersForm>({

--- a/bot/admin/web/src/app/bot/story/edit-story/edit-story.component.ts
+++ b/bot/admin/web/src/app/bot/story/edit-story/edit-story.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subject, take, takeUntil } from 'rxjs';
+import { Subject, take } from 'rxjs';
 import { BotService } from '../../bot-service';
 import { StoryDefinitionConfiguration } from '../../model/story';
 

--- a/bot/admin/web/src/app/bot/story/search-story/stories-filter/stories-filter.component.ts
+++ b/bot/admin/web/src/app/bot/story/search-story/stories-filter/stories-filter.component.ts
@@ -49,7 +49,7 @@ export class StoriesFilterComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(300)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(300), takeUntil(this.destroy$)).subscribe(() => {
       this.onFilter.emit(this.form.value as StoriesFilters);
     });
   }

--- a/bot/admin/web/src/app/configuration/bot-configurations/bot-configuration/bot-configuration.component.html
+++ b/bot/admin/web/src/app/configuration/bot-configurations/bot-configuration/bot-configuration.component.html
@@ -15,7 +15,15 @@
   -->
 
 <nb-card *ngIf="configuration">
-  <nb-card-body [ngClass]="{ 'pt-5': configuration._id }">
+  <nb-card-body
+    *ngIf="loading"
+    [nbSpinner]="loading"
+  ></nb-card-body>
+
+  <nb-card-body
+    *ngIf="!loading"
+    [ngClass]="{ 'pt-5': configuration._id }"
+  >
     <div
       *ngIf="configuration._id"
       class="connector-title-box"
@@ -255,7 +263,10 @@
     </nb-accordion>
   </nb-card-body>
 
-  <nb-card-footer style="text-align: right">
+  <nb-card-footer
+    *ngIf="!loading"
+    style="text-align: right"
+  >
     <button
       nbButton
       ghost

--- a/bot/admin/web/src/app/configuration/bot-configurations/bot-configurations.component.html
+++ b/bot/admin/web/src/app/configuration/bot-configurations/bot-configurations.component.html
@@ -63,7 +63,7 @@
 </div>
 
 <tock-no-data-found
-  *ngIf="!configurations.length"
+  *ngIf="!configurations.length && !newApplicationConfiguration"
   title="No bot configuration detected"
   message="Use the NEW CONFIGURATION button to create one"
 ></tock-no-data-found>

--- a/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
@@ -46,7 +46,7 @@ export class ObservabilitySettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(200)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(200), takeUntil(this.destroy$)).subscribe(() => {
       this.setActivationDisabledState();
     });
 

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
@@ -50,7 +50,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(200)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(200), takeUntil(this.destroy$)).subscribe(() => {
       this.setActivationDisabledState();
     });
 

--- a/bot/admin/web/src/app/configuration/synchronization/synchronization.component.html
+++ b/bot/admin/web/src/app/configuration/synchronization/synchronization.component.html
@@ -25,7 +25,7 @@
                 (selectedChange)="selectSourceNamespace(this.sourceNamespace)"
               >
                 <nb-option
-                  *ngFor="let namespace of namespaces"
+                  *ngFor="let namespace of state.namespaces"
                   [value]="namespace"
                   >{{ namespace.namespace }}</nb-option
                 >
@@ -51,7 +51,7 @@
                 (selectedChange)="selectTargetNamespace(this.targetNamespace)"
               >
                 <nb-option
-                  *ngFor="let namespace of namespaces"
+                  *ngFor="let namespace of state.namespaces"
                   [value]="namespace"
                   >{{ namespace.namespace }}</nb-option
                 >

--- a/bot/admin/web/src/app/configuration/synchronization/synchronization.component.ts
+++ b/bot/admin/web/src/app/configuration/synchronization/synchronization.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ApplicationService } from '../../core-nlp/applications.service';
 import { Application, UserNamespace } from '../../model/application';
-import { AuthService } from '../../core-nlp/auth/auth.service';
 import { StateService } from '../../core-nlp/state.service';
 import { BotConfigurationService } from '../../core/bot-configuration.service';
 import { DialogService } from '../../core-nlp/dialog.service';
@@ -16,7 +15,6 @@ import { ChoiceDialogComponent } from '../../shared/components';
   styleUrls: ['./synchronization.component.css']
 })
 export class SynchronizationComponent implements OnInit {
-  namespaces: UserNamespace[];
   sourceNamespace: UserNamespace;
   targetNamespace: UserNamespace;
   sourceApplications: Application[];
@@ -27,7 +25,6 @@ export class SynchronizationComponent implements OnInit {
 
   constructor(
     private applicationService: ApplicationService,
-    private authService: AuthService,
     public state: StateService,
     private botConfigurationService: BotConfigurationService,
     private dialog: DialogService,
@@ -36,7 +33,6 @@ export class SynchronizationComponent implements OnInit {
     private router: Router
   ) {}
   ngOnInit(): void {
-    this.applicationService.getNamespaces().subscribe((n) => (this.namespaces = n));
     this.sourceApplications = this.state.applications;
   }
 
@@ -67,7 +63,7 @@ export class SynchronizationComponent implements OnInit {
       context: {
         title: 'Overwrite configuration?',
         subtitle: `During synchronization, configuration will be copied from the source application to the target application (answers, stories, training).
-  
+
 Please note : ${inboxMessagesCopySubtitle}
 
 The synchronization of both applications will be permanent, and there will be no way to reverse it. Do you want to continue?

--- a/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.ts
@@ -46,7 +46,7 @@ export class VectorDbSettingsComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(200)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(200), takeUntil(this.destroy$)).subscribe(() => {
       this.setActivationDisabledState();
     });
 

--- a/bot/admin/web/src/app/core-nlp/applications.service.ts
+++ b/bot/admin/web/src/app/core-nlp/applications.service.ts
@@ -64,6 +64,7 @@ export class ApplicationService implements OnDestroy {
   resetConfiguration() {
     this.locales().subscribe((locales) => (this.state.locales = locales));
     this.nlpEngineTypes().subscribe((engines) => (this.state.supportedNlpEngines = engines));
+    this.getNamespaces().subscribe((namespaces) => (this.state.namespaces = namespaces));
     this.getApplications().subscribe((applications) => {
       this.state.applications = applications;
       this.state.currentApplication = null;

--- a/bot/admin/web/src/app/core-nlp/applications.service.ts
+++ b/bot/admin/web/src/app/core-nlp/applications.service.ts
@@ -62,8 +62,8 @@ export class ApplicationService implements OnDestroy {
   }
 
   resetConfiguration() {
-    this.locales().subscribe((locales) => (this.state.locales = locales));
-    this.nlpEngineTypes().subscribe((engines) => (this.state.supportedNlpEngines = engines));
+    this.getLocales().subscribe((locales) => (this.state.locales = locales));
+    this.getNlpEngineTypes().subscribe((engines) => (this.state.supportedNlpEngines = engines));
     this.getNamespaces().subscribe((namespaces) => (this.state.namespaces = namespaces));
     this.getApplications().subscribe((applications) => {
       this.state.applications = applications;
@@ -80,8 +80,28 @@ export class ApplicationService implements OnDestroy {
     return this.getApplicationsPending;
   }
 
-  nlpEngineTypes(): Observable<NlpEngineType[]> {
-    return this.rest.getArray('/nlp-engines', NlpEngineType.fromJSONArray);
+  getNamespacesPending: Observable<UserNamespace[]>;
+  getNamespaces(): Observable<UserNamespace[]> {
+    if (!this.getNamespacesPending) {
+      this.getNamespacesPending = this.rest.get(`/namespaces`, UserNamespace.fromJSONArray).pipe(share());
+    }
+    return this.getNamespacesPending;
+  }
+
+  getLocalesPending: Observable<Entry<string, string>[]>;
+  getLocales(): Observable<Entry<string, string>[]> {
+    if (!this.getLocalesPending) {
+      this.getLocalesPending = this.rest.get(`/locales`, (m) => Entry.fromJSONArray<string, string>(m)).pipe(share());
+    }
+    return this.getLocalesPending;
+  }
+
+  getNlpEngineTypesPending: Observable<NlpEngineType[]>;
+  getNlpEngineTypes(): Observable<NlpEngineType[]> {
+    if (!this.getNlpEngineTypesPending) {
+      this.getNlpEngineTypesPending = this.rest.getArray('/nlp-engines', NlpEngineType.fromJSONArray).pipe(share());
+    }
+    return this.getNlpEngineTypesPending;
   }
 
   triggerBuild(application: Application) {
@@ -136,10 +156,6 @@ export class ApplicationService implements OnDestroy {
     }
   }
 
-  locales(): Observable<Entry<string, string>[]> {
-    return this.rest.get(`/locales`, (m) => Entry.fromJSONArray<string, string>(m));
-  }
-
   getApplicationDump(application: Application): Observable<Blob> {
     return this.rest.get(`/application/dump/${application._id}`, (r) => new Blob([JSON.stringify(r)], { type: 'application/json' }));
   }
@@ -166,10 +182,6 @@ export class ApplicationService implements OnDestroy {
       url = `/dump/application`;
     }
     this.rest.setFileUploaderOptions(uploader, url);
-  }
-
-  getNamespaces(): Observable<UserNamespace[]> {
-    return this.rest.get(`/namespaces`, UserNamespace.fromJSONArray);
   }
 
   getUsersForNamespace(namespace: string): Observable<UserNamespace[]> {

--- a/bot/admin/web/src/app/core-nlp/state.service.ts
+++ b/bot/admin/web/src/app/core-nlp/state.service.ts
@@ -16,7 +16,7 @@
 
 import { map } from 'rxjs/operators';
 import { EventEmitter, Injectable } from '@angular/core';
-import { Application } from '../model/application';
+import { Application, UserNamespace } from '../model/application';
 import { AuthService } from './auth/auth.service';
 import { AuthListener } from './auth/auth.listener';
 import { User, UserRole } from '../model/auth';
@@ -44,6 +44,7 @@ export class StateService implements AuthListener {
   supportedNlpEngines: NlpEngineType[];
 
   user: User;
+  namespaces: UserNamespace[];
   applications: Application[];
 
   dateRange = { start: null, end: null, rangeInDays: null };
@@ -265,6 +266,7 @@ export class StateService implements AuthListener {
   logout() {
     this.user = null;
     this.currentApplication = null;
+    this.namespaces = null;
     this.applications = null;
   }
 

--- a/bot/admin/web/src/app/language-understanding/intents/intents-filters/intents-filters.component.ts
+++ b/bot/admin/web/src/app/language-understanding/intents/intents-filters/intents-filters.component.ts
@@ -29,7 +29,7 @@ export class IntentsFiltersComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(300)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(300), takeUntil(this.destroy$)).subscribe(() => {
       this.onFilter.emit(this.form.value as IntentsFilter);
     });
   }

--- a/bot/admin/web/src/app/metrics/indicators/indicators-filters/indicators-filters.component.ts
+++ b/bot/admin/web/src/app/metrics/indicators/indicators-filters/indicators-filters.component.ts
@@ -42,7 +42,7 @@ export class IndicatorsFiltersComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.form.valueChanges.pipe(takeUntil(this.destroy), debounceTime(500)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(500), takeUntil(this.destroy)).subscribe(() => {
       this.onFilter.emit(this.form.value as IndicatorsFilter);
     });
   }

--- a/bot/admin/web/src/app/model-quality/count-stats/count-stats.component.ts
+++ b/bot/admin/web/src/app/model-quality/count-stats/count-stats.component.ts
@@ -33,7 +33,7 @@ export class CountStatsComponent implements OnInit, OnDestroy {
   constructor(public state: StateService, private qualityService: QualityService) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy), debounceTime(500)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(500), takeUntil(this.destroy)).subscribe(() => {
       if (isNaN(parseInt(this.minCount.value))) {
         this.minCount.patchValue(1);
       }

--- a/bot/admin/web/src/app/model-quality/intent-quality/intent-quality.component.ts
+++ b/bot/admin/web/src/app/model-quality/intent-quality/intent-quality.component.ts
@@ -24,7 +24,7 @@ export class IntentQualityComponent implements OnInit, OnDestroy {
   constructor(private state: StateService, private quality: QualityService) {}
 
   ngOnInit(): void {
-    this.form.valueChanges.pipe(takeUntil(this.destroy), debounceTime(500)).subscribe(() => {
+    this.form.valueChanges.pipe(debounceTime(500), takeUntil(this.destroy)).subscribe(() => {
       if (isNaN(parseInt(this.minOccurrences.value))) {
         this.minOccurrences.patchValue(1);
       }

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-filters/sentence-training-filters.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-filters/sentence-training-filters.component.ts
@@ -149,7 +149,7 @@ export class SentenceTrainingFiltersComponent implements OnInit, OnDestroy {
 
     this.updateEntitiesFilters();
 
-    this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(500)).subscribe(() => this.submitFiltersChange());
+    this.form.valueChanges.pipe(debounceTime(500), takeUntil(this.destroy$)).subscribe(() => this.submitFiltersChange());
   }
 
   submitFiltersChange(): void {

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training.component.ts
@@ -57,6 +57,7 @@ export class SentenceTrainingComponent implements OnInit, OnDestroy {
   @ViewChild('sentenceTrainingFilter') sentenceTrainingFilter: SentenceTrainingFiltersComponent;
 
   loading: boolean = false;
+  unloading: boolean = false;
 
   sentences: SentenceExtended[] = [];
 
@@ -187,7 +188,7 @@ export class SentenceTrainingComponent implements OnInit, OnDestroy {
   ): Observable<PaginatedResult<SentenceExtended>> {
     if (showLoadingSpinner) this.loading = true;
 
-    let search = this.search(this.state.createPaginatedQuery(start, size)).pipe(takeUntil(this.destroy$), share());
+    let search = this.search(this.state.createPaginatedQuery(start, size)).pipe(share(), takeUntil(this.destroy$));
 
     search.subscribe({
       next: (data: PaginatedResult<SentenceExtended>) => {
@@ -372,6 +373,8 @@ export class SentenceTrainingComponent implements OnInit, OnDestroy {
   }
 
   retrieveSentence(sentence: SentenceExtended, tryCount = 0): Subscription | void {
+    if (this.unloading) return;
+
     let exists = this.sentences.find((stnce) => {
       return stnce.text == sentence.text;
     });
@@ -574,6 +577,7 @@ Would you like to translate all the sentences matching the search criteria above
   }
 
   ngOnDestroy(): void {
+    this.unloading = true;
     this.destroy$.next(true);
     this.destroy$.complete();
   }

--- a/bot/admin/web/src/app/theme/components/header/header.component.html
+++ b/bot/admin/web/src/app/theme/components/header/header.component.html
@@ -65,7 +65,7 @@
       </nb-select>
     </nb-form-field>
 
-    <nb-form-field *ngIf="namespaces">
+    <nb-form-field *ngIf="state.namespaces">
       <nb-icon
         nbPrefix
         icon="folder"
@@ -77,7 +77,7 @@
         class="mb-0 min-width-5 max-width-15em"
       >
         <nb-option
-          *ngFor="let namespace of namespaces"
+          *ngFor="let namespace of state.namespaces"
           [value]="namespace.namespace"
           >{{ namespace.namespace }}
         </nb-option>

--- a/bot/admin/web/src/app/theme/components/header/header.component.ts
+++ b/bot/admin/web/src/app/theme/components/header/header.component.ts
@@ -23,7 +23,6 @@ import { SettingsService } from '../../../core-nlp/settings.service';
 import { Subject, take, takeUntil } from 'rxjs';
 import { APP_BASE_HREF } from '@angular/common';
 import { ApplicationService } from '../../../core-nlp/applications.service';
-import { UserNamespace } from '../../../model/application';
 import { BotConfigurationService } from '../../../core/bot-configuration.service';
 import { CoreConfig } from '../../../core-nlp/core.config';
 import { Router } from '@angular/router';
@@ -39,8 +38,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   @Input() position = 'normal';
 
   currentTheme = 'default';
-
-  namespaces: UserNamespace[];
 
   currentApplicationName: string;
 
@@ -69,8 +66,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     }
 
     this.botConfiguration.configurations.pipe(takeUntil(this.destroy)).subscribe((confs) => {
-      this.grabNamespaces();
-
       this.currentApplicationName = '';
       setTimeout(() => {
         this.currentApplicationName = this.state?.currentApplication?.name;
@@ -78,12 +73,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     });
   }
 
-  grabNamespaces(): void {
-    this.applicationService.getNamespaces().subscribe((n) => (this.namespaces = n));
-  }
-
   get currentNamespaceName() {
-    return this.namespaces?.find((n) => n.current).namespace;
+    return this.state.namespaces?.find((n) => n.current).namespace;
   }
 
   changeNamespace(namespace: string) {
@@ -93,7 +84,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
       .subscribe((_) =>
         this.auth.loadUser().subscribe((_) => {
           this.applicationService.resetConfiguration();
-          this.grabNamespaces();
 
           this.applicationService
             .getApplications()

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -228,3 +228,8 @@ nb-menu {
   border-color: var(--input-basic-disabled-border-color);
   color: var(--input-basic-disabled-text-color);
 }
+
+.nb-spinner-container {
+  // prevent spinners from being displayed over the application header
+  z-index: 1020;
+}


### PR DESCRIPTION
- Namespaces retrieval management is delegated to the state service. In this way, the namespace list selector in the application header is updated when a new namespace is created.
- Some competing requests made during application initialization are avoided
- List of dialogs in Analytics > Dialogs view are refereshed when configuration change
- Make sure that `takeUntil` is always the last operator of subscription pipes through the application
- Poorly managed subscriptions corrected on certain components (work to be extended to the entire app)
- Correction of a case not correctly handled in the destruction of the Sentence-training component
- Prevent spinners from being displayed over the application header