### PR TITLE
:bug: #1796 [GenAI] Fixes async mode for PG in ingestion tooling scripts

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/open_search_factory.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/open_search_factory.py
@@ -14,6 +14,7 @@
 #
 """Model for creating OpenSearchFactory"""
 import logging
+from typing import Optional
 
 from langchain_community.vectorstores.opensearch_vector_search import OpenSearchVectorSearch
 from langchain_core.vectorstores import VectorStoreRetriever
@@ -41,7 +42,7 @@ class OpenSearchFactory(LangChainVectorStoreFactory):
 
     setting: OpenSearchVectorStoreSetting
 
-    def get_vector_store(self) -> OpenSearchVectorSearch:
+    def get_vector_store(self, async_mode: Optional[bool] = True) -> OpenSearchVectorSearch:
         password = fetch_secret_key_value(self.setting.password)
         logger.info(
             'OpenSearch user credentials: %s:%s',

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/pgvector_factory.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/pgvector_factory.py
@@ -14,6 +14,7 @@
 #
 """Model for creating PGVectorFactory"""
 import logging
+from typing import Optional
 
 from langchain_core.vectorstores import VectorStoreRetriever
 from langchain_postgres import PGVector
@@ -37,7 +38,7 @@ class PGVectorFactory(LangChainVectorStoreFactory):
 
     setting: PGVectorStoreSetting
 
-    def get_vector_store(self) -> PGVector:
+    def get_vector_store(self, async_mode: Optional[bool] = True) -> PGVector:
         password = fetch_secret_key_value(self.setting.password)
         logger.info(
             'PostgreSQL user credentials: %s:%s',
@@ -50,7 +51,7 @@ class PGVectorFactory(LangChainVectorStoreFactory):
             collection_name=self.index_name,
             connection=f'postgresql+psycopg://{self.setting.username}:{password}@{self.setting.host}:{self.setting.port}/{self.setting.database}',
             use_jsonb=True,
-            async_mode=True
+            async_mode=async_mode
         )
 
     def get_vector_store_retriever(self, search_kwargs: dict) -> VectorStoreRetriever:

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/vector_store_factory.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/vector_store_factory.py
@@ -16,7 +16,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -42,9 +42,11 @@ class LangChainVectorStoreFactory(ABC, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @abstractmethod
-    def get_vector_store(self) -> VectorStore:
+    def get_vector_store(self, async_mode: Optional[bool] = True) -> VectorStore:
         """
         Fabric the Vector Store.
+        Args:
+            async_mode: enable/disable the async_mode for vector DB client (if supported). Default to True.
         :return: VectorStore the interface for Vector Database.
         """
         pass

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/index_documents.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/index_documents.py
@@ -178,7 +178,7 @@ def index_documents() -> IndexingDetails:
         embedding_function=embeddings
     )
     vector_store_factory.check_vector_store_connection()
-    vector_store = vector_store_factory.get_vector_store()
+    vector_store = vector_store_factory.get_vector_store(async_mode=False)
 
     embedding_and_indexing(splitted_docs, vector_store)
 


### PR DESCRIPTION
Fixes #1796 

This pull request includes changes to add an optional `async_mode` parameter to the `get_vector_store` method across multiple vector store factory classes. This enhancement provides more flexibility in enabling or disabling asynchronous mode for vector database clients.

Key changes include:

### Enhancements to vector store factories:

* [`gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/open_search_factory.py`](diffhunk://#diff-6840b69918257a452e9b8bb8b946e1baad9c7e897fbe78468e1289cccabed2f9L44-R45): Added `async_mode` parameter to `get_vector_store` method in `OpenSearchFactory` class.
* [`gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/pgvector_factory.py`](diffhunk://#diff-69bb08ddf1d180bca904a5c1763e636258b4008d25a565742b72fc8e01cbd3d0L40-R41): Added `async_mode` parameter to `get_vector_store` method in `PGVectorFactory` class and updated its usage. [[1]](diffhunk://#diff-69bb08ddf1d180bca904a5c1763e636258b4008d25a565742b72fc8e01cbd3d0L40-R41) [[2]](diffhunk://#diff-69bb08ddf1d180bca904a5c1763e636258b4008d25a565742b72fc8e01cbd3d0L53-R54)
* [`gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/factories/vector_stores/vector_store_factory.py`](diffhunk://#diff-9b3cbf3a1263b938ce33526008896f17c58e12ddea2e9e7693ead36e9e6b24fbL45-R49): Added `async_mode` parameter to abstract method `get_vector_store` in `LangChainVectorStoreFactory` class and updated the method's docstring.


### Application of new parameter:

* [`gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/index_documents.py`](diffhunk://#diff-243b91e087d3da3cc90ce84632c78af53595f5cbd6c01f6e8846f85e45ce6977L181-R181): Updated the call to `get_vector_store` to explicitly set `async_mode` to `False`.