### PR TITLE
[DERCBOT-1193] Fix logging

### DIFF
--- a/shared/src/main/kotlin/security/auth/CASAuthProvider.kt
+++ b/shared/src/main/kotlin/security/auth/CASAuthProvider.kt
@@ -176,6 +176,7 @@ abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
                             rc.clearUser()
                             rc.session().destroy()
                             // note: below method has ability to redirect to custom error pages
+                            logger.error("Upgrade to TockUser failed", it.cause)
                             handleUpgradeFailure(rc, it.code, it.cause)
                         }
                     }
@@ -183,10 +184,7 @@ abstract class CASAuthProvider(vertx: Vertx) : SSOTockAuthProvider(vertx) {
             } else {
                 rc.next()
             }
-        }).failureHandler { rc ->
-            logger.error("Authentication failure", rc.failure())
-            handleUpgradeFailure(rc, 500, null)
-        }
+        })
 
         with(verticle) {
             router.get("$basePath/user").handler {


### PR DESCRIPTION
the deleted failure catch does not exclusively handle authentication errors. Since it is associated with the via (“/*”) route, it will catch all errors generated in this route, including those not strictly related to authentication. This means it can also intercept application errors, network errors or other types of failure. 
(Rollback of https://github.com/CreditMutuelArkea/tock/pull/355)