### PR TITLE
fixes #1786 bot_engine: Fix default keyword story with multiple listeners

### DIFF
--- a/bot/engine/src/main/kotlin/definition/BotDefinitionBase.kt
+++ b/bot/engine/src/main/kotlin/definition/BotDefinitionBase.kt
@@ -225,7 +225,7 @@ open class BotDefinitionBase(
 
         fun handleWithKeywordListeners(bus: BotBus, keyword: String?): Boolean {
             if (keyword != null) {
-                keywordServices.asSequence().map { it.keywordHandler(keyword) }.firstOrNull()?.let { handler ->
+                keywordServices.firstNotNullOfOrNull { it.keywordHandler(keyword) }?.let { handler ->
                     handler(bus)
                     return true
                 }


### PR DESCRIPTION
Resolves #1786 by merging the sequence of calls to a single call to `firstNotNullOfOrNull`