### PR TITLE
[Tock Studio] Ubiquitous test component

### DIFF
--- a/bot/admin/web/package-lock.json
+++ b/bot/admin/web/package-lock.json
@@ -111,15 +111,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.8.tgz",
-      "integrity": "sha512-ixsdXggWaFRP7Jvxd0AMukImnePuGflT9Yy7NJ9/y0cL/k//S/3RnkQv5i411KzN+7D4RIbNkRGGTYeqH24zlg==",
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-17.3.11.tgz",
+      "integrity": "sha512-lHX5V2dSts328yvo/9E2u9QMGcvJhbEKKDDp9dBecwvIG9s+4lTOJgi9DPUE7W+AtmPcmbbhwC2JRQ/SLQhAoA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.1703.8",
-        "@angular-devkit/build-webpack": "0.1703.8",
-        "@angular-devkit/core": "17.3.8",
+        "@angular-devkit/architect": "0.1703.11",
+        "@angular-devkit/build-webpack": "0.1703.11",
+        "@angular-devkit/core": "17.3.11",
         "@babel/core": "7.24.0",
         "@babel/generator": "7.23.6",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -130,7 +130,7 @@
         "@babel/preset-env": "7.24.0",
         "@babel/runtime": "7.24.0",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "17.3.8",
+        "@ngtools/webpack": "17.3.11",
         "@vitejs/plugin-basic-ssl": "1.1.0",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.18",
@@ -142,7 +142,7 @@
         "css-loader": "6.10.0",
         "esbuild-wasm": "0.20.1",
         "fast-glob": "3.3.2",
-        "http-proxy-middleware": "2.0.6",
+        "http-proxy-middleware": "2.0.7",
         "https-proxy-agent": "7.0.4",
         "inquirer": "9.2.15",
         "jsonc-parser": "3.2.1",
@@ -172,9 +172,9 @@
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
         "undici": "6.11.1",
-        "vite": "5.1.7",
+        "vite": "5.1.8",
         "watchpack": "2.4.0",
-        "webpack": "5.90.3",
+        "webpack": "5.94.0",
         "webpack-dev-middleware": "6.1.2",
         "webpack-dev-server": "4.15.1",
         "webpack-merge": "5.10.0",
@@ -235,6 +235,48 @@
           "optional": true
         },
         "tailwindcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/architect": {
+      "version": "0.1703.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.11.tgz",
+      "integrity": "sha512-YNasVZk4rYdcM6M+KRH8PUBhVyJfqzUYLpO98GgRokW+taIDgifckSlmfDZzQRbw45qiwei1IKCLqcpC8nM5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "17.3.11",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@angular-devkit/core": {
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.11.tgz",
+      "integrity": "sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
           "optional": true
         }
       }
@@ -637,9 +679,9 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-angular/node_modules/vite": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.7.tgz",
-      "integrity": "sha512-sgnEEFTZYMui/sTlH1/XEnVNHMujOahPLGMxn1+5sIT45Xjng1Ec1K78jRP15dSmVgg5WBin9yO81j3o9OxofA==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.8.tgz",
+      "integrity": "sha512-mB8ToUuSmzODSpENgvpFk2fTiU/YQ1tmcVJJ4WZbq4fPdGJkFNVcmVL5k7iDug6xzWjjuGDKAuSievIsD6H7Xw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
@@ -730,12 +772,12 @@
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1703.8",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.8.tgz",
-      "integrity": "sha512-9u6fl8VVOxcLOEMzrUeaybSvi9hSLSRucHnybneYrabsgreDo32tuy/4G8p6YAHQjpWEj9jvF9Um13ertdni5Q==",
+      "version": "0.1703.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1703.11.tgz",
+      "integrity": "sha512-qbCiiHuoVkD7CtLyWoRi/Vzz6nrEztpF5XIyWUcQu67An1VlxbMTE4yoSQiURjCQMnB/JvS1GPVed7wOq3SJ/w==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1703.8",
+        "@angular-devkit/architect": "0.1703.11",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -746,6 +788,48 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^4.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/architect": {
+      "version": "0.1703.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1703.11.tgz",
+      "integrity": "sha512-YNasVZk4rYdcM6M+KRH8PUBhVyJfqzUYLpO98GgRokW+taIDgifckSlmfDZzQRbw45qiwei1IKCLqcpC8nM5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "17.3.11",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/@angular-devkit/core": {
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.3.11.tgz",
+      "integrity": "sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.12.0",
+        "ajv-formats": "2.1.1",
+        "jsonc-parser": "3.2.1",
+        "picomatch": "4.0.1",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.13.0 || >=20.9.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -3847,9 +3931,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "17.3.8",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.8.tgz",
-      "integrity": "sha512-CjSVVa/9fzMpEDQP01SC4colKCbZwj7vUq0H2bivp8jVsmd21x9Fu0gDBH0Y9NdfAIm4eGZvmiZKMII3vIOaYQ==",
+      "version": "17.3.11",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-17.3.11.tgz",
+      "integrity": "sha512-SfTCbplt4y6ak5cf2IfqdoVOsnoNdh/j6Vu+wb8WWABKwZ5yfr2S/Gk6ithSKcdIZhAF8DNBOoyk1EJuf8Xkfg==",
       "dev": true,
       "engines": {
         "node": "^18.13.0 || >=20.9.0",
@@ -4381,9 +4465,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.19.2.tgz",
-      "integrity": "sha512-OHflWINKtoCFSpm/WmuQaWW4jeX+3Qt3XQDepkkiFTsoxFc5BpF3Z5aDxFZgBqRjO6ATP5+b1iilp4kGIZVWlA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.3.tgz",
+      "integrity": "sha512-EzxVSkIvCFxUd4Mgm4xR9YXrcp976qVaHnqom/Tgm+vU79k4vV4eYTjmRvGfeoW8m9LVcsAy/lGjcgVegKEhLQ==",
       "cpu": [
         "arm"
       ],
@@ -4394,9 +4478,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.19.2.tgz",
-      "integrity": "sha512-k0OC/b14rNzMLDOE6QMBCjDRm3fQOHAL8Ldc9bxEWvMo4Ty9RY6rWmGetNTWhPo+/+FNd1lsQYRd0/1OSix36A==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.3.tgz",
+      "integrity": "sha512-LJc5pDf1wjlt9o/Giaw9Ofl+k/vLUaYsE2zeQGH85giX2F+wn/Cg8b3c5CDP3qmVmeO5NzwVUzQQxwZvC2eQKw==",
       "cpu": [
         "arm64"
       ],
@@ -4407,9 +4491,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.19.2.tgz",
-      "integrity": "sha512-IIARRgWCNWMTeQH+kr/gFTHJccKzwEaI0YSvtqkEBPj7AshElFq89TyreKNFAGh5frLfDCbodnq+Ye3dqGKPBw==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.3.tgz",
+      "integrity": "sha512-OuRysZ1Mt7wpWJ+aYKblVbJWtVn3Cy52h8nLuNSzTqSesYw1EuN6wKp5NW/4eSre3mp12gqFRXOKTcN3AI3LqA==",
       "cpu": [
         "arm64"
       ],
@@ -4420,9 +4504,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.19.2.tgz",
-      "integrity": "sha512-52udDMFDv54BTAdnw+KXNF45QCvcJOcYGl3vQkp4vARyrcdI/cXH8VXTEv/8QWfd6Fru8QQuw1b2uNersXOL0g==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.3.tgz",
+      "integrity": "sha512-xW//zjJMlJs2sOrCmXdB4d0uiilZsOdlGQIC/jjmMWT47lkLLoB1nsNhPUcnoqyi5YR6I4h+FjBpILxbEy8JRg==",
       "cpu": [
         "x64"
       ],
@@ -4432,10 +4516,36 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.3.tgz",
+      "integrity": "sha512-58E0tIcwZ+12nK1WiLzHOD8I0d0kdrY/+o7yFVPRHuVGY3twBwzwDdTIBGRxLmyjciMYl1B/U515GJy+yn46qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.3.tgz",
+      "integrity": "sha512-78fohrpcVwTLxg1ZzBMlwEimoAJmY6B+5TsyAZ3Vok7YabRBUvjYTsRXPTjGEvv/mfgVBepbW28OlMEz4w8wGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.19.2.tgz",
-      "integrity": "sha512-r+SI2t8srMPYZeoa1w0o/AfoVt9akI1ihgazGYPQGRilVAkuzMGiTtexNZkrPkQsyFrvqq/ni8f3zOnHw4hUbA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.3.tgz",
+      "integrity": "sha512-h2Ay79YFXyQi+QZKo3ISZDyKaVD7uUvukEHTOft7kh00WF9mxAaxZsNs3o/eukbeKuH35jBvQqrT61fzKfAB/Q==",
       "cpu": [
         "arm"
       ],
@@ -4446,9 +4556,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.19.2.tgz",
-      "integrity": "sha512-+tYiL4QVjtI3KliKBGtUU7yhw0GMcJJuB9mLTCEauHEsqfk49gtUBXGtGP3h1LW8MbaTY6rSFIQV1XOBps1gBA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.3.tgz",
+      "integrity": "sha512-Sv2GWmrJfRY57urktVLQ0VKZjNZGogVtASAgosDZ1aUB+ykPxSi3X1nWORL5Jk0sTIIwQiPH7iE3BMi9zGWfkg==",
       "cpu": [
         "arm"
       ],
@@ -4459,9 +4569,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.19.2.tgz",
-      "integrity": "sha512-OR5DcvZiYN75mXDNQQxlQPTv4D+uNCUsmSCSY2FolLf9W5I4DSoJyg7z9Ea3TjKfhPSGgMJiey1aWvlWuBzMtg==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.3.tgz",
+      "integrity": "sha512-FPoJBLsPW2bDNWjSrwNuTPUt30VnfM8GPGRoLCYKZpPx0xiIEdFip3dH6CqgoT0RnoGXptaNziM0WlKgBc+OWQ==",
       "cpu": [
         "arm64"
       ],
@@ -4472,9 +4582,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.19.2.tgz",
-      "integrity": "sha512-Hw3jSfWdUSauEYFBSFIte6I8m6jOj+3vifLg8EU3lreWulAUpch4JBjDMtlKosrBzkr0kwKgL9iCfjA8L3geoA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.3.tgz",
+      "integrity": "sha512-TKxiOvBorYq4sUpA0JT+Fkh+l+G9DScnG5Dqx7wiiqVMiRSkzTclP35pE6eQQYjP4Gc8yEkJGea6rz4qyWhp3g==",
       "cpu": [
         "arm64"
       ],
@@ -4485,9 +4595,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.19.2.tgz",
-      "integrity": "sha512-rhjvoPBhBwVnJRq/+hi2Q3EMiVF538/o9dBuj9TVLclo9DuONqt5xfWSaE6MYiFKpo/lFPJ/iSI72rYWw5Hc7w==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.3.tgz",
+      "integrity": "sha512-v2M/mPvVUKVOKITa0oCFksnQQ/TqGrT+yD0184/cWHIu0LoIuYHwox0Pm3ccXEz8cEQDLk6FPKd1CCm+PlsISw==",
       "cpu": [
         "ppc64"
       ],
@@ -4498,9 +4608,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.19.2.tgz",
-      "integrity": "sha512-EAz6vjPwHHs2qOCnpQkw4xs14XJq84I81sDRGPEjKPFVPBw7fwvtwhVjcZR6SLydCv8zNK8YGFblKWd/vRmP8g==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.3.tgz",
+      "integrity": "sha512-LdrI4Yocb1a/tFVkzmOE5WyYRgEBOyEhWYJe4gsDWDiwnjYKjNs7PS6SGlTDB7maOHF4kxevsuNBl2iOcj3b4A==",
       "cpu": [
         "riscv64"
       ],
@@ -4511,9 +4621,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.19.2.tgz",
-      "integrity": "sha512-IJSUX1xb8k/zN9j2I7B5Re6B0NNJDJ1+soezjNojhT8DEVeDNptq2jgycCOpRhyGj0+xBn7Cq+PK7Q+nd2hxLA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.3.tgz",
+      "integrity": "sha512-d4wVu6SXij/jyiwPvI6C4KxdGzuZOvJ6y9VfrcleHTwo68fl8vZC5ZYHsCVPUi4tndCfMlFniWgwonQ5CUpQcA==",
       "cpu": [
         "s390x"
       ],
@@ -4524,9 +4634,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.19.2.tgz",
-      "integrity": "sha512-OgaToJ8jSxTpgGkZSkwKE+JQGihdcaqnyHEFOSAU45utQ+yLruE1dkonB2SDI8t375wOKgNn8pQvaWY9kPzxDQ==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.3.tgz",
+      "integrity": "sha512-/6bn6pp1fsCGEY5n3yajmzZQAh+mW4QPItbiWxs69zskBzJuheb3tNynEjL+mKOsUSFK11X4LYF2BwwXnzWleA==",
       "cpu": [
         "x64"
       ],
@@ -4537,9 +4647,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.19.2.tgz",
-      "integrity": "sha512-5V3mPpWkB066XZZBgSd1lwozBk7tmOkKtquyCJ6T4LN3mzKENXyBwWNQn8d0Ci81hvlBw5RoFgleVpL6aScLYg==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.3.tgz",
+      "integrity": "sha512-nBXOfJds8OzUT1qUreT/en3eyOXd2EH5b0wr2bVB5999qHdGKkzGzIyKYaKj02lXk6wpN71ltLIaQpu58YFBoQ==",
       "cpu": [
         "x64"
       ],
@@ -4550,9 +4660,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.19.2.tgz",
-      "integrity": "sha512-ayVstadfLeeXI9zUPiKRVT8qF55hm7hKa+0N1V6Vj+OTNFfKSoUxyZvzVvgtBxqSb5URQ8sK6fhwxr9/MLmxdA==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.3.tgz",
+      "integrity": "sha512-ogfbEVQgIZOz5WPWXF2HVb6En+kWzScuxJo/WdQTqEgeyGkaa2ui5sQav9Zkr7bnNCLK48uxmmK0TySm22eiuw==",
       "cpu": [
         "arm64"
       ],
@@ -4563,9 +4673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.19.2.tgz",
-      "integrity": "sha512-Mda7iG4fOLHNsPqjWSjANvNZYoW034yxgrndof0DwCy0D3FvTjeNo+HGE6oGWgvcLZNLlcp0hLEFcRs+UGsMLg==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.3.tgz",
+      "integrity": "sha512-ecE36ZBMLINqiTtSNQ1vzWc5pXLQHlf/oqGp/bSbi7iedcjcNb6QbCBNG73Euyy2C+l/fn8qKWEwxr+0SSfs3w==",
       "cpu": [
         "ia32"
       ],
@@ -4576,9 +4686,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.19.2.tgz",
-      "integrity": "sha512-DPi0ubYhSow/00YqmG1jWm3qt1F8aXziHc/UNy8bo9cpCacqhuWu+iSq/fp2SyEQK7iYTZ60fBU9cat3MXTjIQ==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.3.tgz",
+      "integrity": "sha512-vliZLrDmYKyaUoMzEbMTg2JkerfBjn03KmAw9CykO0Zzkzoyd7o3iZNam/TpyWNjNT+Cz2iO3P9Smv2wgrR+Eg==",
       "cpu": [
         "x64"
       ],
@@ -4857,30 +4967,10 @@
         "@types/zrender": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
-      "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
     "node_modules/@types/express": {
@@ -4896,9 +4986,21 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.5",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.1.tgz",
+      "integrity": "sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -4928,9 +5030,9 @@
       "dev": true
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.14",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.14.tgz",
-      "integrity": "sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==",
+      "version": "1.17.15",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+      "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -4992,9 +5094,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "version": "6.9.17",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
+      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
       "dev": true
     },
     "node_modules/@types/raf": {
@@ -5066,9 +5168,9 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5740,10 +5842,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
@@ -6058,9 +6160,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6280,9 +6382,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -6293,7 +6395,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -6319,9 +6421,9 @@
       "dev": true
     },
     "node_modules/bonjour-service": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
-      "integrity": "sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6908,30 +7010,21 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
+      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
       "dev": true,
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
+        "negotiator": "~0.6.4",
         "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/compression/node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/compression/node_modules/debug": {
@@ -6949,11 +7042,14 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7027,9 +7123,9 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -7293,9 +7389,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7823,9 +7919,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
-      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -7833,7 +7929,7 @@
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "~0.4.1",
+        "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
@@ -8538,37 +8634,37 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -8580,9 +8676,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -8597,14 +8693,23 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/express/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -9808,9 +9913,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -11136,9 +11241,9 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
-      "integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.1.tgz",
+      "integrity": "sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==",
       "dev": true,
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -11772,10 +11877,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -12336,9 +12444,9 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -13319,9 +13427,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -13795,9 +13903,9 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -14251,12 +14359,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -14849,12 +14957,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.19.2.tgz",
-      "integrity": "sha512-6/jgnN1svF9PjNYJ4ya3l+cqutg49vOZ4rVgsDKxdl+5gpGPnByFXWGyfH9YGx9i3nfBwSu1Iyu6vGwFFA0BdQ==",
+      "version": "4.27.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.3.tgz",
+      "integrity": "sha512-SLsCOnlmGt9VoZ9Ek8yBK8tAdmPHeppkw+Xa7yDlCEhDTvwYei03JlWo1fdc7YTfLZ4tD8riJCUyAgTbszk1fQ==",
       "dev": true,
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -14864,22 +14972,24 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.19.2",
-        "@rollup/rollup-android-arm64": "4.19.2",
-        "@rollup/rollup-darwin-arm64": "4.19.2",
-        "@rollup/rollup-darwin-x64": "4.19.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.19.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.19.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.19.2",
-        "@rollup/rollup-linux-arm64-musl": "4.19.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.19.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.19.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.19.2",
-        "@rollup/rollup-linux-x64-gnu": "4.19.2",
-        "@rollup/rollup-linux-x64-musl": "4.19.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.19.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.19.2",
-        "@rollup/rollup-win32-x64-msvc": "4.19.2",
+        "@rollup/rollup-android-arm-eabi": "4.27.3",
+        "@rollup/rollup-android-arm64": "4.27.3",
+        "@rollup/rollup-darwin-arm64": "4.27.3",
+        "@rollup/rollup-darwin-x64": "4.27.3",
+        "@rollup/rollup-freebsd-arm64": "4.27.3",
+        "@rollup/rollup-freebsd-x64": "4.27.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.27.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.27.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.27.3",
+        "@rollup/rollup-linux-arm64-musl": "4.27.3",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.27.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.27.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.27.3",
+        "@rollup/rollup-linux-x64-gnu": "4.27.3",
+        "@rollup/rollup-linux-x64-musl": "4.27.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.27.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.27.3",
+        "@rollup/rollup-win32-x64-msvc": "4.27.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -15081,9 +15191,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -15225,18 +15335,27 @@
       "dev": true
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-function-length": {
@@ -15365,16 +15484,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
-      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.5.2",
+        "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
       },
@@ -16781,26 +16900,25 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.90.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.3.tgz",
-      "integrity": "sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
@@ -16808,7 +16926,7 @@
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.3.10",
-        "watchpack": "^2.4.0",
+        "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -17056,6 +17174,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/webpack/node_modules/watchpack": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+      "dev": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/websocket-driver": {

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -168,7 +168,6 @@
                 [replay]="true"
                 [sender]="getUserName(action)"
                 [avatar]="getUserAvatar(action)"
-                [connectorType]="action.connectorType"
                 [applicationId]="action.applicationId"
               >
                 <div

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -158,7 +158,7 @@
   >
     <div *ngFor="let dialog of data">
       <nb-card>
-        <nb-card-body class="p-1 pt-2">
+        <nb-card-body class="px-3">
           <tock-chat-ui>
             <ng-container *ngFor="let action of dialog.actions">
               <tock-chat-ui-message
@@ -168,6 +168,8 @@
                 [replay]="true"
                 [sender]="getUserName(action)"
                 [avatar]="getUserAvatar(action)"
+                [connectorType]="action.connectorType"
+                [applicationId]="action.applicationId"
               >
                 <div
                   *ngIf="$any(action).metadata.isGenAiRagAnswer"

--- a/bot/admin/web/src/app/analytics/users/users.component.html
+++ b/bot/admin/web/src/app/analytics/users/users.component.html
@@ -166,8 +166,9 @@
     >
       <nb-card-header class="position-relative p-0">
         <tock-chat-ui
-          height="calc(100vh - 350px)"
           *ngIf="selectedUser && selectedUser.displayDialogs && selectedUser.userDialog"
+          height="calc(100vh - 350px)"
+          padding="1em 0.5em 1em 1em"
         >
           <tock-chat-ui-message
             *ngFor="let action of selectedUser.userDialog.actions"

--- a/bot/admin/web/src/app/analytics/users/users.component.html
+++ b/bot/admin/web/src/app/analytics/users/users.component.html
@@ -178,6 +178,7 @@
             [replay]="true"
             [sender]="getUserName(action)"
             [avatar]="getUserAvatar(action)"
+            [applicationId]="action.applicationId"
           >
           </tock-chat-ui-message>
         </tock-chat-ui>

--- a/bot/admin/web/src/app/bot/model/i18n.ts
+++ b/bot/admin/web/src/app/bot/model/i18n.ts
@@ -237,7 +237,6 @@ export class I18LabelQuery {
   toString(): string {
     const labelString = this.label && this.label.trim().length > 0 ? '_' + this.label : '';
     const categoryString = this.category && this.category.trim().length > 0 ? '_' + this.category : '';
-    //console.log(this.state);
     const stateString = this.state === I18nLabelStateQuery.ALL ? '' : '_' + this.state.toLowerCase();
     const notUsedSinceString = this.notUsedSince && this.notUsedSince > 0 ? '_not_used_since_' + this.notUsedSince + '_days' : '';
     return labelString + categoryString + stateString + notUsedSinceString;

--- a/bot/admin/web/src/app/bot/story/action/step/step.component.ts
+++ b/bot/admin/web/src/app/bot/story/action/step/step.component.ts
@@ -19,7 +19,7 @@ import { NbDialogService } from '@nebular/theme';
 import { Observable, of, take } from 'rxjs';
 
 import { EntityStepSelection, IntentName, StoryStepMetric, StoryStep } from '../../../model/story';
-import {EntityType, Intent, IntentsCategory, ParseQuery} from '../../../../model/nlp';
+import { EntityType, Intent, IntentsCategory, ParseQuery } from '../../../../model/nlp';
 import { StateService } from '../../../../core-nlp/state.service';
 import { IntentDialogComponent } from '../../../../language-understanding/intent-dialog/intent-dialog.component';
 import { NlpService } from '../../../../core-nlp/nlp.service';
@@ -221,7 +221,6 @@ export class StepComponent implements OnInit {
 
   setEntity() {
     const e = this.step.entity;
-    //console.log(e);
     let dialogRef = this.nbDialogService.open(SelectEntityDialogComponent, {
       context: {
         //@ts-ignore todo fix this
@@ -237,7 +236,6 @@ export class StepComponent implements OnInit {
           this.step.entity = null;
         } else {
           this.step.entity = new EntityStepSelection(result.value, result.role, result.entity.name);
-          //console.log(this.step);
         }
       }
     });

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.html
@@ -21,28 +21,31 @@
       <div class="row">
         <div class="col-md-6">
           <div class="truncate text-muted">
-            <small
-              class="d-block"
-              *ngIf="faq.utterances.length === 1"
-            >
-              Question
-            </small>
-            <small
-              class="d-block"
-              *ngIf="faq.utterances.length > 1"
-            >
-              First question (out of {{ faq.utterances.length }})
-            </small>
+            <div class="text-nowrap">
+              <small *ngIf="faq.utterances.length === 1"> Question </small>
+              <small *ngIf="faq.utterances.length > 1"> First question (out of {{ faq.utterances.length }}) </small>
+              <button
+                nbButton
+                ghost
+                size="tiny"
+                nbTooltip="Copy question"
+                (click)="copyString(faq.utterances[0])"
+              >
+                <nb-icon icon="copy"></nb-icon>
+              </button>
+
+              <button
+                nbButton
+                ghost
+                size="tiny"
+                nbTooltip="Test this question in a dialog"
+                (click)="testDialogSentence(faq.utterances[0], faq.language)"
+              >
+                <nb-icon icon="terminal-plus"></nb-icon>
+              </button>
+            </div>
+
             {{ faq.utterances[0] }}
-            <button
-              nbButton
-              ghost
-              size="tiny"
-              nbTooltip="Copy question"
-              (click)="copyString(faq.utterances[0])"
-            >
-              <nb-icon icon="copy"></nb-icon>
-            </button>
           </div>
         </div>
 

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-list/faq-management-list.component.ts
@@ -7,6 +7,7 @@ import { DialogService } from '../../../core-nlp/dialog.service';
 import { copyToClipboard, getExportFileName } from '../../../shared/utils';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
 import { ChoiceDialogComponent, IntentStoryDetailsComponent } from '../../../shared/components';
+import { TestDialogService } from '../../../shared/components/test-dialog/test-dialog.service';
 
 @Component({
   selector: 'tock-faq-management-list',
@@ -25,7 +26,8 @@ export class FaqManagementListComponent {
     public state: StateService,
     private dialogService: DialogService,
     private toastrService: NbToastrService,
-    private nbDialogService: NbDialogService
+    private nbDialogService: NbDialogService,
+    private testDialogService: TestDialogService
   ) {}
 
   getCurrentLocaleAnswerLabel(faq: FaqDefinitionExtended) {
@@ -122,6 +124,13 @@ export class FaqManagementListComponent {
       context: {
         intentId: faq.intentId
       }
+    });
+  }
+
+  testDialogSentence(message: string, locale: string) {
+    this.testDialogService.testSentenceDialog({
+      sentenceText: message,
+      sentenceLocale: locale
     });
   }
 }

--- a/bot/admin/web/src/app/shared/bot-shared.module.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.module.ts
@@ -84,7 +84,7 @@ import {
   BotConfigurationSelectorComponent
 } from './components';
 
-import { AutofocusDirective } from './directives';
+import { AutofocusDirective, TextareaAutocompleteDirective } from './directives';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AnalyticsService } from '../analytics/analytics.service';
@@ -162,7 +162,8 @@ import { ScrollComponent } from '../scroll/scroll.component';
     DataExportComponent,
     WysiwygEditorComponent,
     TestDialogComponent,
-    BotConfigurationSelectorComponent
+    BotConfigurationSelectorComponent,
+    TextareaAutocompleteDirective
   ],
   exports: [
     SelectBotComponent,
@@ -191,7 +192,8 @@ import { ScrollComponent } from '../scroll/scroll.component';
     AiSettingsEngineConfigParamInputComponent,
     SentencesGenerationComponent,
     DataExportComponent,
-    WysiwygEditorComponent
+    WysiwygEditorComponent,
+    TextareaAutocompleteDirective
   ],
   providers: [BotSharedService, AnalyticsService]
 })

--- a/bot/admin/web/src/app/shared/bot-shared.module.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.module.ts
@@ -79,7 +79,9 @@ import {
   SelectBotComponent,
   DateRangeCalendarComponent,
   DataExportComponent,
-  WysiwygEditorComponent
+  WysiwygEditorComponent,
+  TestDialogComponent,
+  BotConfigurationSelectorComponent
 } from './components';
 
 import { AutofocusDirective } from './directives';
@@ -88,8 +90,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { NgxSliderModule } from '@angular-slider/ngx-slider';
 import { ScrollComponent } from '../scroll/scroll.component';
-import { TestDialogComponent } from './components/test-dialog/test-dialog.component';
-import { BotConfigurationSelectorComponent } from './components/bot-configuration-selector/bot-configuration-selector.component';
 
 @NgModule({
   imports: [

--- a/bot/admin/web/src/app/shared/bot-shared.module.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.module.ts
@@ -88,6 +88,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AnalyticsService } from '../analytics/analytics.service';
 import { NgxSliderModule } from '@angular-slider/ngx-slider';
 import { ScrollComponent } from '../scroll/scroll.component';
+import { TestDialogComponent } from './components/test-dialog/test-dialog.component';
+import { BotConfigurationSelectorComponent } from './components/bot-configuration-selector/bot-configuration-selector.component';
 
 @NgModule({
   imports: [
@@ -158,7 +160,9 @@ import { ScrollComponent } from '../scroll/scroll.component';
     SentencesGenerationComponent,
     ScrollComponent,
     DataExportComponent,
-    WysiwygEditorComponent
+    WysiwygEditorComponent,
+    TestDialogComponent,
+    BotConfigurationSelectorComponent
   ],
   exports: [
     SelectBotComponent,

--- a/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.html
+++ b/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.html
@@ -1,18 +1,44 @@
-<div>
-  <nb-form-field nbTooltip="Select configuration">
+<div class="d-flex gap-1">
+  <nb-form-field nbTooltip="Select a configuration">
     <nb-icon
       nbPrefix
       icon="link-45deg"
     ></nb-icon>
     <nb-select
       size="small"
-      [(ngModel)]="currentBotName"
       fullWidth
+      [(ngModel)]="currentBotName"
+      (selectedChange)="changeBotName()"
     >
       <nb-option
         *ngFor="let n of botNames"
         [value]="n"
         >{{ n }}</nb-option
+      >
+    </nb-select>
+  </nb-form-field>
+
+  <nb-form-field nbTooltip="Select a connector">
+    <nb-icon
+      nbPrefix
+      icon="plug"
+    ></nb-icon>
+    <nb-select
+      size="small"
+      fullWidth
+      placeholder="Select a connector"
+      [(ngModel)]="currentConfiguration"
+      (selectedChange)="changeCurrentConfiguration()"
+    >
+      <nb-option
+        *ngFor="let c of configurations"
+        [value]="c"
+      >
+        <img
+          src="{{ c.connectorType.iconUrl() }}"
+          class="connector-icon"
+        />
+        {{ c.connectorType.label() }} ({{ c.applicationId }})</nb-option
       >
     </nb-select>
   </nb-form-field>

--- a/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.html
+++ b/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.html
@@ -1,0 +1,19 @@
+<div>
+  <nb-form-field nbTooltip="Select configuration">
+    <nb-icon
+      nbPrefix
+      icon="link-45deg"
+    ></nb-icon>
+    <nb-select
+      size="small"
+      [(ngModel)]="currentBotName"
+      fullWidth
+    >
+      <nb-option
+        *ngFor="let n of botNames"
+        [value]="n"
+        >{{ n }}</nb-option
+      >
+    </nb-select>
+  </nb-form-field>
+</div>

--- a/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.scss
+++ b/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.scss
@@ -1,0 +1,6 @@
+.connector-icon {
+  vertical-align: text-top;
+  width: 20px;
+  height: auto;
+  margin-right: 10px;
+}

--- a/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.spec.ts
+++ b/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BotConfigurationSelectorComponent } from './bot-configuration-selector.component';
+
+describe('BotConfigurationSelectorComponent', () => {
+  let component: BotConfigurationSelectorComponent;
+  let fixture: ComponentFixture<BotConfigurationSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BotConfigurationSelectorComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(BotConfigurationSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.ts
+++ b/bot/admin/web/src/app/shared/components/bot-configuration-selector/bot-configuration-selector.component.ts
@@ -1,0 +1,75 @@
+import { Component, Input, OnDestroy, SimpleChanges } from '@angular/core';
+import { Subject, take, takeUntil } from 'rxjs';
+import { BotConfigurationService } from '../../../core/bot-configuration.service';
+import { BotApplicationConfiguration } from '../../../core/model/configuration';
+
+@Component({
+  selector: 'tock-bot-configuration-selector',
+  templateUrl: './bot-configuration-selector.component.html',
+  styleUrl: './bot-configuration-selector.component.scss'
+})
+export class BotConfigurationSelectorComponent implements OnDestroy {
+  destroy = new Subject();
+
+  allConfigurations: BotApplicationConfiguration[];
+
+  currentRestConfiguration: BotApplicationConfiguration;
+  currentConfiguration: BotApplicationConfiguration;
+
+  botNames: string[];
+
+  currentBotName: string;
+
+  @Input() configurationId: string;
+
+  constructor(private botConfiguration: BotConfigurationService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.allConfigurations) {
+      this.botConfiguration.configurations.pipe(takeUntil(this.destroy)).subscribe((conf) => {
+        this.allConfigurations = conf;
+        this.initConfigurations();
+      });
+
+      return;
+    }
+
+    if (changes.configurationId && changes.configurationId.previousValue! == changes.configurationId.currentValue) {
+      console.log(changes.configurationId);
+      this.initConfigurations();
+    }
+  }
+
+  initConfigurations(): void {
+    const initConfiguration = this.allConfigurations.find((conf) => {
+      return conf._id === this.configurationId;
+    });
+
+    if (initConfiguration) {
+      if (initConfiguration.targetConfigurationId) {
+        this.currentRestConfiguration = initConfiguration;
+        this.currentConfiguration = this.allConfigurations.find((conf) => {
+          return conf._id === initConfiguration.targetConfigurationId;
+        });
+      } else {
+        this.currentConfiguration = initConfiguration;
+        this.currentRestConfiguration = this.allConfigurations.find((conf) => {
+          return conf.targetConfigurationId === initConfiguration._id;
+        });
+      }
+
+      this.currentBotName = this.currentConfiguration.name;
+    }
+
+    const retainedConfs = this.allConfigurations
+      .filter((c) => c.targetConfigurationId == null)
+      .sort((c1, c2) => c1.applicationId.localeCompare(c2.applicationId));
+
+    this.botNames = Array.from(new Set(retainedConfs.map((c) => c.name))).sort();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next(true);
+    this.destroy.complete();
+  }
+}

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
@@ -13,7 +13,16 @@
         class="sender"
         *ngIf="sender || date"
       >
-        {{ sender }} <time>{{ date | date: 'HH:mm:ss y/MM/dd' }}</time>
+        {{ sender }}
+
+        <time>{{ date | date: 'HH:mm:ss y/MM/dd' }}</time>
+
+        <span
+          *ngIf="applicationId"
+          nbTooltip="Configuration"
+        >
+          [{{ getApplicationConfigurationName(applicationId) }}]</span
+        >
 
         <button
           *ngIf="!reply"
@@ -22,7 +31,7 @@
           size="tiny"
           class="ml-2"
           nbTooltip="Test this sentence in a dialog"
-          (click)="testDialogSentence(message, connectorType, applicationId, $event)"
+          (click)="testDialogSentence(message, applicationId, $event)"
         >
           <nb-icon icon="terminal-plus"></nb-icon>
         </button>

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
@@ -14,6 +14,18 @@
         *ngIf="sender || date"
       >
         {{ sender }} <time>{{ date | date: 'HH:mm:ss y/MM/dd' }}</time>
+
+        <button
+          *ngIf="!reply"
+          nbButton
+          ghost
+          size="tiny"
+          class="ml-2"
+          nbTooltip="Test this sentence in a dialog"
+          (click)="testDialogSentence(message, connectorType, applicationId, $event)"
+        >
+          <nb-icon icon="terminal-plus"></nb-icon>
+        </button>
       </p>
 
       <div class="text">

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
@@ -42,7 +42,7 @@
     }
 
     .text {
-      padding: 1rem;
+      padding: 0.6rem;
       border-radius: 0.5rem;
     }
   }
@@ -88,7 +88,8 @@
 
         .text {
           border-top-right-radius: 0;
-          background: nb-theme(chat-message-reply-background-color);
+          // background: nb-theme(chat-message-reply-background-color);
+          background-color: var(--background-basic-color-3);
           color: nb-theme(chat-message-reply-text-color);
         }
       }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 import { BotMessage } from '../../../model/dialog-data';
+import { TestDialogService } from '../../test-dialog/test-dialog.service';
+import { ConnectorType } from '../../../../core/model/configuration';
 
 @Component({
   selector: 'tock-chat-ui-message',
@@ -10,8 +12,10 @@ import { BotMessage } from '../../../model/dialog-data';
 export class ChatUiMessageComponent {
   @Input() message: BotMessage;
   @Input() replay: boolean = false;
-  @Input() sender: string;
-  @Input() date: Date;
+  @Input() sender?: string;
+  @Input() date?: Date;
+  @Input() applicationId?: string;
+  @Input() connectorType?: ConnectorType;
 
   @Input()
   set avatar(value: string) {
@@ -42,9 +46,19 @@ export class ChatUiMessageComponent {
 
   @Output() sendMessage: EventEmitter<BotMessage> = new EventEmitter();
 
-  constructor(protected domSanitizer: DomSanitizer) {}
+  constructor(protected domSanitizer: DomSanitizer, private testDialogService: TestDialogService) {}
 
   replyMessage(message: BotMessage) {
     this.sendMessage.emit(message);
+  }
+
+  testDialogSentence(message, connectorType, applicationId, event) {
+    event?.stopPropagation();
+
+    this.testDialogService.testSentenceDialog({
+      sentenceText: message.text,
+      connectorType,
+      applicationId
+    });
   }
 }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
@@ -1,7 +1,10 @@
 <div
   #scrollable
   class="scrollable"
+  [class.mayScroll]="height || maxHeight"
   [style.height]="height"
+  [style.max-height]="maxHeight"
+  [style.padding]="padding"
 >
   <div class="messages">
     <ng-content></ng-content>

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
@@ -13,12 +13,17 @@
     flex: 1;
 
     .messages {
-      padding: 1rem 1.25rem;
       overflow-y: auto;
       overflow-x: hidden;
       display: flex;
       flex-shrink: 0;
       flex-direction: column;
+    }
+
+    &.mayScroll {
+      .messages {
+        padding: 0 0.5em 0 0;
+      }
     }
   }
 }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.ts
@@ -6,7 +6,9 @@ import { Component, ElementRef, Input, ViewChild } from '@angular/core';
   styleUrls: ['./chat-ui.component.scss']
 })
 export class ChatUiComponent {
-  @Input() height: string;
+  @Input() height?: string;
+  @Input() maxHeight?: string;
+  @Input() padding?: string;
 
   @ViewChild('scrollable') private scrollable: ElementRef;
 

--- a/bot/admin/web/src/app/shared/components/index.ts
+++ b/bot/admin/web/src/app/shared/components/index.ts
@@ -38,3 +38,5 @@ export * from './select-bot/select-bot.component';
 export * from './date-range/date-range-calendar.component';
 export * from './data-export/data-export.component';
 export * from './wysiwyg-editor/wysiwyg-editor.component';
+export * from './test-dialog/test-dialog.component';
+export * from './bot-configuration-selector/bot-configuration-selector.component';

--- a/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.html
+++ b/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.html
@@ -1,4 +1,19 @@
-<nb-card class="min-width-90vw">
+<nb-card
+  class="min-width-90vw"
+  *ngIf="!loading && !intent"
+>
+  <nb-card-body class="p-0 pb-2">
+    <tock-no-data-found
+      title="Intent not found"
+      message="There is no intention of the name '{{ this.intentName || this.intentId }}'. Perhaps it has been deleted."
+    ></tock-no-data-found>
+  </nb-card-body>
+</nb-card>
+
+<nb-card
+  class="min-width-90vw"
+  *ngIf="intent"
+>
   <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
     <div>Intent &laquo;{{ this.intent.label || this.intent.name }}&raquo; story details</div>
     <button
@@ -85,10 +100,26 @@
           </label>
 
           <div>
-            <span *ngIf="story.storyId"
-              ><span class="text-mitigated-light">&laquo;</span>{{ story.userSentence
-              }}<span class="text-mitigated-light">&raquo;</span></span
-            >
+            <span *ngIf="story.storyId">
+              <span class="text-mitigated-light">&laquo;</span>{{ story.userSentence }}<span class="text-mitigated-light">&raquo;</span>
+              <span
+                nbTooltip="Locale"
+                class="ml-2"
+              >
+                [{{ story.userSentenceLocale }}]
+              </span>
+
+              <button
+                nbButton
+                ghost
+                size="tiny"
+                class="ml-2"
+                nbTooltip="Test this sentence in a dialog"
+                (click)="testDialogSentence(story.userSentence, story.userSentenceLocale)"
+              >
+                <nb-icon icon="terminal-plus"></nb-icon>
+              </button>
+            </span>
 
             <div
               class="mt-1"
@@ -124,12 +155,28 @@
                   <small>
                     <span class="text-mitigated-light">&laquo;</span>{{ $any(sentence).text
                     }}<span class="text-mitigated-light">&raquo;</span>
-
+                    <span
+                      nbTooltip="Locale"
+                      class="ml-2"
+                    >
+                      [{{ $any(sentence).language }}]
+                    </span>
                     <span
                       nbTooltip="Usage count"
                       class="ml-2"
                       >({{ $any(sentence).classification?.usageCount }})</span
                     >
+
+                    <button
+                      nbButton
+                      ghost
+                      size="tiny"
+                      class="ml-2"
+                      nbTooltip="Test this sentence in a dialog"
+                      (click)="testDialogSentence($any(sentence).text, $any(sentence).language)"
+                    >
+                      <nb-icon icon="terminal-plus"></nb-icon>
+                    </button>
                   </small>
                 </li>
               </ul>

--- a/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.ts
+++ b/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.ts
@@ -73,7 +73,6 @@ export class IntentStoryDetailsComponent implements OnInit {
       this.sentences = res.sentences.sort((a, b) => {
         return b.classification?.usageCount - a.classification?.usageCount;
       });
-      console.log(this.sentences);
     });
   }
 

--- a/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.ts
+++ b/bot/admin/web/src/app/shared/components/intent-story-details/intent-story-details.component.ts
@@ -6,6 +6,7 @@ import { StoryDefinitionConfiguration } from '../../../bot/model/story';
 import { Intent, SearchQuery } from '../../../model/nlp';
 import { PaginatedQuery } from '../../../model/commons';
 import { NlpService } from '../../../core-nlp/nlp.service';
+import { TestDialogService } from '../test-dialog/test-dialog.service';
 
 @Component({
   selector: 'tock-intent-story-details',
@@ -26,7 +27,8 @@ export class IntentStoryDetailsComponent implements OnInit {
     private dialogRef: NbDialogRef<IntentStoryDetailsComponent>,
     private stateService: StateService,
     private botService: BotService,
-    private nlpService: NlpService
+    private nlpService: NlpService,
+    private testDialogService: TestDialogService
   ) {}
 
   ngOnInit(): void {
@@ -38,13 +40,16 @@ export class IntentStoryDetailsComponent implements OnInit {
       this.intent = this.stateService.findIntentByName(this.intentName);
     }
 
-    this.botService.findStoryByBotIdAndIntent(this.stateService.currentApplication.name, this.intent.name).subscribe((s) => {
-      this.story = s;
+    if (this.intent) {
+      this.botService.findStoryByBotIdAndIntent(this.stateService.currentApplication.name, this.intent.name).subscribe((s) => {
+        this.story = s;
 
-      this.searchIntentSentences();
-
+        this.searchIntentSentences();
+        this.loading = false;
+      });
+    } else {
       this.loading = false;
-    });
+    }
   }
 
   searchIntentSentences(): void {
@@ -56,7 +61,7 @@ export class IntentStoryDetailsComponent implements OnInit {
     const searchQuery = new SearchQuery(
       paginatedQuery.namespace,
       paginatedQuery.applicationName,
-      paginatedQuery.language,
+      null,
       paginatedQuery.start,
       paginatedQuery.size,
       paginatedQuery.searchMark,
@@ -68,8 +73,17 @@ export class IntentStoryDetailsComponent implements OnInit {
       this.sentences = res.sentences.sort((a, b) => {
         return b.classification?.usageCount - a.classification?.usageCount;
       });
+      console.log(this.sentences);
     });
   }
+
+  testDialogSentence(message, locale) {
+    this.testDialogService.testSentenceDialog({
+      sentenceText: message,
+      sentenceLocale: locale
+    });
+  }
+
   cancel(): void {
     this.dialogRef.close();
   }

--- a/bot/admin/web/src/app/shared/components/select-bot/select-bot.component.css
+++ b/bot/admin/web/src/app/shared/components/select-bot/select-bot.component.css
@@ -18,7 +18,7 @@
   width: 200px;
 }
 .select-width {
-  min-width: 12rem;
+  min-width: 8rem;
 }
 
 .connector-icon {

--- a/bot/admin/web/src/app/shared/components/select-bot/select-bot.component.html
+++ b/bot/admin/web/src/app/shared/components/select-bot/select-bot.component.html
@@ -53,7 +53,8 @@
   </span>
   <span
     *ngIf="displayConnectorChoice && currentBotName !== 'None'"
-    class="select-configuration w-50 lineHeight-1"
+    class="select-configuration lineHeight-1"
+    [class.w-50]="botNames && (allowNoSelection || botNames.length > 1)"
   >
     <nb-form-field nbTooltip="Select connector">
       <nb-icon

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.html
@@ -52,6 +52,7 @@
     <tock-chat-ui
       *ngIf="displayedDialog?.actions"
       height="calc(100vh - 320px)"
+      padding="1em 0.5em 1em 1em"
     >
       <tock-chat-ui-message
         *ngFor="let action of displayedDialog.actions"

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-entry/sentence-training-entry.component.html
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-entry/sentence-training-entry.component.html
@@ -35,11 +35,22 @@
           nbButton
           ghost
           size="tiny"
-          class="mr-2 lineFirstSmallButtonRetract"
+          class="lineFirstSmallButtonRetract"
           nbTooltip="Copy sentence"
           (click)="copySentence(sentence)"
         >
           <nb-icon icon="copy"></nb-icon>
+        </button>
+
+        <button
+          nbButton
+          ghost
+          size="tiny"
+          class="mr-2"
+          nbTooltip="Test this sentence in a dialog"
+          (click)="testDialogSentence(sentence)"
+        >
+          <nb-icon icon="terminal-plus"></nb-icon>
         </button>
 
         <time>{{ sentence.creationDate | date: 'yy/MM/dd HH:mm:ss' }}</time>

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-entry/sentence-training-entry.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-entry/sentence-training-entry.component.ts
@@ -28,6 +28,7 @@ import { getSentenceId } from '../commons/utils';
 import { copyToClipboard } from '../../../utils';
 import { IntentStoryDetailsComponent } from '../../intent-story-details/intent-story-details.component';
 import { ChoiceDialogComponent } from '../../choice-dialog/choice-dialog.component';
+import { TestDialogService } from '../../test-dialog/test-dialog.service';
 
 @Component({
   selector: 'tock-sentence-training-entry',
@@ -66,7 +67,8 @@ export class SentenceTrainingEntryComponent implements OnInit, DoCheck, OnDestro
     private router: Router,
     private nbDialogService: NbDialogService,
     private toastrService: NbToastrService,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private testDialogService: TestDialogService
   ) {}
 
   ngOnInit(): void {
@@ -261,6 +263,13 @@ export class SentenceTrainingEntryComponent implements OnInit, DoCheck, OnDestro
   async copySentence(sentence) {
     copyToClipboard(sentence.getText());
     this.toastrService.success(`Sentence copied to clipboard`, 'Clipboard');
+  }
+
+  testDialogSentence(sentence) {
+    this.testDialogService.testSentenceDialog({
+      sentenceText: sentence.text,
+      sentenceLocale: sentence.language
+    });
   }
 
   redirectToFaqManagement(sentence: SentenceExtended): void {

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training.component.ts
@@ -482,7 +482,6 @@ Would you like to change the intent of all the sentences matching the search cri
   }
 
   changeSentencesEntity(entities: { old: EntityDefinition; new: EntityDefinition }, changeAll?: boolean): void {
-    //console.log(entities);
     if (!this.selection.selected.length && !changeAll) {
       const action = 'Change intent of all results';
       const dialogRef = this.nbDialogService.open(ChoiceDialogComponent, {

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -29,7 +29,7 @@
 
       <div
         *ngIf="showOptions"
-        class="d-flex flex-wrap gap-1 align-items-center mt-2 pb-1"
+        class="d-flex flex-wrap gap-1 row-gap-1 align-items-center mt-2 pb-1"
       >
         <nb-form-field>
           <nb-icon

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -110,32 +110,26 @@
 
     <div class="d-flex justify-content-between align-items-center flex-wrap gap-1 mt-3">
       <div class="d-flex gap-1 flex-grow-1">
-        <div class="w-100">
-          <input
-            nbInput
-            fullWidth
-            fieldSize="medium"
-            placeholder="Type some text"
-            [(ngModel)]="userMessage"
-            (keyup.enter)="submit()"
-            autocomplete="off"
-            [nbAutocomplete]="userMessageAutocomplete"
-            (click)="updateUserMessageAutocompleteValues()"
-            (keyup)="updateUserMessageAutocompleteValues($event)"
-            tockAutofocusElement
-          />
-          <nb-autocomplete
-            #userMessageAutocomplete
-            size="tiny"
-          >
-            <nb-option
-              *ngFor="let option of userMessageAutocompleteValues | async"
-              [value]="option"
-            >
-              {{ option }}
-            </nb-option>
-          </nb-autocomplete>
-        </div>
+        <textarea
+          #textareaAutocompleteDirectiveRef
+          [ngStyle]="{ height: getUserMessageInputHeight() }"
+          rows="1"
+          class="w-100 nb-autocomplete-position-top"
+          nbInput
+          fullWidth
+          fieldSize="medium"
+          status="primary"
+          placeholder="Type some text"
+          [(ngModel)]="userMessage"
+          (onInputValueChange)="onUserMessageChange($event)"
+          (keyup.shift.enter)="insertCarriage()"
+          (keyup.enter)="submit($event)"
+          autocomplete="off"
+          [nbAutocomplete]="userMessageAutocomplete"
+          position="top"
+          (click)="updateUserMessageAutocompleteValues()"
+          (keyup)="updateUserMessageAutocompleteValues($event)"
+        ></textarea>
 
         <button
           nbButton
@@ -157,5 +151,16 @@
         <nb-icon icon="trash"></nb-icon>
       </button>
     </div>
+    <nb-autocomplete
+      #userMessageAutocomplete
+      size="tiny"
+    >
+      <nb-option
+        *ngFor="let option of userMessageAutocompleteValues | async"
+        [value]="option"
+      >
+        {{ option }}
+      </nb-option>
+    </nb-autocomplete>
   </ng-container>
 </div>

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -48,16 +48,11 @@
             >
           </nb-select>
         </nb-form-field>
-        {{ currentConfigurationId }}
 
-        <tock-bot-configuration-selector [configurationId]="currentConfigurationId"></tock-bot-configuration-selector>
-
-        <tock-select-bot
-          [(configurationId)]="currentConfigurationId"
-          [returnsRestConfiguration]="true"
-          (selectionChange)="changeConfiguration($event)"
-        >
-        </tock-select-bot>
+        <tock-bot-configuration-selector
+          [currentConfigurationId]="currentConfigurationId"
+          (currentConfigurationChange)="changeCurrentConfiguration($event)"
+        ></tock-bot-configuration-selector>
 
         <div class="d-flex gap-1">
           <nb-checkbox

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -1,0 +1,166 @@
+<div
+  class="mr-n1"
+  [nbSpinner]="loading"
+>
+  <tock-no-data-found
+    *ngIf="configurations?.length === 0"
+    title="No bot configuration detected"
+    message="Go to Settings > Configurations to define one"
+  ></tock-no-data-found>
+
+  <ng-container *ngIf="configurations?.length">
+    <div class="options-wrapper border-top border-bottom">
+      <div
+        (click)="swapOptions()"
+        class="d-flex align-items-center font-weight-bold mb-1 pointer"
+      >
+        <nb-icon
+          *ngIf="!showOptions"
+          icon="chevron-down-outline"
+          pack="nebular-essentials"
+        ></nb-icon>
+        <nb-icon
+          *ngIf="showOptions"
+          icon="chevron-up-outline"
+          pack="nebular-essentials"
+        ></nb-icon>
+        Options
+      </div>
+
+      <div
+        *ngIf="showOptions"
+        class="d-flex flex-wrap gap-1 align-items-center mt-2 pb-1"
+      >
+        <nb-form-field>
+          <nb-icon
+            nbPrefix
+            icon="globe2"
+          ></nb-icon>
+          <nb-select
+            [(ngModel)]="locale"
+            size="small"
+            nbTooltip="Select the dialog locale"
+          >
+            <nb-option
+              *ngFor="let loc of state.currentApplication.supportedLocales"
+              [value]="loc"
+              >{{ state.localeName(loc) }}</nb-option
+            >
+          </nb-select>
+        </nb-form-field>
+        {{ currentConfigurationId }}
+
+        <tock-bot-configuration-selector [configurationId]="currentConfigurationId"></tock-bot-configuration-selector>
+
+        <tock-select-bot
+          [(configurationId)]="currentConfigurationId"
+          [returnsRestConfiguration]="true"
+          (selectionChange)="changeConfiguration($event)"
+        >
+        </tock-select-bot>
+
+        <div class="d-flex gap-1">
+          <nb-checkbox
+            [(ngModel)]="debug"
+            nbTooltip="Get debug infos of RAG responses"
+            >Debug</nb-checkbox
+          >
+
+          <nb-checkbox
+            [(ngModel)]="sourceWithContent"
+            nbTooltip="Get text content of RAG sources"
+            >Sources content</nb-checkbox
+          >
+        </div>
+      </div>
+    </div>
+
+    <div class="shaders-wrapper mt-2">
+      <div class="shader-top"></div>
+      <tock-chat-ui
+        maxHeight="calc(100vh - 450px)"
+        padding="0.2em 0 0 0"
+        #chatUi
+      >
+        <tock-chat-ui-message
+          *ngFor="let m of messages"
+          [message]="m.message"
+          [reply]="m.bot"
+          [avatar]="getUserAvatar(m.bot)"
+          (sendMessage)="onNewMessage($event)"
+        >
+          <span
+            *ngIf="m.locale"
+            class="stats"
+          >
+            [{{ m.locale }}]
+            <button
+              *ngIf="m.hasNlpStats"
+              (click)="displayNlpStats(m)"
+              nbTooltip="View Nlp Stats"
+              nbButton
+              ghost
+              shape="round"
+              size="tiny"
+              status="primary"
+            >
+              <nb-icon icon="clipboard-data"></nb-icon>
+            </button>
+          </span>
+        </tock-chat-ui-message>
+      </tock-chat-ui>
+
+      <div class="shader-bottom"></div>
+    </div>
+
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-1 mt-3">
+      <div class="d-flex gap-1 flex-grow-1">
+        <div class="w-100">
+          <input
+            nbInput
+            fullWidth
+            fieldSize="medium"
+            placeholder="Type some text"
+            [(ngModel)]="userMessage"
+            (keyup.enter)="submit()"
+            autocomplete="off"
+            [nbAutocomplete]="userMessageAutocomplete"
+            (click)="updateUserMessageAutocompleteValues()"
+            (keyup)="updateUserMessageAutocompleteValues($event)"
+            tockAutofocusElement
+          />
+          <nb-autocomplete
+            #userMessageAutocomplete
+            size="tiny"
+          >
+            <nb-option
+              *ngFor="let option of userMessageAutocompleteValues | async"
+              [value]="option"
+            >
+              {{ option }}
+            </nb-option>
+          </nb-autocomplete>
+        </div>
+
+        <button
+          nbButton
+          size="medium"
+          (click)="submit()"
+        >
+          GO
+        </button>
+      </div>
+
+      <button
+        *ngIf="messages.length !== 0"
+        nbTooltip="Clear conversation"
+        nbButton
+        status="warning"
+        size="medium"
+        (click)="clear()"
+      >
+        <nb-icon icon="trash"></nb-icon>
+      </button>
+    </div>
+  </ng-container>
+</div>

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.scss
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.scss
@@ -1,0 +1,38 @@
+.stats {
+  font-size: xx-small;
+  float: left;
+  margin-right: 20px;
+  margin-top: -2px;
+}
+
+.options-wrapper {
+  margin-top: -1em;
+  margin-right: -2em;
+  margin-left: -2em;
+
+  background-color: var(--background-basic-color-3);
+  padding: 0.5em 2em;
+}
+
+.shaders-wrapper {
+  position: relative;
+
+  .shader-top,
+  .shader-bottom {
+    pointer-events: none;
+    padding: 0.5em;
+    position: absolute;
+
+    left: 0;
+    right: 0.7em;
+  }
+
+  .shader-top {
+    top: 0;
+    background: linear-gradient(0deg, rgba(255, 255, 255, 0) 10%, var(--background-basic-color-2) 100%);
+  }
+  .shader-bottom {
+    bottom: 0;
+    background: linear-gradient(0deg, var(--background-basic-color-2) 10%, rgba(255, 255, 255, 0) 100%);
+  }
+}

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.scss
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.scss
@@ -7,8 +7,8 @@
 
 .options-wrapper {
   margin-top: -1em;
-  margin-right: -2em;
-  margin-left: -2em;
+  margin-right: -1.3em;
+  margin-left: -1.6em;
 
   background-color: var(--background-basic-color-3);
   padding: 0.5em 2em;

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.spec.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TestDialogComponent } from './test-dialog.component';
+
+describe('TestDialogComponent', () => {
+  let component: TestDialogComponent;
+  let fixture: ComponentFixture<TestDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestDialogComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TestDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
@@ -13,11 +13,11 @@ import { BotSharedService } from '../../bot-shared.service';
 import { ChatUiComponent } from '../chat-ui/chat-ui.component';
 import { NlpStatsDisplayComponent } from '../../../test/dialog/nlp-stats-display/nlp-stats-display.component';
 import { RestService } from '../../../core-nlp/rest/rest.service';
-import { SelectBotEvent } from '../select-bot/select-bot.component';
 import { TestDialogService } from './test-dialog.service';
 import { BotConfigurationService } from '../../../core/bot-configuration.service';
 import { BotApplicationConfiguration } from '../../../core/model/configuration';
 import { currentConfigurationSelection } from '../bot-configuration-selector/bot-configuration-selector.component';
+import { TextareaAutocompleteDirective } from '../../directives';
 
 @Component({
   selector: 'tock-test-dialog',
@@ -68,6 +68,8 @@ export class TestDialogComponent implements OnInit, OnDestroy {
   }
 
   @ViewChild('chatUi') private chatUi: ChatUiComponent;
+
+  @ViewChild(TextareaAutocompleteDirective) textareaAutocompleteDirectiveRef: TextareaAutocompleteDirective<HTMLTextAreaElement>;
 
   constructor(
     private botConfiguration: BotConfigurationService,
@@ -206,17 +208,35 @@ export class TestDialogComponent implements OnInit, OnDestroy {
     }
 
     this.userMessageAutocompleteValues = of(results);
+
+    if (event && event.key !== 'Escape') this.textareaAutocompleteDirectiveRef.updatePosition();
   }
 
   getUserAvatar(isBot: boolean): string {
     return getDialogMessageUserAvatar(isBot);
   }
 
+  getUserMessageInputHeight(): string {
+    const lineHeight = 1.5;
+    const padding = 2 * 0.5;
+    return lineHeight * this.userMessage.split(/\n/).length + padding + 'rem';
+  }
+
+  onUserMessageChange(value: string): void {
+    this.userMessage = value ?? '';
+  }
+
+  insertCarriage(): void {
+    this.onUserMessageChange(this.userMessage + '\n');
+  }
+
   onNewMessage(message: BotMessage): void {
     this.talk(message);
   }
 
-  submit(): void {
+  submit(event?: Event): void {
+    if (event) event.preventDefault();
+
     if (!this.currentConfigurationId) {
       this.toastrService.show(`Please select a Bot first`, 'Error', { duration: 3000 });
       return;

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
@@ -1,0 +1,311 @@
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Observable, Subject, of, take, takeUntil } from 'rxjs';
+import { PaginatedQuery, randomString } from '../../../model/commons';
+import { StateService } from '../../../core-nlp/state.service';
+import { SearchQuery } from '../../../model/nlp';
+import { NlpService } from '../../../core-nlp/nlp.service';
+import { getDialogMessageUserAvatar } from '../../utils';
+import { BotMessage, Sentence } from '../../model/dialog-data';
+import { NbDialogService, NbToastrService, NbWindowRef, NbWindowState } from '@nebular/theme';
+import { BotDialogRequest, BotDialogResponse, TestMessage } from '../../../test/model/test';
+
+import { BotSharedService } from '../../bot-shared.service';
+import { ChatUiComponent } from '../chat-ui/chat-ui.component';
+import { NlpStatsDisplayComponent } from '../../../test/dialog/nlp-stats-display/nlp-stats-display.component';
+import { RestService } from '../../../core-nlp/rest/rest.service';
+import { SelectBotEvent } from '../select-bot/select-bot.component';
+import { TestDialogService } from './test-dialog.service';
+import { BotConfigurationService } from '../../../core/bot-configuration.service';
+import { BotApplicationConfiguration, ConnectorType } from '../../../core/model/configuration';
+
+@Component({
+  selector: 'tock-test-dialog',
+  templateUrl: './test-dialog.component.html',
+  styleUrl: './test-dialog.component.scss'
+})
+export class TestDialogComponent implements OnInit, OnDestroy {
+  destroy = new Subject();
+
+  loading: boolean = true;
+
+  configurations: BotApplicationConfiguration[];
+  currentConfigurationId: string;
+
+  locale: string;
+
+  userMessage: string = '';
+  messages: TestMessage[] = [];
+
+  showOptions: boolean = false;
+
+  userModifierId: string = randomString();
+
+  recentSentences: string[];
+  userMessageAutocompleteValues: Observable<string[]>;
+
+  _debug: boolean = false;
+
+  set debug(value: boolean) {
+    this._debug = value;
+    this.shared.session_storage = { ...this.shared.session_storage, ...{ test: { ...this.shared.session_storage?.test, debug: value } } };
+  }
+  get debug() {
+    return this._debug;
+  }
+
+  _sourceWithContent: boolean = false;
+
+  set sourceWithContent(value: boolean) {
+    this._sourceWithContent = value;
+    this.shared.session_storage = {
+      ...this.shared.session_storage,
+      ...{ test: { ...this.shared.session_storage?.test, sourceWithContent: value } }
+    };
+  }
+  get sourceWithContent() {
+    return this._sourceWithContent;
+  }
+
+  @ViewChild('chatUi') private chatUi: ChatUiComponent;
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    public state: StateService,
+    private nlp: NlpService,
+    private toastrService: NbToastrService,
+    private shared: BotSharedService,
+    private nbDialogService: NbDialogService,
+    private rest: RestService,
+    private testDialogService: TestDialogService,
+    protected windowRef: NbWindowRef
+  ) {}
+
+  ngOnInit() {
+    this.state.configurationChange.pipe(takeUntil(this.destroy)).subscribe((res) => {
+      if (this.locale != this.state.currentLocale) this.locale = this.state.currentLocale;
+    });
+
+    this.locale = this.state.currentLocale;
+
+    this.rest.errorEmitter.pipe(takeUntil(this.destroy)).subscribe((e) => (this.loading = false));
+
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy)).subscribe((confs) => {
+      this.loading = true;
+
+      this.configurations = confs;
+
+      this.initCurrentConfiguration();
+
+      this.getRecentSentences();
+    });
+
+    if (this.shared.session_storage?.test?.debug) {
+      this._debug = this.shared.session_storage.test.debug;
+    }
+
+    if (this.shared.session_storage?.test?.sourceWithContent) {
+      this._sourceWithContent = this.shared.session_storage.test.sourceWithContent;
+    }
+
+    this.windowRef.stateChange.pipe(takeUntil(this.destroy)).subscribe((change) => {
+      if (change.newState === NbWindowState.MINIMIZED) {
+        this.testDialogService.storeMessages(this.messages);
+      }
+
+      if ([NbWindowState.MAXIMIZED, NbWindowState.FULL_SCREEN].includes(change.newState)) {
+        const storedMessages = this.testDialogService.getStoredMessages();
+        if (storedMessages?.length > 0) {
+          this.messages = storedMessages;
+          setTimeout(() => this.chatUi.scrollToBottom());
+        }
+      }
+    });
+
+    this.testDialogService.defineLocaleObservable.pipe(takeUntil(this.destroy)).subscribe((locale) => {
+      this.locale = locale;
+    });
+
+    this.testDialogService.defineApplicationIdObservable.pipe(takeUntil(this.destroy)).subscribe((applicationId) => {
+      this.setCurrentConfigurationByApplicationId(applicationId);
+    });
+
+    this.testDialogService.defineConnectorTypeObservable.pipe(takeUntil(this.destroy)).subscribe((connectorType) => {
+      this.setCurrentConfigurationByConnectorType(connectorType);
+    });
+
+    this.testDialogService.testSentenceObservable.pipe(takeUntil(this.destroy)).subscribe((sentenceText) => {
+      // this.talk(new Sentence(0, [], sentenceText));
+    });
+  }
+
+  setCurrentConfigurationByApplicationId(applicationId: string): void {
+    let requiredApplication = this.configurations.find((a) => a.applicationId === applicationId);
+    if (requiredApplication) {
+      console.log(this.configurations);
+      console.log(requiredApplication);
+
+      if (requiredApplication.targetConfigurationId) {
+        requiredApplication = this.configurations.find((a) => a._id === requiredApplication.targetConfigurationId);
+      }
+
+      this.currentConfigurationId = requiredApplication._id;
+    }
+  }
+
+  setCurrentConfigurationByConnectorType(connectorType: ConnectorType): void {
+    // console.log(connectorType);
+  }
+
+  initCurrentConfiguration(): void {
+    const previousConfigurationId = this.currentConfigurationId;
+
+    if (this.configurations.length) {
+      const retainedConfs = this.configurations
+        .filter((c) => c.targetConfigurationId == null)
+        .sort((c1, c2) => c1.applicationId.localeCompare(c2.applicationId));
+
+      const currentConf = retainedConfs[0];
+      const currentConfRest = BotApplicationConfiguration.getRestConfiguration(this.configurations, currentConf);
+
+      this.currentConfigurationId = currentConfRest._id;
+
+      if (previousConfigurationId !== this.currentConfigurationId) {
+        this.clear();
+      }
+    }
+  }
+
+  swapOptions(): void {
+    this.showOptions = !this.showOptions;
+  }
+
+  getRecentSentences(): void {
+    const cursor: number = 0;
+    const pageSize: number = 50;
+    const mark = null;
+    const paginatedQuery: PaginatedQuery = this.state.createPaginatedQuery(cursor, pageSize, mark);
+    const searchQuery = new SearchQuery(
+      paginatedQuery.namespace,
+      paginatedQuery.applicationName,
+      paginatedQuery.language,
+      paginatedQuery.start,
+      paginatedQuery.size,
+      paginatedQuery.searchMark
+    );
+    this.nlp
+      .searchSentences(searchQuery)
+      .pipe(take(1))
+      .subscribe((res) => {
+        this.recentSentences = res.rows.map((r) => r.text);
+        this.loading = false;
+      });
+  }
+
+  updateUserMessageAutocompleteValues(event?: KeyboardEvent): void {
+    if (this.loading) return;
+
+    let results = this.recentSentences;
+
+    if (event) {
+      const targetEvent = event.target as HTMLInputElement;
+      results = results.filter((sentence: string) => sentence.toLowerCase().includes(targetEvent.value.trim().toLowerCase()));
+    }
+
+    this.userMessageAutocompleteValues = of(results);
+  }
+
+  getUserAvatar(isBot: boolean): string {
+    return getDialogMessageUserAvatar(isBot);
+  }
+
+  onNewMessage(message: BotMessage): void {
+    this.talk(message);
+  }
+
+  submit(): void {
+    if (!this.currentConfigurationId) {
+      this.toastrService.show(`Please select a Bot first`, 'Error', { duration: 3000 });
+      return;
+    }
+    let m = this.userMessage;
+    if (!m || m.trim().length === 0) {
+      return;
+    }
+    m = m.trim();
+    this.talk(new Sentence(0, [], m));
+  }
+
+  talkRequest(query: BotDialogRequest, debug: boolean = false, sourceWithContent: boolean = false): Observable<BotDialogResponse> {
+    let params: { debug?: boolean; sourceWithContent?: boolean } = {};
+    if (debug) params.debug = true;
+    if (sourceWithContent) params.sourceWithContent = true;
+    return this.rest.post('/test/talk', query, BotDialogResponse.fromJSON, null, false, params);
+  }
+
+  private talk(message: BotMessage): void {
+    this.userMessageAutocompleteValues = of([]);
+    const userAction = new TestMessage(false, message);
+    this.messages.push(userAction);
+    this.userMessage = '';
+    this.loading = true;
+    this.talkRequest(
+      new BotDialogRequest(
+        this.currentConfigurationId,
+        message,
+        this.state.currentApplication.namespace,
+        this.state.currentApplication.name,
+        this.locale,
+        this.userModifierId
+      ),
+      this.debug,
+      this.sourceWithContent
+    )
+      .pipe(take(1))
+      .subscribe((r) => {
+        this.loading = false;
+        userAction.locale = r.userLocale;
+        userAction.hasNlpStats = r.hasNlpStats;
+        userAction.actionId = r.userActionId;
+        r.messages.forEach((m) => {
+          this.messages.push(new TestMessage(true, m, undefined, undefined, undefined));
+
+          setTimeout(() => this.chatUi.scrollToBottom());
+        });
+      });
+  }
+
+  clear(): void {
+    this.messages = [];
+    this.userModifierId = randomString();
+  }
+
+  changeConfiguration(selectBotEvent: SelectBotEvent): void {
+    if (selectBotEvent?.configurationId !== this.currentConfigurationId) {
+      this.messages = [];
+      this.currentConfigurationId = selectBotEvent.configurationId;
+    }
+
+    this.loading = false;
+  }
+
+  displayNlpStats(m: TestMessage): void {
+    this.shared
+      .getNlpDialogStats(m.actionId)
+      .pipe(take(1))
+      .subscribe((response) => {
+        this.nbDialogService.open(NlpStatsDisplayComponent, {
+          context: {
+            data: {
+              request: response.nlpQueryAsJson(),
+              response: response.nlpResultAsJson()
+            }
+          }
+        });
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next(true);
+    this.destroy.complete();
+  }
+}

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.spec.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TestDialogService } from './test-dialog.service';
+
+describe('TestDialogService', () => {
+  let service: TestDialogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TestDialogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@angular/core';
+import { NbWindowRef, NbWindowService, NbWindowState } from '@nebular/theme';
+import { TestDialogComponent } from './test-dialog.component';
+import { TestMessage } from '../../../test/model/test';
+import { Subject } from 'rxjs';
+import { ConnectorType } from '../../../core/model/configuration';
+
+export interface openTestDialogOptions {
+  sentenceText?: string;
+  sentenceLocale?: string;
+  connectorType?: ConnectorType;
+  applicationId?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TestDialogService {
+  constructor(private nbWindowService: NbWindowService) {}
+
+  windowRef: NbWindowRef<any, any>;
+
+  openTestDialog() {
+    if (this.windowRef) {
+      this.windowRef.close();
+    } else {
+      this.windowRef?.close();
+      this.windowRef = this.nbWindowService.open(TestDialogComponent, {
+        title: 'Test dialog',
+        windowClass: 'test-dialog-window',
+        closeOnBackdropClick: false,
+        initialState: NbWindowState.MAXIMIZED
+      });
+
+      this.windowRef.onClose.subscribe(() => {
+        this.messages = undefined;
+        this.windowRef = undefined;
+      });
+    }
+  }
+
+  private defineLocaleSubject = new Subject<string>();
+  defineLocaleObservable = this.defineLocaleSubject.asObservable();
+
+  private defineConnectorTypeSubject = new Subject<ConnectorType>();
+  defineConnectorTypeObservable = this.defineConnectorTypeSubject.asObservable();
+
+  private defineApplicationIdSubject = new Subject<string>();
+  defineApplicationIdObservable = this.defineApplicationIdSubject.asObservable();
+
+  private testSentenceSubject = new Subject<string>();
+  testSentenceObservable = this.testSentenceSubject.asObservable();
+
+  testSentenceDialog(options: openTestDialogOptions) {
+    if (!this.windowRef) this.openTestDialog();
+
+    if (this.windowRef.state === NbWindowState.MINIMIZED) {
+      this.windowRef.maximize();
+      setTimeout(() => {
+        this.testSentenceDialog(options);
+      });
+      return;
+    }
+
+    if (options.sentenceLocale) {
+      this.defineLocaleSubject.next(options.sentenceLocale);
+    }
+
+    if (options.applicationId) {
+      this.defineApplicationIdSubject.next(options.applicationId);
+    }
+
+    if (options.connectorType) {
+      this.defineConnectorTypeSubject.next(options.connectorType);
+    }
+
+    if (options.sentenceText?.trim().length) {
+      this.testSentenceSubject.next(options.sentenceText);
+    }
+  }
+
+  messages: TestMessage[];
+
+  storeMessages(messages) {
+    this.messages = messages;
+  }
+
+  getStoredMessages() {
+    return this.messages;
+  }
+}

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
@@ -3,12 +3,10 @@ import { NbWindowRef, NbWindowService, NbWindowState } from '@nebular/theme';
 import { TestDialogComponent } from './test-dialog.component';
 import { TestMessage } from '../../../test/model/test';
 import { Subject } from 'rxjs';
-import { ConnectorType } from '../../../core/model/configuration';
 
 export interface openTestDialogOptions {
   sentenceText?: string;
   sentenceLocale?: string;
-  connectorType?: ConnectorType;
   applicationId?: string;
 }
 
@@ -42,9 +40,6 @@ export class TestDialogService {
   private defineLocaleSubject = new Subject<string>();
   defineLocaleObservable = this.defineLocaleSubject.asObservable();
 
-  private defineConnectorTypeSubject = new Subject<ConnectorType>();
-  defineConnectorTypeObservable = this.defineConnectorTypeSubject.asObservable();
-
   private defineApplicationIdSubject = new Subject<string>();
   defineApplicationIdObservable = this.defineApplicationIdSubject.asObservable();
 
@@ -70,12 +65,24 @@ export class TestDialogService {
       this.defineApplicationIdSubject.next(options.applicationId);
     }
 
-    if (options.connectorType) {
-      this.defineConnectorTypeSubject.next(options.connectorType);
-    }
-
     if (options.sentenceText?.trim().length) {
       this.testSentenceSubject.next(options.sentenceText);
+    }
+
+    this.bringToFront();
+  }
+
+  bringToFront() {
+    const hasManyOverlays = document.getElementsByClassName('cdk-global-overlay-wrapper');
+    if (hasManyOverlays?.length > 1) {
+      const currentOverlay = this.windowRef.componentRef.location.nativeElement.closest('.cdk-global-overlay-wrapper');
+      const otherOverlays = Array.from(hasManyOverlays).filter((ovl) => ovl !== currentOverlay);
+      let maxZIndex = 0;
+      otherOverlays.forEach((ovl) => {
+        const zIndex = window.getComputedStyle(ovl).zIndex;
+        if (zIndex && +zIndex > maxZIndex) maxZIndex = +zIndex;
+      });
+      currentOverlay.style.zIndex = maxZIndex + 1;
     }
   }
 

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.service.ts
@@ -20,9 +20,12 @@ export class TestDialogService {
 
   openTestDialog() {
     if (this.windowRef) {
-      this.windowRef.close();
+      if (this.windowRef.state === NbWindowState.MINIMIZED) {
+        this.windowRef.maximize();
+      } else {
+        this.windowRef.close();
+      }
     } else {
-      this.windowRef?.close();
       this.windowRef = this.nbWindowService.open(TestDialogComponent, {
         title: 'Test dialog',
         windowClass: 'test-dialog-window',

--- a/bot/admin/web/src/app/shared/directives/index.ts
+++ b/bot/admin/web/src/app/shared/directives/index.ts
@@ -1,2 +1,3 @@
 export * from './autofocus/autofocus.directive';
 export * from './fullscreen/fullscreen.directive';
+export * from './textarea-autocomplete/textarea-autocomplete.directive';

--- a/bot/admin/web/src/app/shared/directives/textarea-autocomplete/textarea-autocomplete.directive.spec.ts
+++ b/bot/admin/web/src/app/shared/directives/textarea-autocomplete/textarea-autocomplete.directive.spec.ts
@@ -1,0 +1,8 @@
+import { TextareaAutocompleteDirective } from './textarea-autocomplete.directive';
+
+describe('TextareaAutocompleteDirective', () => {
+  it('should create an instance', () => {
+    // const directive = new TextareaAutocompleteDirective();
+    // expect(directive).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/directives/textarea-autocomplete/textarea-autocomplete.directive.ts
+++ b/bot/admin/web/src/app/shared/directives/textarea-autocomplete/textarea-autocomplete.directive.ts
@@ -1,0 +1,51 @@
+import { ChangeDetectorRef, Directive, ElementRef, EventEmitter, Input, Output, Renderer2 } from '@angular/core';
+import {
+  NbAdjustableConnectedPositionStrategy,
+  NbAdjustment,
+  NbAutocompleteDirective,
+  NbFocusKeyManagerFactoryService,
+  NbOptionComponent,
+  NbOverlayService,
+  NbPosition,
+  NbPositionBuilderService,
+  NbTriggerStrategyBuilderService
+} from '@nebular/theme';
+import { takeUntil } from 'rxjs';
+
+@Directive({
+  selector: 'textarea[nbAutocomplete]'
+})
+export class TextareaAutocompleteDirective<T> extends NbAutocompleteDirective<T> {
+  @Input() position: 'top' | 'bottom' = 'bottom';
+  @Output() onInputValueChange = new EventEmitter<string>();
+
+  constructor(
+    protected override hostRef: ElementRef,
+    protected override overlay: NbOverlayService,
+    protected override cd: ChangeDetectorRef,
+    protected override triggerStrategyBuilder: NbTriggerStrategyBuilderService,
+    protected override positionBuilder: NbPositionBuilderService,
+    protected nbFocusKeyManagerFactoryService: NbFocusKeyManagerFactoryService<NbOptionComponent<T>>,
+    protected override renderer: Renderer2
+  ) {
+    super(hostRef, overlay, cd, triggerStrategyBuilder, positionBuilder, nbFocusKeyManagerFactoryService, renderer);
+  }
+
+  protected override handleInputValueUpdate(value: T, focusInput: boolean = false) {
+    super.handleInputValueUpdate(value, focusInput);
+    this.onInputValueChange.emit(this.hostRef.nativeElement.value);
+  }
+
+  protected override createPositionStrategy(): NbAdjustableConnectedPositionStrategy {
+    return this.positionBuilder
+      .connectedTo(this.customOverlayHost || this.hostRef)
+      .position(this.position === 'top' ? NbPosition.TOP : NbPosition.BOTTOM)
+      .offset(this.overlayOffset)
+      .adjustment(NbAdjustment.VERTICAL);
+  }
+
+  updatePosition(): void {
+    this.hide();
+    this.show();
+  }
+}

--- a/bot/admin/web/src/app/shared/model/dialog-data.ts
+++ b/bot/admin/web/src/app/shared/model/dialog-data.ts
@@ -52,7 +52,8 @@ export class ActionReport {
     public message: BotMessage,
     public id: String,
     public test: boolean,
-    public connectorType?: ConnectorType
+    public connectorType?: ConnectorType,
+    public applicationId?: string
   ) {}
 
   isBot(): boolean {

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
@@ -94,32 +94,25 @@
 
     <div class="d-flex justify-content-between align-items-center flex-wrap gap-1 mt-3">
       <div class="d-flex gap-1 flex-grow-1">
-        <div class="w-100">
-          <input
-            nbInput
-            fullWidth
-            fieldSize="medium"
-            status="primary"
-            placeholder="Type some text"
-            [(ngModel)]="userMessage"
-            (keyup.enter)="submit()"
-            autocomplete="off"
-            [nbAutocomplete]="userMessageAutocomplete"
-            (click)="updateUserMessageAutocompleteValues()"
-            (keyup)="updateUserMessageAutocompleteValues($event)"
-          />
-          <nb-autocomplete
-            #userMessageAutocomplete
-            size="tiny"
-          >
-            <nb-option
-              *ngFor="let option of userMessageAutocompleteValues | async"
-              [value]="option"
-            >
-              {{ option }}
-            </nb-option>
-          </nb-autocomplete>
-        </div>
+        <textarea
+          [ngStyle]="{ height: getUserMessageInputHeight() }"
+          rows="1"
+          class="w-100 nb-autocomplete-position-top"
+          nbInput
+          fullWidth
+          fieldSize="medium"
+          status="primary"
+          placeholder="Type some text"
+          [(ngModel)]="userMessage"
+          (onInputValueChange)="onUserMessageChange($event)"
+          (keyup.shift.enter)="insertCarriage()"
+          (keyup.enter)="submit()"
+          autocomplete="off"
+          [nbAutocomplete]="userMessageAutocomplete"
+          position="top"
+          (click)="updateUserMessageAutocompleteValues()"
+          (keyup)="updateUserMessageAutocompleteValues($event)"
+        ></textarea>
 
         <button
           nbButton
@@ -144,6 +137,18 @@
         <nb-icon icon="trash"></nb-icon>
       </button>
     </div>
+
+    <nb-autocomplete
+      #userMessageAutocomplete
+      size="tiny"
+    >
+      <nb-option
+        *ngFor="let option of userMessageAutocompleteValues | async"
+        [value]="option"
+      >
+        {{ option }}
+      </nb-option>
+    </nb-autocomplete>
 
     <div
       *ngIf="testContext"

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.scss
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.scss
@@ -19,7 +19,6 @@
   font-size: xx-small;
   float: left;
   margin-right: 20px;
-  margin-top: -12px;
 }
 
 #messagesWrapper {

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.ts
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.ts
@@ -180,6 +180,20 @@ export class BotDialogComponent implements OnInit, OnDestroy {
     this.talk(message);
   }
 
+  getUserMessageInputHeight() {
+    const linHeight = 1.5;
+    const padding = 2 * 0.5;
+    return linHeight * this.userMessage.split(/\n/).length + padding + 'rem';
+  }
+
+  onUserMessageChange(value: string) {
+    this.userMessage = value ?? '';
+  }
+
+  insertCarriage() {
+    this.onUserMessageChange(this.userMessage + '\n');
+  }
+
   submit(): void {
     if (!this.currentConfigurationId) {
       this.toastrService.show(`Please select a Bot first`, 'Error', { duration: 3000 });

--- a/bot/admin/web/src/app/theme/components/header/header.component.html
+++ b/bot/admin/web/src/app/theme/components/header/header.component.html
@@ -107,6 +107,16 @@
       nbButton
       ghost
       size="medium"
+      (click)="openDialogTest()"
+      nbTooltip="Open a test dialog"
+    >
+      <nb-icon icon="terminal-plus"></nb-icon>
+    </button>
+
+    <button
+      nbButton
+      ghost
+      size="medium"
       *ngIf="auth.isLoggedIn() && !auth.isSSO()"
       (click)="auth.logout()"
       nbTooltip="Logout"

--- a/bot/admin/web/src/app/theme/components/header/header.component.html
+++ b/bot/admin/web/src/app/theme/components/header/header.component.html
@@ -113,15 +113,19 @@
       <nb-icon icon="terminal-plus"></nb-icon>
     </button>
 
-    <button
-      nbButton
-      ghost
-      size="medium"
+    <div
       *ngIf="auth.isLoggedIn() && !auth.isSSO()"
-      (click)="auth.logout()"
-      nbTooltip="Logout"
+      class="border-left pl-3"
     >
-      <nb-icon icon="box-arrow-right"></nb-icon>
-    </button>
+      <button
+        nbButton
+        ghost
+        size="medium"
+        (click)="auth.logout()"
+        nbTooltip="Logout"
+      >
+        <nb-icon icon="box-arrow-right"></nb-icon>
+      </button>
+    </div>
   </div>
 </div>

--- a/bot/admin/web/src/app/theme/components/header/header.component.ts
+++ b/bot/admin/web/src/app/theme/components/header/header.component.ts
@@ -26,6 +26,7 @@ import { ApplicationService } from '../../../core-nlp/applications.service';
 import { BotConfigurationService } from '../../../core/bot-configuration.service';
 import { CoreConfig } from '../../../core-nlp/core.config';
 import { Router } from '@angular/router';
+import { TestDialogService } from '../../../shared/components/test-dialog/test-dialog.service';
 
 @Component({
   selector: 'tock-header',
@@ -52,7 +53,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private applicationService: ApplicationService,
     private botConfiguration: BotConfigurationService,
     private config: CoreConfig,
-    private router: Router
+    private router: Router,
+    private testDialogService: TestDialogService
   ) {}
 
   ngOnInit() {
@@ -134,6 +136,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   changeLocale(locale) {
     setTimeout((_) => this.state.changeLocale(locale));
+  }
+
+  openDialogTest() {
+    this.testDialogService.openTestDialog();
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -253,3 +253,31 @@ nb-menu {
 .opacity-0 {
   opacity: 0 !important;
 }
+
+.test-dialog-window {
+  margin: 0 1rem !important;
+
+  nb-card {
+    box-shadow: 0px 2px 10px #00000025;
+    background-color: var(--background-basic-color-2);
+  }
+
+  &.maximized {
+    nb-card {
+      max-width: 55vw;
+    }
+  }
+  &.full-screen {
+    nb-card {
+      width: 90vw;
+    }
+  }
+}
+
+// may disappear with the switch to bootstrap 5
+.border-top {
+  border-color: var(--border-basic-color-4) !important;
+}
+.border-bottom {
+  border-color: var(--border-basic-color-4) !important;
+}

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -9,10 +9,25 @@
   text-overflow: ellipsis;
 }
 
+// Should disappear with bootstrap update to v5. The erroneous unit will be corrected (1 = 0.5, 2 = 0.5, 3 = 1, etc...).
 @for $i from 1 through 4 {
   .gap-#{$i} {
     gap: #{$i}rem;
   }
+}
+
+// Should disappear with bootstrap update to v5.
+.row-gap-1 {
+  row-gap: 0.25rem;
+}
+.row-gap-2 {
+  row-gap: 0.5rem;
+}
+.row-gap-3 {
+  row-gap: 1rem;
+}
+.row-gap-4 {
+  row-gap: 1.5rem;
 }
 
 .lineHeight-0 {
@@ -27,8 +42,21 @@
   font-size: 12px;
 }
 
-.nb-theme-dark .border {
-  border-color: var(--input-basic-border-color) !important;
+// may disappear with the switch to bootstrap 5
+.border {
+  border-color: var(--border-basic-color-4) !important;
+}
+.border-top {
+  border-color: var(--border-basic-color-4) !important;
+}
+.border-bottom {
+  border-color: var(--border-basic-color-4) !important;
+}
+.border-left {
+  border-color: var(--border-basic-color-4) !important;
+}
+.border-right {
+  border-color: var(--border-basic-color-4) !important;
 }
 
 .nb-theme-default .text-mitigated {
@@ -131,6 +159,10 @@ nb-card.selected {
   user-select: none;
 }
 
+.unClickable {
+  pointer-events: none;
+}
+
 .card-footer-actions {
   display: flex;
   flex-direction: column;
@@ -156,10 +188,6 @@ nb-card.selected {
   LABEL {
     margin-bottom: 0;
   }
-}
-
-.unClickable {
-  pointer-events: none;
 }
 
 .shader {
@@ -272,12 +300,4 @@ nb-menu {
       width: 90vw;
     }
   }
-}
-
-// may disappear with the switch to bootstrap 5
-.border-top {
-  border-color: var(--border-basic-color-4) !important;
-}
-.border-bottom {
-  border-color: var(--border-basic-color-4) !important;
 }


### PR DESCRIPTION
New component for testing dialogs from anywhere in the studio: 
- Addition of a button in the application header to open a test dialog in a modal window
- Add a button in different views to open the modal and launch a discussion with the sentence provided:
     - Language understanding > Inbox sentences
     - Language understanding > Search sentences
     - Stories& answers > Faqs
     - Analytics > Dialogs
     - Analytics > Users
     - Story details modal

Initial locale and configuration are automatically set if supplied.

Also added : the ability to put carriage returns in user message.

The historical test view remains unchanged except for the ability to enter carriage returns.

![image](https://github.com/user-attachments/assets/d39f1e62-c2f6-43e0-a6e9-43c89ed344f9)

