### PR TITLE
[DERCBOT-1250] FAQ by namespace

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -1023,7 +1023,7 @@ open class BotAdminVerticle : AdminVerticle() {
             val applicationDefinition = front.getApplicationById(applicationId.toId())
             if (context.organization == applicationDefinition?.namespace) {
                 try {
-                    FaqAdminService.searchTags(applicationDefinition._id.toString())
+                    FaqAdminService.searchTags(applicationDefinition.name, context.organization)
                 } catch (t: Exception) {
                     logger.error(t)
                     badRequest("Error searching faq tags: ${t.message}")

--- a/bot/admin/server/src/main/kotlin/FaqAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/FaqAdminService.kt
@@ -104,7 +104,7 @@ object FaqAdminService {
         createOrUpdateUtterances(query, application, intent._id, userLogin)
 
         val existingFaqInCurrentApplication =
-            faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(intent._id, query.applicationName)
+            faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace(intent._id, application.name, application.namespace)
 
         val i18nLabel: I18nLabel = manageI18nLabelUpdate(query, application.namespace, existingFaqInCurrentApplication)
 
@@ -242,7 +242,10 @@ object FaqAdminService {
         applicationDefinition: ApplicationDefinition, faqSettings: FaqSettings
     ) {
 
-        val listFaq = faqDefinitionDAO.getFaqDefinitionByBotId(applicationDefinition.name)
+        val listFaq = faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(
+            applicationDefinition.name,
+            applicationDefinition.namespace
+        )
 
         listFaq.forEach {
             val currentIntent = it.intentId.let {
@@ -438,8 +441,8 @@ object FaqAdminService {
         return Pair(notYetPresentSentences.toList(), noMorePresentSentences.toList())
     }
 
-    fun searchTags(applicationId: String): List<String> {
-        return faqDefinitionDAO.getTags(applicationId)
+    fun searchTags(botId: String, namespace: String): List<String> {
+        return faqDefinitionDAO.getTags(botId, namespace)
     }
 
     /**

--- a/nlp/front/service/src/main/kotlin/ApplicationConfigurationService.kt
+++ b/nlp/front/service/src/main/kotlin/ApplicationConfigurationService.kt
@@ -327,7 +327,7 @@ object ApplicationConfigurationService :
         ConfigurationRepository.entityTypeByName(name)?.obfuscated ?: true
 
     override fun getFaqsDefinitionByApplicationId(id: Id<ApplicationDefinition>): List<FaqDefinition> =
-        getApplicationById(id)?.let { faqDefinitionDAO.getFaqDefinitionByBotId(it.name) } ?: arrayListOf()
+        getApplicationById(id)?.let { faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(it.name, it.namespace) } ?: arrayListOf()
 
     override fun getFaqDefinitionByIntentId(id: Id<IntentDefinition>): FaqDefinition? =
         faqDefinitionDAO.getFaqDefinitionByIntentId(id)

--- a/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
+++ b/nlp/front/service/src/main/kotlin/storage/FaqDefinitionDAO.kt
@@ -40,9 +40,10 @@ interface FaqDefinitionDAO {
 
     /**
      * Retrieve faqDefinition by filtering on the application name [id][ApplicationDefinition]
-     * @param id the application name
+     * @param botId the application name
+     * @param namespace the namespace
      */
-    fun getFaqDefinitionByBotId(id: String): List<FaqDefinition>
+    fun getFaqDefinitionByBotIdAndNamespace(botId: String, namespace: String): List<FaqDefinition>
 
     fun listenFaqDefinitionChanges(listener: () -> Unit)
 
@@ -60,8 +61,9 @@ interface FaqDefinitionDAO {
      * Retrieve faqDefinition by filtering on intent id [intentId][IntentDefinition] and the application name[botId][ApplicationDefinition]
      * @param intentId intent id
      * @param botId the application name
+     * @param namespace the namespace
      */
-    fun getFaqDefinitionByIntentIdAndBotId(intentId: Id<IntentDefinition>, botId: String): FaqDefinition?
+    fun getFaqDefinitionByIntentIdAndBotIdAndNamespace(intentId: Id<IntentDefinition>, botId: String, namespace: String): FaqDefinition?
 
     /**
      * Retrieve faq details with total count numbers according to the filter present un [FaqQuery]
@@ -75,7 +77,7 @@ interface FaqDefinitionDAO {
         i18nIds: List<Id<I18nLabel>>? = null
     ): Pair<List<FaqQueryResult>, Long>
 
-    fun getTags(botId: String): List<String>
+    fun getTags(botId: String, namespace: String): List<String>
 
     /**
      * Make migration


### PR DESCRIPTION
This pull request includes updates to the `FaqAdminService` class to improve namespace handling.


Updates to `FaqAdminService`:

* Modified `searchTags` method to include `namespace` parameter for better namespace handling. [[1]](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL1026-R1026) [[2]](diffhunk://#diff-103294100662f794374b9e9eebb8ee71e9a7f0cb1227c69365af9b970b73a36aL441-R445)
* Updated `getFaqDefinitionByIntentIdAndBotId` calls to `getFaqDefinitionByIntentIdAndBotIdAndNamespace` to include namespace in the query.
* Updated `getFaqDefinitionByBotId` calls to `getFaqDefinitionByBotIdAndNamespace` to include namespace in the query.