### PR TITLE
:bug: Fixing test for FAQ with namespace

### DIFF
--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt
@@ -72,7 +72,7 @@ class FaqAdminServiceSettingsTest : AbstractTest() {
         faqs: List<FaqDefinition>,
         stories: List<StoryDefinitionConfiguration>
     ) {
-        every { faqDefinitionDAO.getFaqDefinitionByBotId(any()) } answers { faqs }
+        every { faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(any(), any()) } answers { faqs }
 
         every { AdminService.front.getIntentById(any()) } answers { intent }
 

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
@@ -281,9 +281,10 @@ class FaqAdminServiceTest : AbstractTest() {
                 every { faqDefinitionDAO.getFaqDefinitionById(any()) } answers { existingFaq }
                 every { faqDefinitionDAO.save(any()) } just Runs
                 every {
-                    faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(
+                    faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace(
                         eq(intentId),
-                        eq(botId)
+                        eq(botId),
+                        eq(namespace)
                     )
                 } answers { existingFaq }
             }
@@ -531,7 +532,7 @@ class FaqAdminServiceTest : AbstractTest() {
          */
         private fun initMocksForSharedIntentFaq(existingFaq: FaqDefinition) {
             every { faqDefinitionDAO.getFaqDefinitionByIntentId(any()) } answers { existingFaq }
-            every { faqDefinitionDAO.getFaqDefinitionByBotId(eq(OTHER_APP_NAME)) } answers { emptyList() }
+            every { faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(eq(OTHER_APP_NAME), eq(defaultNamespace)) } answers { emptyList() }
             every { faqDefinitionDAO.save(any()) } just Runs
         }
 
@@ -620,9 +621,10 @@ class FaqAdminServiceTest : AbstractTest() {
             //GIVEN
             // new faq is created there was none before
             every {
-                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(
+                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace(
                     eq(intentId),
-                    eq(OTHER_APP_NAME)
+                    eq(OTHER_APP_NAME),
+                    eq(namespace)
                 )
             } answers { null }
 
@@ -710,9 +712,10 @@ class FaqAdminServiceTest : AbstractTest() {
             )
 
             every {
-                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(
+                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace(
                     eq(intentId),
-                    eq(OTHER_APP_NAME)
+                    eq(OTHER_APP_NAME),
+                    eq(namespace)
                 )
             } answers { existingFaqSharedIntentDefinition }
 
@@ -791,9 +794,10 @@ class FaqAdminServiceTest : AbstractTest() {
             )
 
             every {
-                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId(
+                faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace(
                     eq(intentId),
-                    eq(OTHER_APP_NAME)
+                    eq(OTHER_APP_NAME),
+                    eq(namespace)
                 )
             } answers { existingFaqSharedIntentDefinition }
 

--- a/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
+++ b/nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt
@@ -108,7 +108,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
         faqDefinitionDao.save(faqDefinition)
         assertEquals(
             expected = faqDefinition,
-            actual = faqDefinitionDao.getFaqDefinitionByBotId(botId).first(),
+            actual = faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId, namespace).first(),
             message = "There should be something returned with an applicationId"
         )
         assertEquals(
@@ -144,12 +144,12 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
 
         assertEquals(
             expected = 2,
-            actual = faqDefinitionDao.getFaqDefinitionByBotId(botId).size,
+            actual = faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId, namespace).size,
             message = "There should be something returned with an applicationId"
         )
         assertEquals(
             expected = 1,
-            actual = faqDefinitionDao.getFaqDefinitionByBotId(botId2).size,
+            actual = faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId2, namespace).size,
             message = "There should be something returned with an applicationId"
         )
     }
@@ -241,12 +241,12 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
 
         assertEquals(3, col.countDocuments())
 
-        assertEquals(2, faqDefinitionDao.getFaqDefinitionByBotId(botId1).size)
+        assertEquals(2, faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId1, namespace).size)
 
         faqDefinitionDao.deleteFaqDefinitionByBotIdAndNamespace(botId1,namespace)
 
-        assertEquals(0, faqDefinitionDao.getFaqDefinitionByBotId(botId1).size)
-        assertEquals(1, faqDefinitionDao.getFaqDefinitionByBotId(botId2).size)
+        assertEquals(0, faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId1, namespace).size)
+        assertEquals(1, faqDefinitionDao.getFaqDefinitionByBotIdAndNamespace(botId2, namespace).size)
     }
 
     @Test
@@ -295,7 +295,7 @@ class FaqDefinitionMongoDAOTest : AbstractTest() {
         intentDefinitionDao.save(secondIntentWithIntentId3)
         faqDefinitionDao.save(secondFaqDefinition)
 
-        val tags = faqDefinitionDao.getTags(botId)
+        val tags = faqDefinitionDao.getTags(botId, namespace)
         assertEquals(tags, otherTagList + faqDefinition.tags)
     }
 


### PR DESCRIPTION
Fixing tests for FAQ with namespace introduced in #1753 

This pull request includes changes to the `FaqAdminServiceTest`, `FaqAdminServiceSettingsTest`, and `FaqDefinitionMongoDAOTest` classes to update method calls to include a `namespace` parameter. This ensures that the correct FAQ definitions are retrieved based on both the bot ID and namespace.

Updates to method calls to include `namespace` parameter:

* [`bot/admin/server/src/test/kotlin/FaqAdminServiceSettingsTest.kt`](diffhunk://#diff-bcf6ce7903daea9bc479bfebdf6d277bac639fedc564403376101e7576caf8b5L75-R75): Updated the method call `faqDefinitionDAO.getFaqDefinitionByBotId` to `faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace` to include the `namespace` parameter.

* `bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt`: Updated multiple method calls to include the `namespace` parameter:
  - `faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotId` to `faqDefinitionDAO.getFaqDefinitionByIntentIdAndBotIdAndNamespace`. [[1]](diffhunk://#diff-55ad3b58f7320a4b32aa67c8efa3ae6a2881a7f9efdfece5373ad979dd861b5aL284-R287) [[2]](diffhunk://#diff-55ad3b58f7320a4b32aa67c8efa3ae6a2881a7f9efdfece5373ad979dd861b5aL623-R627) [[3]](diffhunk://#diff-55ad3b58f7320a4b32aa67c8efa3ae6a2881a7f9efdfece5373ad979dd861b5aL713-R718) [[4]](diffhunk://#diff-55ad3b58f7320a4b32aa67c8efa3ae6a2881a7f9efdfece5373ad979dd861b5aL794-R800)
  - `faqDefinitionDAO.getFaqDefinitionByBotId` to `faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace`.

* `nlp/front/storage-mongo/src/test/kotlin/FaqDefinitionMongoDAOTest.kt`: Updated method calls to include the `namespace` parameter:
  - `faqDefinitionDAO.getFaqDefinitionByBotId` to `faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace`. [[1]](diffhunk://#diff-f9c7ec5fb6996025d7d64fe686295b140d3cd49edd45fbd97a048cb04c3141f9L111-R111) [[2]](diffhunk://#diff-f9c7ec5fb6996025d7d64fe686295b140d3cd49edd45fbd97a048cb04c3141f9L147-R152) [[3]](diffhunk://#diff-f9c7ec5fb6996025d7d64fe686295b140d3cd49edd45fbd97a048cb04c3141f9L244-R249)
  - `faqDefinitionDAO.getTags` to include `namespace` parameter.