### PR TITLE
[Tock Studio] Add the ability to open a single dialog in a view with url

### DIFF
--- a/bot/admin/web/src/app/analytics/analytics-routing.module.ts
+++ b/bot/admin/web/src/app/analytics/analytics-routing.module.ts
@@ -42,7 +42,7 @@ const routes: Routes = [
         component: DialogsComponent
       },
       {
-        path: 'dialog/:dialogId',
+        path: 'dialog/:namespace/:applicationId/:dialogId',
         component: DialogComponent
       },
       {

--- a/bot/admin/web/src/app/analytics/analytics-routing.module.ts
+++ b/bot/admin/web/src/app/analytics/analytics-routing.module.ts
@@ -10,6 +10,7 @@ import { DialogsComponent } from './dialogs/dialogs.component';
 import { UsersComponent } from './users/users.component';
 import { PreferencesComponent } from './preferences/preferences.component';
 import { SatisfactionComponent } from './satisfaction/satisfaction.component';
+import { DialogComponent } from './dialog/dialog.component';
 
 const routes: Routes = [
   {
@@ -39,6 +40,10 @@ const routes: Routes = [
       {
         path: 'dialogs',
         component: DialogsComponent
+      },
+      {
+        path: 'dialog/:dialogId',
+        component: DialogComponent
       },
       {
         path: 'users',

--- a/bot/admin/web/src/app/analytics/analytics-routing.module.ts
+++ b/bot/admin/web/src/app/analytics/analytics-routing.module.ts
@@ -42,7 +42,7 @@ const routes: Routes = [
         component: DialogsComponent
       },
       {
-        path: 'dialog/:namespace/:applicationId/:dialogId',
+        path: 'dialogs/:namespace/:applicationId/:dialogId',
         component: DialogComponent
       },
       {

--- a/bot/admin/web/src/app/analytics/analytics.module.ts
+++ b/bot/admin/web/src/app/analytics/analytics.module.ts
@@ -44,7 +44,8 @@ import {
   NbRadioModule,
   NbToggleModule,
   NbIconModule,
-  NbFormFieldModule
+  NbFormFieldModule,
+  NbPopoverModule
 } from '@nebular/theme';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from './chart/chart.component';
@@ -96,7 +97,8 @@ import { DialogComponent } from './dialog/dialog.component';
     NbIconModule,
     NgxEchartsModule.forRoot({
       echarts: () => import('echarts')
-    })
+    }),
+    NbPopoverModule
   ],
   declarations: [
     AnalyticsTabsComponent,

--- a/bot/admin/web/src/app/analytics/analytics.module.ts
+++ b/bot/admin/web/src/app/analytics/analytics.module.ts
@@ -59,6 +59,7 @@ import { ActivateSatisfactionComponent } from './satisfaction/activate-satisfact
 import { SatisfactionDetailsComponent } from './satisfaction/satisfaction-details/satisfaction-details.component';
 import { AnalyticsRoutingModule } from './analytics-routing.module';
 import { DialogsListComponent } from './dialogs/dialogs-list/dialogs-list.component';
+import { DialogComponent } from './dialog/dialog.component';
 
 @NgModule({
   schemas: [NO_ERRORS_SCHEMA],
@@ -110,7 +111,8 @@ import { DialogsListComponent } from './dialogs/dialogs-list/dialogs-list.compon
     SatisfactionComponent,
     ActivateSatisfactionComponent,
     SatisfactionDetailsComponent,
-    DialogsListComponent
+    DialogsListComponent,
+    DialogComponent
   ],
   exports: [],
   providers: [AnalyticsService]

--- a/bot/admin/web/src/app/analytics/analytics.service.ts
+++ b/bot/admin/web/src/app/analytics/analytics.service.ts
@@ -24,9 +24,8 @@ import { TestPlan } from '../test/model/test';
 import { DialogReport } from '../shared/model/dialog-data';
 import { ApplicationDialogFlow, DialogFlowRequest } from './flow/flow';
 import { UserAnalyticsPreferences } from './preferences/UserAnalyticsPreferences';
-import { StorySearchQuery } from "../bot/model/story";
-import {RatingReportQueryResult} from "./satisfaction/satisfaction-details/RatingReportQueryResult";
-
+import { StorySearchQuery } from '../bot/model/story';
+import { RatingReportQueryResult } from './satisfaction/satisfaction-details/RatingReportQueryResult';
 
 @Injectable()
 export class AnalyticsService {
@@ -104,8 +103,8 @@ export class AnalyticsService {
     return this.rest.get(`/dialog/${applicationId}/${dialogId}`, DialogReport.fromJSON);
   }
 
-  dialogWithIntentFilter(applicationId: string, dialogId: string, intentsToHide: string[]) : Observable<DialogReport> {
-    return this.rest.post(`/dialog/${applicationId}/${dialogId}/satisfaction`,intentsToHide, DialogReport.fromJSON);
+  dialogWithIntentFilter(applicationId: string, dialogId: string, intentsToHide: string[]): Observable<DialogReport> {
+    return this.rest.post(`/dialog/${applicationId}/${dialogId}/satisfaction`, intentsToHide, DialogReport.fromJSON);
   }
 
   getTestPlansByNamespaceAndNlpModel(): Observable<TestPlan[]> {
@@ -134,30 +133,38 @@ export class AnalyticsService {
   }
 
   isActiveSatisfactionByBot(): Observable<Boolean> {
-    let request = new StorySearchQuery(this.state.currentApplication.namespace, this.state.currentApplication.name, this.state.currentLocale, 0, 1000, "Builtin Satisfaction", "builtin_satisfaction", true);
-    return this.rest.post(
-      '/analytics/satisfaction/active', request, (res: string) => BooleanResponse.fromJSON(res || {}).success);
+    let request = new StorySearchQuery(
+      this.state.currentApplication.namespace,
+      this.state.currentApplication.name,
+      this.state.currentLocale,
+      0,
+      1000,
+      'Builtin Satisfaction',
+      'builtin_satisfaction',
+      true
+    );
+    return this.rest.post('/analytics/satisfaction/active', request, (res: string) => BooleanResponse.fromJSON(res || {}).success);
   }
 
   createSatisfactionModule(): Observable<Boolean> {
     return this.rest.post(
-      '/analytics/satisfaction/init', this.state.createApplicationScopedQuery(), (res: string) => BooleanResponse.fromJSON(res || {}).success);
+      '/analytics/satisfaction/init',
+      this.state.createApplicationScopedQuery(),
+      (res: string) => BooleanResponse.fromJSON(res || {}).success
+    );
   }
 
   getSatisfactionStat(): Observable<RatingReportQueryResult> {
-    return this.rest.post(
-      '/analytics/satisfaction', this.state.createApplicationScopedQuery());
+    return this.rest.post('/analytics/satisfaction', this.state.createApplicationScopedQuery());
   }
 
   downloadDialogsCsv(dialogReportQuery: DialogReportQuery): Observable<Blob> {
-    return this.rest.post('/dialogs/ratings/export',dialogReportQuery, (r) => new Blob([r], { type: 'text/csv;charset=utf-8' }));
+    return this.rest.post('/dialogs/ratings/export', dialogReportQuery, (r) => new Blob([r], { type: 'text/csv;charset=utf-8' }));
   }
 
   downloadDialogsWithIntentsCsv(dialogReportQuery: DialogReportQuery): Observable<Blob> {
-    return this.rest.post('/dialogs/ratings/intents/export',dialogReportQuery, (r) => new Blob([r], { type: 'text/csv;charset=utf-8' }));
+    return this.rest.post('/dialogs/ratings/intents/export', dialogReportQuery, (r) => new Blob([r], { type: 'text/csv;charset=utf-8' }));
   }
-
-
 }
 
 export class BooleanResponse {

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.html
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.html
@@ -1,1 +1,54 @@
-<p>dialog works!</p>
+<div class="d-flex align-items-center">
+  <h1 class="flex-grow-1">Dialog</h1>
+
+  <button
+    nbButton
+    ghost
+    status="primary"
+    nbTooltip="Back to dialog monitoring"
+    (click)="jumpToDialogs(true)"
+  >
+    <nb-icon icon="chevron-left"></nb-icon>
+    BACK
+  </button>
+</div>
+
+<tock-no-data-found
+  *ngIf="accessDenied"
+  title="Access denied or resource deleted"
+  message="Your access rights do not allow you to view this resource, or the resource has been deleted."
+></tock-no-data-found>
+
+<nb-card *ngIf="dialog">
+  <nb-card-body class="px-3 position-relative">
+    <tock-chat-ui>
+      <ng-container *ngFor="let action of dialog.actions">
+        <tock-chat-ui-message
+          [message]="action.message"
+          [date]="action.date"
+          [reply]="action.isBot()"
+          [replay]="true"
+          [sender]="getUserName(action)"
+          [avatar]="getUserAvatar(action)"
+          [applicationId]="action.applicationId"
+        >
+          <div
+            *ngIf="$any(action).metadata.isGenAiRagAnswer"
+            class="mt-3 text-right"
+          >
+            <button
+              nbButton
+              size="tiny"
+              status="warning"
+              type="button"
+              (click)="createFaq(action, dialog.actions)"
+            >
+              <nb-icon icon="chat-left-text"></nb-icon>
+              Create a FAQ with this question/answer pair
+            </button>
+          </div>
+        </tock-chat-ui-message>
+      </ng-container>
+    </tock-chat-ui>
+  </nb-card-body>
+</nb-card>

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.html
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.html
@@ -1,16 +1,29 @@
 <div class="d-flex align-items-center">
   <h1 class="flex-grow-1">Dialog</h1>
 
-  <button
-    nbButton
-    ghost
-    status="primary"
-    nbTooltip="Back to dialog monitoring"
-    (click)="jumpToDialogs(true)"
-  >
-    <nb-icon icon="chevron-left"></nb-icon>
-    BACK
-  </button>
+  <section class="grid-actions">
+    <div nbPopover="Url copied">
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Copy url"
+        (click)="copyUrl()"
+      >
+        <nb-icon icon="share"></nb-icon>
+      </button>
+    </div>
+
+    <button
+      nbButton
+      ghost
+      shape="round"
+      nbTooltip="Go to dialogs monitoring"
+      (click)="jumpToDialogs(true)"
+    >
+      <nb-icon icon="wechat"></nb-icon>
+    </button>
+  </section>
 </div>
 
 <tock-no-data-found
@@ -20,35 +33,14 @@
 ></tock-no-data-found>
 
 <nb-card *ngIf="dialog">
-  <nb-card-body class="px-3 position-relative">
+  <nb-card-body class="pl-3 pr-0">
     <tock-chat-ui>
-      <ng-container *ngFor="let action of dialog.actions">
-        <tock-chat-ui-message
-          [message]="action.message"
-          [date]="action.date"
-          [reply]="action.isBot()"
-          [replay]="true"
-          [sender]="getUserName(action)"
-          [avatar]="getUserAvatar(action)"
-          [applicationId]="action.applicationId"
-        >
-          <div
-            *ngIf="$any(action).metadata.isGenAiRagAnswer"
-            class="mt-3 text-right"
-          >
-            <button
-              nbButton
-              size="tiny"
-              status="warning"
-              type="button"
-              (click)="createFaq(action, dialog.actions)"
-            >
-              <nb-icon icon="chat-left-text"></nb-icon>
-              Create a FAQ with this question/answer pair
-            </button>
-          </div>
-        </tock-chat-ui-message>
-      </ng-container>
+      <tock-chat-ui-dialog-logger
+        [dialog]="dialog"
+        [highlightedAction]="getTargetedAction()"
+      ></tock-chat-ui-dialog-logger>
     </tock-chat-ui>
   </nb-card-body>
 </nb-card>
+
+<tock-scroll-top-button></tock-scroll-top-button>

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.html
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.html
@@ -1,30 +1,32 @@
-<div class="d-flex align-items-center">
-  <h1 class="flex-grow-1">Dialog</h1>
+<tock-sticky-menu [offset]="50">
+  <div class="d-flex align-items-center">
+    <h1 class="flex-grow-1">Dialog</h1>
 
-  <section class="grid-actions">
-    <div nbPopover="Url copied">
+    <section class="grid-actions">
+      <div nbPopover="Url copied">
+        <button
+          nbButton
+          ghost
+          shape="round"
+          nbTooltip="Copy url"
+          (click)="copyUrl()"
+        >
+          <nb-icon icon="share"></nb-icon>
+        </button>
+      </div>
+
       <button
         nbButton
         ghost
         shape="round"
-        nbTooltip="Copy url"
-        (click)="copyUrl()"
+        nbTooltip="Go to dialogs monitoring"
+        (click)="jumpToDialogs(true)"
       >
-        <nb-icon icon="share"></nb-icon>
+        <nb-icon icon="wechat"></nb-icon>
       </button>
-    </div>
-
-    <button
-      nbButton
-      ghost
-      shape="round"
-      nbTooltip="Go to dialogs monitoring"
-      (click)="jumpToDialogs(true)"
-    >
-      <nb-icon icon="wechat"></nb-icon>
-    </button>
-  </section>
-</div>
+    </section>
+  </div>
+</tock-sticky-menu>
 
 <tock-no-data-found
   *ngIf="accessDenied"

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.html
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.html
@@ -1,0 +1,1 @@
+<p>dialog works!</p>

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.scss
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.scss
@@ -1,0 +1,7 @@
+.grid-actions {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: end;
+}

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.spec.ts
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DialogComponent } from './dialog.component';
+
+describe('DialogComponent', () => {
+  let component: DialogComponent;
+  let fixture: ComponentFixture<DialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DialogComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(DialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'tock-dialog',
+  templateUrl: './dialog.component.html',
+  styleUrl: './dialog.component.scss'
+})
+export class DialogComponent {}

--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
@@ -1,8 +1,144 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject, take, takeUntil } from 'rxjs';
+import { AnalyticsService } from '../analytics.service';
+import { StateService } from '../../core-nlp/state.service';
+import { BotConfigurationService } from '../../core/bot-configuration.service';
+import { BotApplicationConfiguration } from '../../core/model/configuration';
+import { ActionReport, Debug, DialogReport, Sentence, SentenceWithFootnotes } from '../../shared/model/dialog-data';
+import { ApplicationService } from '../../core-nlp/applications.service';
+import { AuthService } from '../../core-nlp/auth/auth.service';
+import { SettingsService } from '../../core-nlp/settings.service';
+import { getDialogMessageUserAvatar, getDialogMessageUserQualifier } from '../../shared/utils';
 
 @Component({
   selector: 'tock-dialog',
   templateUrl: './dialog.component.html',
   styleUrl: './dialog.component.scss'
 })
-export class DialogComponent {}
+export class DialogComponent implements OnInit, OnDestroy {
+  destroy = new Subject();
+
+  dialog: DialogReport;
+
+  accessDenied: boolean = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private analytics: AnalyticsService,
+    private state: StateService,
+    private applicationService: ApplicationService,
+    public auth: AuthService,
+    public settings: SettingsService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.initialize();
+  }
+
+  initialize(): void {
+    this.route.params.pipe(take(1)).subscribe((routeParams) => {
+      // User does not have rights to access this namespace
+      if (!this.state.namespaces.find((ns) => ns.namespace === routeParams.namespace)) {
+        this.accessDenied = true;
+
+        return;
+      }
+
+      // The current application does not belong to the requested namespace, so we move to the target namespace.
+      if (routeParams.namespace !== this.state.currentApplication.namespace) {
+        this.applicationService
+          .selectNamespace(routeParams.namespace)
+          .pipe(take(1))
+          .subscribe((_) => {
+            this.auth.loadUser().subscribe((_) => {
+              this.state.currentApplicationEmitter.pipe(take(1)).subscribe((arg) => {
+                this.initialize();
+              });
+              this.applicationService.resetConfiguration();
+            });
+          });
+
+        return;
+      }
+
+      // The current application is not the requested one, we move to the targeted application.
+      if (routeParams.applicationId !== this.state.currentApplication._id) {
+        const targetApp = this.state.applications.find((app) => app._id === routeParams.applicationId);
+        if (targetApp) {
+          this.state.currentApplicationEmitter.pipe(take(1)).subscribe((arg) => {
+            this.initialize();
+          });
+          this.state.changeApplicationWithName(targetApp.name);
+        } else {
+          this.accessDenied = true;
+        }
+
+        return;
+      }
+
+      this.analytics
+        .dialog(this.state.currentApplication._id, routeParams.dialogId)
+        .pipe(take(1))
+        .subscribe((dialog) => {
+          if (dialog?.actions?.length) {
+            this.dialog = dialog;
+          } else {
+            this.accessDenied = true;
+          }
+        });
+
+      // We monitor changes in the current application to redirect to the dialogs page in case of change.
+      this.state.currentApplicationEmitter.pipe(takeUntil(this.destroy)).subscribe((arg) => {
+        if (
+          routeParams.namespace !== this.state.currentApplication.namespace ||
+          routeParams.applicationId !== this.state.currentApplication._id
+        ) {
+          this.jumpToDialogs();
+        }
+      });
+    });
+  }
+
+  getUserName(action: ActionReport): string {
+    return getDialogMessageUserQualifier(action.isBot());
+  }
+
+  getUserAvatar(action: ActionReport): string {
+    return getDialogMessageUserAvatar(action.isBot());
+  }
+
+  createFaq(action: ActionReport, actionsStack: ActionReport[]): void {
+    const actionIndex = actionsStack.findIndex((act) => act === action);
+    if (actionIndex > 0) {
+      const answerSentence = action.message as unknown as SentenceWithFootnotes;
+      const answer = answerSentence.text;
+
+      let question;
+      const questionAction = actionsStack[actionIndex - 1];
+
+      if (questionAction.message.isDebug()) {
+        const actionDebug = questionAction.message as unknown as Debug;
+        question = actionDebug.data.condense_question || actionDebug.data.user_question;
+      } else if (!questionAction.isBot()) {
+        const questionSentence = questionAction.message as unknown as Sentence;
+        question = questionSentence.text;
+      }
+
+      if (question && answer) {
+        this.router.navigate(['faq/management'], { state: { question, answer } });
+      }
+    }
+  }
+
+  jumpToDialogs(addAnchorRef: boolean = false): void {
+    const extras = addAnchorRef && this.dialog?.id ? { state: { dialogId: this.dialog.id } } : undefined;
+    this.router.navigateByUrl('/analytics/dialogs', extras);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next(true);
+    this.destroy.complete();
+  }
+}

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -157,8 +157,18 @@
     (scrolled)="onScroll()"
   >
     <div *ngFor="let dialog of data">
-      <nb-card>
-        <nb-card-body class="px-3">
+      <nb-card id="dialog-wrapper-{{ dialog.id }}">
+        <nb-card-body class="px-3 position-relative">
+          <button
+            nbButton
+            class="dialog-detail-link"
+            size="small"
+            nbTooltip="Display this dialog alone"
+            (click)="jumpToDialog(dialog.id)"
+          >
+            <nb-icon icon="link"></nb-icon>
+          </button>
+
           <tock-chat-ui>
             <ng-container *ngFor="let action of dialog.actions">
               <tock-chat-ui-message

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.html
@@ -158,45 +158,9 @@
   >
     <div *ngFor="let dialog of data">
       <nb-card id="dialog-wrapper-{{ dialog.id }}">
-        <nb-card-body class="px-3 position-relative">
-          <button
-            nbButton
-            class="dialog-detail-link"
-            size="small"
-            nbTooltip="Display this dialog alone"
-            (click)="jumpToDialog(dialog.id)"
-          >
-            <nb-icon icon="link"></nb-icon>
-          </button>
-
+        <nb-card-body class="pl-3 pr-0">
           <tock-chat-ui>
-            <ng-container *ngFor="let action of dialog.actions">
-              <tock-chat-ui-message
-                [message]="action.message"
-                [date]="action.date"
-                [reply]="action.isBot()"
-                [replay]="true"
-                [sender]="getUserName(action)"
-                [avatar]="getUserAvatar(action)"
-                [applicationId]="action.applicationId"
-              >
-                <div
-                  *ngIf="$any(action).metadata.isGenAiRagAnswer"
-                  class="mt-3 text-right"
-                >
-                  <button
-                    nbButton
-                    size="tiny"
-                    status="warning"
-                    type="button"
-                    (click)="createFaq(action, dialog.actions)"
-                  >
-                    <nb-icon icon="chat-left-text"></nb-icon>
-                    Create a FAQ with this question/answer pair
-                  </button>
-                </div>
-              </tock-chat-ui-message>
-            </ng-container>
+            <tock-chat-ui-dialog-logger [dialog]="dialog"></tock-chat-ui-dialog-logger>
           </tock-chat-ui>
         </nb-card-body>
       </nb-card>

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
@@ -16,3 +16,9 @@
 .loader {
   min-height: 20vh;
 }
+
+.dialog-detail-link {
+  position: absolute;
+  right: 0.5em;
+  top: 0.5em;
+}

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.scss
@@ -16,9 +16,3 @@
 .loader {
   min-height: 20vh;
 }
-
-.dialog-detail-link {
-  position: absolute;
-  right: 0.5em;
-  top: 0.5em;
-}

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { ActionReport, Debug, DialogReport, SentenceWithFootnotes } from '../../../shared/model/dialog-data';
+import { DialogReport } from '../../../shared/model/dialog-data';
 import { ConnectorType } from '../../../core/model/configuration';
 import { StateService } from '../../../core-nlp/state.service';
 import { DialogReportQuery } from '../dialogs';
@@ -9,9 +9,9 @@ import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { BotSharedService } from '../../../shared/bot-shared.service';
 import { PaginatedQuery, SearchMark } from '../../../model/commons';
 import { BehaviorSubject, Observable, Subject, filter, mergeMap, take, takeUntil } from 'rxjs';
-import { PaginatedResult, Sentence } from '../../../model/nlp';
+import { PaginatedResult } from '../../../model/nlp';
 import { saveAs } from 'file-saver-es';
-import { getDialogMessageUserAvatar, getDialogMessageUserQualifier, getExportFileName } from '../../../shared/utils';
+import { getExportFileName } from '../../../shared/utils';
 import { Location } from '@angular/common';
 
 export class DialogFilter {
@@ -71,7 +71,6 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
     private botConfiguration: BotConfigurationService,
     private route: ActivatedRoute,
     public botSharedService: BotSharedService,
-    private router: Router,
     private location: Location
   ) {
     this.dialogAnchorRef = (this.location.getState() as any)?.dialogId;
@@ -184,7 +183,7 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
         if (target) {
           target.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
-      }, 100);
+      }, 300);
     }
 
     return true;
@@ -235,43 +234,6 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
     this.analytics.downloadDialogsWithIntentsCsv(this.dialogReportQuery).subscribe((blob) => {
       saveAs(blob, exportFileName2);
     });
-  }
-
-  getUserName(action: ActionReport): string {
-    return getDialogMessageUserQualifier(action.isBot());
-  }
-
-  getUserAvatar(action: ActionReport): string {
-    return getDialogMessageUserAvatar(action.isBot());
-  }
-
-  createFaq(action: ActionReport, actionsStack: ActionReport[]) {
-    const actionIndex = actionsStack.findIndex((act) => act === action);
-    if (actionIndex > 0) {
-      const answerSentence = action.message as unknown as SentenceWithFootnotes;
-      const answer = answerSentence.text;
-
-      let question;
-      const questionAction = actionsStack[actionIndex - 1];
-
-      if (questionAction.message.isDebug()) {
-        const actionDebug = questionAction.message as unknown as Debug;
-        question = actionDebug.data.condense_question || actionDebug.data.user_question;
-      } else if (!questionAction.isBot()) {
-        const questionSentence = questionAction.message as unknown as Sentence;
-        question = questionSentence.text;
-      }
-
-      if (question && answer) {
-        this.router.navigate(['faq/management'], { state: { question, answer } });
-      }
-    }
-  }
-
-  jumpToDialog(dialogId: string) {
-    this.router.navigateByUrl(
-      `analytics/dialog/${this.state.currentApplication.namespace}/${this.state.currentApplication._id}/${dialogId}`
-    );
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs-list/dialogs-list.component.ts
@@ -12,6 +12,7 @@ import { BehaviorSubject, Observable, Subject, filter, mergeMap, take, takeUntil
 import { PaginatedResult, Sentence } from '../../../model/nlp';
 import { saveAs } from 'file-saver-es';
 import { getDialogMessageUserAvatar, getDialogMessageUserQualifier, getExportFileName } from '../../../shared/utils';
+import { Location } from '@angular/common';
 
 export class DialogFilter {
   constructor(
@@ -62,14 +63,19 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
 
   dialogReportQuery: DialogReportQuery;
 
+  dialogAnchorRef: string;
+
   constructor(
     public state: StateService,
     private analytics: AnalyticsService,
     private botConfiguration: BotConfigurationService,
     private route: ActivatedRoute,
     public botSharedService: BotSharedService,
-    private router: Router
-  ) {}
+    private router: Router,
+    private location: Location
+  ) {
+    this.dialogAnchorRef = (this.location.getState() as any)?.dialogId;
+  }
 
   ngOnInit() {
     this.botSharedService
@@ -171,6 +177,16 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
     this.totalDialogsCount.next(this.formattedTotal());
     this.loading = false;
 
+    if (this.dialogAnchorRef) {
+      setTimeout(() => {
+        const target = document.querySelector(`#dialog-wrapper-${this.dialogAnchorRef}`);
+        this.dialogAnchorRef = undefined;
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 100);
+    }
+
     return true;
   }
 
@@ -250,6 +266,12 @@ export class DialogsListComponent implements OnInit, OnChanges, OnDestroy {
         this.router.navigate(['faq/management'], { state: { question, answer } });
       }
     }
+  }
+
+  jumpToDialog(dialogId: string) {
+    this.router.navigateByUrl(
+      `analytics/dialog/${this.state.currentApplication.namespace}/${this.state.currentApplication._id}/${dialogId}`
+    );
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/analytics/dialogs/dialogs.component.html
+++ b/bot/admin/web/src/app/analytics/dialogs/dialogs.component.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<div class="d-flex flex-wrap align-items-center mt-3">
+<div class="d-flex flex-wrap align-items-center">
   <h1 class="flex-grow-1">
     Dialogs
     <span

--- a/bot/admin/web/src/app/analytics/users/users.component.html
+++ b/bot/admin/web/src/app/analytics/users/users.component.html
@@ -167,20 +167,10 @@
       <nb-card-header class="position-relative p-0">
         <tock-chat-ui
           *ngIf="selectedUser && selectedUser.displayDialogs && selectedUser.userDialog"
+          padding="1em 0em 1em 1em"
           height="calc(100vh - 350px)"
-          padding="1em 0.5em 1em 1em"
         >
-          <tock-chat-ui-message
-            *ngFor="let action of selectedUser.userDialog.actions"
-            [message]="action.message"
-            [date]="action.date"
-            [reply]="action.isBot()"
-            [replay]="true"
-            [sender]="getUserName(action)"
-            [avatar]="getUserAvatar(action)"
-            [applicationId]="action.applicationId"
-          >
-          </tock-chat-ui-message>
+          <tock-chat-ui-dialog-logger [dialog]="selectedUser.userDialog"></tock-chat-ui-dialog-logger>
         </tock-chat-ui>
 
         <div class="shader"></div>

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
@@ -13,8 +13,6 @@ import { FaqDefinition, FaqFilter, FaqSearchQuery, PaginatedFaqResult } from '..
 import { FaqManagementEditComponent } from './faq-management-edit/faq-management-edit.component';
 import { FaqManagementSettingsComponent } from './faq-management-settings/faq-management-settings.component';
 import { Pagination } from '../../shared/components';
-import { getExportFileName } from '../../shared/utils';
-import { saveAs } from 'file-saver-es';
 import { I18nLabel } from '../../bot/model/i18n';
 
 export type FaqDefinitionExtended = Partial<FaqDefinition> & { _initQuestion?: string; _initAnswer?: string };

--- a/bot/admin/web/src/app/shared/bot-shared.module.ts
+++ b/bot/admin/web/src/app/shared/bot-shared.module.ts
@@ -36,7 +36,8 @@ import {
   NbWindowModule,
   NbListModule,
   NbToggleModule,
-  NbDatepickerModule
+  NbDatepickerModule,
+  NbTagModule
 } from '@nebular/theme';
 
 import {
@@ -81,7 +82,9 @@ import {
   DataExportComponent,
   WysiwygEditorComponent,
   TestDialogComponent,
-  BotConfigurationSelectorComponent
+  BotConfigurationSelectorComponent,
+  ReportComponent,
+  ChatUiDialogLoggerComponent
 } from './components';
 
 import { AutofocusDirective, TextareaAutocompleteDirective } from './directives';
@@ -116,7 +119,8 @@ import { ScrollComponent } from '../scroll/scroll.component';
     NgxSliderModule,
     NbWindowModule,
     NbListModule,
-    NbToggleModule
+    NbToggleModule,
+    NbTagModule
   ],
   declarations: [
     SelectBotComponent,
@@ -135,6 +139,7 @@ import { ScrollComponent } from '../scroll/scroll.component';
     ChatUiMessageLocationComponent,
     ChatUiMessageDebugComponent,
     ChatUiMessageSentenceFootnotesComponent,
+    ChatUiDialogLoggerComponent,
     ChoiceDialogComponent,
     FileUploadComponent,
     SliderComponent,
@@ -163,7 +168,8 @@ import { ScrollComponent } from '../scroll/scroll.component';
     WysiwygEditorComponent,
     TestDialogComponent,
     BotConfigurationSelectorComponent,
-    TextareaAutocompleteDirective
+    TextareaAutocompleteDirective,
+    ReportComponent
   ],
   exports: [
     SelectBotComponent,
@@ -175,6 +181,7 @@ import { ScrollComponent } from '../scroll/scroll.component';
     FormControlComponent,
     ChatUiComponent,
     ChatUiMessageComponent,
+    ChatUiDialogLoggerComponent,
     ChoiceDialogComponent,
     FileUploadComponent,
     SliderComponent,

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.html
@@ -1,0 +1,122 @@
+<ng-container *ngFor="let action of dialog.actions; let first = first">
+  <div
+    *ngIf="$any(action).message.text || $any(action).message.messages?.length"
+    class="dialogs-messages-grid"
+    [class.mt-3]="!first && !action.isBot()"
+  >
+    <div class="flex-grow-1">
+      <tock-chat-ui-message
+        [message]="action.message"
+        [date]="action.date"
+        [reply]="action.isBot()"
+        [replay]="true"
+        [sender]="getUserName(action)"
+        [avatar]="getUserAvatar(action)"
+        [applicationId]="action.applicationId"
+        id="action-anchor-{{ action.id }}"
+        (click)="
+          (userMessageIsClickable && !action.isBot()) || (botMessageIsClickable && action.isBot()) ? messageClicked(action) : undefined
+        "
+        [class.pointer]="(userMessageIsClickable && !action.isBot()) || (botMessageIsClickable && action.isBot())"
+        [class.highlightedAction]="highlightedAction === action"
+      ></tock-chat-ui-message>
+    </div>
+
+    <div
+      class="dialog-vertical-separator"
+      [class.horizontal-separation-start]="!action.isBot()"
+      [class.horizontal-separation-end]="
+        action.isBot() && !action.message.isDebug() && ($any(action).message.text || $any(action).message.messages?.length)
+      "
+    ></div>
+
+    <div>
+      <div
+        class="pl-1"
+        *ngIf="!action.isBot()"
+      >
+        <!-- <button
+          *ngIf="first"
+          nbButton
+          ghost
+          size="small"
+          nbTooltip="Replay the whole dialog"
+        >
+          <nb-icon icon="terminal-fill"></nb-icon>
+        </button>
+
+        <div
+          *ngIf="!first"
+          class="button-vertical-spacer mt-1"
+        ></div> -->
+
+        <div class="button-vertical-spacer mb-1"></div>
+
+        <button
+          nbButton
+          ghost
+          size="small"
+          nbTooltip="Replay this sentence"
+          (click)="testDialogSentence(action)"
+        >
+          <nb-icon icon="terminal-plus"></nb-icon>
+        </button>
+      </div>
+
+      <div
+        class="pl-1"
+        *ngIf="action.isBot() && !action.message.isDebug() && ($any(action).message.text || $any(action).message.messages?.length)"
+      >
+        <div class="button-horizontal-separator mb-1"></div>
+
+        <!-- <div *ngIf="containsReport(action); else does_not_contain_a_report">
+          <button
+            nbButton
+            size="small"
+            status="warning"
+            ghost
+            nbTooltip="Display report"
+            (click)="openReport(action)"
+          >
+            <nb-icon icon="exclamation-triangle-fill"></nb-icon>
+          </button>
+        </div>
+
+        <ng-template #does_not_contain_a_report>
+          <button
+            nbButton
+            size="small"
+            status="warning"
+            ghost
+            nbTooltip="Add a report"
+            (click)="openReport(action)"
+          >
+            <nb-icon icon="exclamation-triangle"></nb-icon>
+          </button>
+        </ng-template> -->
+
+        <button
+          *ngIf="$any(action).metadata.isGenAiRagAnswer"
+          nbButton
+          size="small"
+          status="primary"
+          ghost
+          nbTooltip="Create a FAQ with this question/answer pair"
+          (click)="createFaq(action, dialog.actions)"
+        >
+          <nb-icon icon="chat-left-text"></nb-icon>
+        </button>
+
+        <button
+          nbButton
+          ghost
+          size="small"
+          nbTooltip="Display this dialog alone"
+          (click)="jumpToDialog(dialog.id, action.id)"
+        >
+          <nb-icon icon="link"></nb-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+</ng-container>

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.scss
@@ -1,0 +1,28 @@
+.dialogs-messages-grid {
+  display: grid;
+  grid-template-columns: auto 1rem 2.5rem;
+  // grid-gap: 0.5rem;
+
+  .dialog-vertical-separator {
+    border-right: 1px dashed var(--border-basic-color-5);
+
+    &.horizontal-separation-start {
+      border-top: 1px dashed var(--border-basic-color-5);
+    }
+
+    &.horizontal-separation-end {
+      border-bottom: 1px dashed var(--border-basic-color-5);
+    }
+  }
+}
+
+.button-vertical-spacer {
+  height: 2rem;
+}
+
+.button-horizontal-separator {
+  border-top: 1px dashed var(--border-basic-color-5);
+  height: 1px;
+  // margin-left: -0.5em;
+  margin-right: 0.5em;
+}

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.spec.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChatUiDialogLoggerComponent } from './chat-ui-dialog-logger.component';
+
+describe('ChatUiDialogLoggerComponent', () => {
+  let component: ChatUiDialogLoggerComponent;
+  let fixture: ComponentFixture<ChatUiDialogLoggerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChatUiDialogLoggerComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ChatUiDialogLoggerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.ts
@@ -1,0 +1,105 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { ActionReport, Debug, DialogReport, Sentence, SentenceWithFootnotes } from '../../../model/dialog-data';
+import { getDialogMessageUserAvatar, getDialogMessageUserQualifier } from '../../../utils';
+import { NbDialogService } from '@nebular/theme';
+import { TestDialogService } from '../../test-dialog/test-dialog.service';
+import { ReportComponent } from '../../report/report.component';
+import { Router } from '@angular/router';
+import { StateService } from '../../../../core-nlp/state.service';
+import { Subject } from 'rxjs';
+
+@Component({
+  selector: 'tock-chat-ui-dialog-logger',
+
+  templateUrl: './chat-ui-dialog-logger.component.html',
+  styleUrl: './chat-ui-dialog-logger.component.scss'
+})
+export class ChatUiDialogLoggerComponent implements OnDestroy {
+  private readonly destroy$: Subject<boolean> = new Subject();
+
+  @Input() dialog: DialogReport;
+
+  @Input() userMessageIsClickable?: boolean;
+  @Input() botMessageIsClickable?: boolean;
+
+  @Output() onMessageClicked = new EventEmitter();
+
+  @Input() highlightedAction?: ActionReport;
+
+  constructor(
+    private testDialogService: TestDialogService,
+    private nbDialogService: NbDialogService,
+    private router: Router,
+    public state: StateService
+  ) {}
+
+  getUserName(action: ActionReport): string {
+    return getDialogMessageUserQualifier(action.isBot());
+  }
+
+  getUserAvatar(action: ActionReport): string {
+    return getDialogMessageUserAvatar(action.isBot());
+  }
+
+  jumpToDialog(dialogId: string, actionId: string) {
+    this.router.navigate(
+      [`analytics/dialogs/${this.state.currentApplication.namespace}/${this.state.currentApplication._id}/${dialogId}`],
+      {
+        fragment: actionId
+      }
+    );
+  }
+
+  createFaq(action: ActionReport, actionsStack: ActionReport[]) {
+    const actionIndex = actionsStack.findIndex((act) => act === action);
+    if (actionIndex > 0) {
+      const answerSentence = action.message as unknown as SentenceWithFootnotes;
+      const answer = answerSentence.text;
+
+      let question;
+      const questionAction = actionsStack[actionIndex - 1];
+
+      if (questionAction.message.isDebug()) {
+        const actionDebug = questionAction.message as unknown as Debug;
+        question = actionDebug.data.condense_question || actionDebug.data.user_question;
+      } else if (!questionAction.isBot()) {
+        const questionSentence = questionAction.message as unknown as Sentence;
+        question = questionSentence.text;
+      }
+
+      if (question && answer) {
+        this.router.navigate(['faq/management'], { state: { question, answer } });
+      }
+    }
+  }
+
+  testDialogSentence(action: ActionReport) {
+    // TO DO : pass locale when it will be present in the message
+    this.testDialogService.testSentenceDialog({
+      sentenceText: (action.message as unknown as Sentence).text,
+      applicationId: action.applicationId
+      // sentenceLocale: locale
+    });
+  }
+
+  // containsReport(action: ActionReport): boolean {
+  //   return (parseInt(action.id) % 10) % 2 === 0;
+  // }
+
+  // openReport(action: ActionReport) {
+  //   this.nbDialogService.open(ReportComponent, {
+  //     context: {
+  //       actionReport: action
+  //     }
+  //   });
+  // }
+
+  messageClicked(action: ActionReport): void {
+    this.onMessageClicked.emit(action);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-sentence-element/chat-ui-message-sentence-element.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-sentence-element/chat-ui-message-sentence-element.component.html
@@ -46,6 +46,7 @@
       <span
         *ngIf="reply"
         [innerHTML]="linkifyHtml(entry.value)"
+        class="chat-ui-message-content-styling"
       ></span>
       <span *ngIf="!reply">{{ entry.value }}</span>
       <span class="text-category">({{ entry.key }})</span>

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-sentence-footnotes/chat-ui-message-sentence-footnotes.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message-sentence-footnotes/chat-ui-message-sentence-footnotes.component.html
@@ -7,6 +7,7 @@
 <span
   *ngIf="reply"
   [innerHTML]="linkifyHtml(sentence.text)"
+  class="chat-ui-message-content-styling"
 ></span>
 <span *ngIf="!reply">{{ sentence.text }}</span>
 

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
@@ -19,22 +19,10 @@
 
         <span
           *ngIf="applicationId"
-          nbTooltip="Configuration"
+          nbTooltip="Configuration : {{ getApplicationConfigurationName(applicationId, false) }}"
         >
-          [{{ getApplicationConfigurationName(applicationId) }}]</span
+          | {{ getApplicationConfigurationName(applicationId) }}</span
         >
-
-        <button
-          *ngIf="!reply"
-          nbButton
-          ghost
-          size="tiny"
-          class="ml-2"
-          nbTooltip="Test this sentence in a dialog"
-          (click)="testDialogSentence(message, applicationId, $event)"
-        >
-          <nb-icon icon="terminal-plus"></nb-icon>
-        </button>
       </p>
 
       <div class="text">

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
@@ -2,6 +2,7 @@
 @import '@nebular/theme/styles/themes';
 
 :host {
+  display: block;
   margin-bottom: 0.5rem;
 
   .wrapper {
@@ -47,11 +48,6 @@
     }
   }
 
-  &.currentsentence .text {
-    background-color: nb-theme(color-success-500) !important;
-    color: white !important;
-  }
-
   &.not-reply {
     .wrapper {
       .message {
@@ -65,6 +61,11 @@
         background: nb-theme(chat-message-background);
         color: nb-theme(chat-message-text-color);
       }
+    }
+
+    &.highlightedAction .text {
+      background-color: nb-theme(color-success-500) !important;
+      color: white !important;
     }
   }
 
@@ -88,11 +89,16 @@
 
         .text {
           border-top-right-radius: 0;
-          // background: nb-theme(chat-message-reply-background-color);
           background-color: var(--background-basic-color-3);
           color: nb-theme(chat-message-reply-text-color);
         }
       }
+    }
+
+    &.highlightedAction .text {
+      border-width: 0.2em;
+      border-style: solid;
+      border-color: nb-theme(color-primary-400) !important;
     }
   }
 }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 import { BotMessage } from '../../../model/dialog-data';
-import { TestDialogService } from '../../test-dialog/test-dialog.service';
 import { BotApplicationConfiguration } from '../../../../core/model/configuration';
 import { BotConfigurationService } from '../../../../core/bot-configuration.service';
 import { take } from 'rxjs';
@@ -49,11 +48,7 @@ export class ChatUiMessageComponent {
 
   @Output() sendMessage: EventEmitter<BotMessage> = new EventEmitter();
 
-  constructor(
-    protected domSanitizer: DomSanitizer,
-    private testDialogService: TestDialogService,
-    private botConfiguration: BotConfigurationService
-  ) {}
+  constructor(protected domSanitizer: DomSanitizer, private botConfiguration: BotConfigurationService) {}
 
   ngOnInit() {
     this.botConfiguration.configurations.pipe(take(1)).subscribe((conf) => {
@@ -61,22 +56,21 @@ export class ChatUiMessageComponent {
     });
   }
 
-  getApplicationConfigurationName(applicationId: string) {
+  getApplicationConfigurationName(applicationId: string, short: boolean = true) {
     if (!this.allConfigurations) return;
     const configuration = this.allConfigurations.find((conf) => conf.applicationId === applicationId);
-    return `${configuration.name} : ${configuration.connectorType.label()} (${configuration.applicationId})`;
+    if (configuration) {
+      if (short) {
+        return `${configuration.applicationId}`;
+      } else {
+        return `${configuration.name} > ${configuration.connectorType.label()} (${configuration.applicationId})`;
+      }
+    }
+
+    return '';
   }
 
   replyMessage(message: BotMessage) {
     this.sendMessage.emit(message);
-  }
-
-  testDialogSentence(message, applicationId, event) {
-    event?.stopPropagation();
-
-    this.testDialogService.testSentenceDialog({
-      sentenceText: message.text,
-      applicationId
-    });
   }
 }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
@@ -1,7 +1,7 @@
 <div
   #scrollable
   class="scrollable"
-  [class.mayScroll]="height || maxHeight"
+  [class.mayScroll]="mayScroll"
   [style.height]="height"
   [style.max-height]="maxHeight"
   [style.padding]="padding"

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
@@ -7,7 +7,7 @@
   line-height: 1.25rem;
 
   .scrollable {
-    min-height: 12rem;
+    min-height: 6rem;
 
     overflow: auto;
     flex: 1;
@@ -40,7 +40,7 @@
 
 // ScrollBars
 :host .scrollable::-webkit-scrollbar {
-  width: 0.625rem;
+  width: 0.425rem;
   height: 0.3125rem;
 }
 

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.ts
@@ -9,6 +9,7 @@ export class ChatUiComponent {
   @Input() height?: string;
   @Input() maxHeight?: string;
   @Input() padding?: string;
+  @Input() mayScroll?: boolean;
 
   @ViewChild('scrollable') private scrollable: ElementRef;
 

--- a/bot/admin/web/src/app/shared/components/form-control/form-control.component.html
+++ b/bot/admin/web/src/app/shared/components/form-control/form-control.component.html
@@ -6,11 +6,13 @@
   <div class="d-flex align-items-center justify-content-between">
     <label
       *ngIf="label"
+      class="mb-0"
       [ngClass]="{
         'font-weight-bold': boldLabel,
         'text-mitigated': true,
         required: required,
-        hasError: showError && (!controls || !!controls.invalid)
+        hasError: showError && (!controls || !!controls.invalid),
+        'mb-0': noLabelMargin
       }"
       [for]="name"
       data-testid="label"

--- a/bot/admin/web/src/app/shared/components/form-control/form-control.component.ts
+++ b/bot/admin/web/src/app/shared/components/form-control/form-control.component.ts
@@ -14,5 +14,6 @@ export class FormControlComponent {
   @Input() showError: boolean = false;
   @Input() required: boolean = false;
   @Input() hasMargin: boolean = true;
+  @Input() noLabelMargin: boolean = false;
   @Input() information?: string;
 }

--- a/bot/admin/web/src/app/shared/components/index.ts
+++ b/bot/admin/web/src/app/shared/components/index.ts
@@ -40,3 +40,5 @@ export * from './data-export/data-export.component';
 export * from './wysiwyg-editor/wysiwyg-editor.component';
 export * from './test-dialog/test-dialog.component';
 export * from './bot-configuration-selector/bot-configuration-selector.component';
+export * from './report/report.component';
+export * from './chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component';

--- a/bot/admin/web/src/app/shared/components/report/report.component.html
+++ b/bot/admin/web/src/app/shared/components/report/report.component.html
@@ -1,0 +1,136 @@
+<nb-card class="min-width-90vw">
+  <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+    <div>Report</div>
+    <button
+      nbButton
+      ghost
+      shape="round"
+      nbTooltip="Close"
+      (click)="cancel()"
+    >
+      <nb-icon icon="x-lg"></nb-icon>
+    </button>
+  </nb-card-header>
+
+  <nb-card-body [nbSpinner]="loading">
+    <tock-form-control
+      label="State"
+      name="state"
+      [required]="true"
+      [noLabelMargin]="true"
+    >
+      <nb-radio-group
+        value="2"
+        class="d-flex"
+      >
+        <nb-radio value="1">Ok</nb-radio>
+        <nb-radio value="2">Not Ok</nb-radio>
+      </nb-radio-group>
+    </tock-form-control>
+
+    <tock-form-control
+      label="Reason"
+      name="reason"
+      [required]="true"
+    >
+      <nb-select
+        placeholder="Select the reason for the report"
+        fullWidth
+        selected="1"
+      >
+        <nb-option value="1">Inaccurate answer</nb-option>
+        <nb-option value="2">Incomplete answer</nb-option>
+        <nb-option value="3">Hallucination</nb-option>
+        <nb-option value="4">Incomplete sources / documents</nb-option>
+        <nb-option value="5">Obsolete sources / documents</nb-option>
+        <nb-option value="6">Wrong answer format</nb-option>
+        <nb-option value="7">Business lexicon problem</nb-option>
+        <nb-option value="8">Question not/misunderstood</nb-option>
+        <nb-option value="9">Other</nb-option>
+      </nb-select>
+    </tock-form-control>
+
+    <tock-form-control
+      label="Tag"
+      name="tag"
+    >
+      <nb-tag-list>
+        <nb-tag
+          text="Brochure 2023 au lieu de 2024"
+          removable
+          status="primary"
+          class="size-small"
+        ></nb-tag>
+        <input
+          type="text"
+          nbTagInput
+          fullWidth
+          fieldSize="small"
+        />
+      </nb-tag-list>
+    </tock-form-control>
+
+    <tock-form-control
+      label="Comments"
+      name="comments"
+    >
+      <div class="comments-list font-size-small">
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>admin&#64;app.com</strong> added a comment - October 23, 2024 17:00</div>
+
+          <div class="">I can confirm that. Action must be taken on the documentary corpus</div>
+        </div>
+
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>JohnDoe&#64;app.com</strong> added a comment - October 23, 2024 17:23</div>
+
+          <div class="">Looks like the infomration is missing in the source documents</div>
+        </div>
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>admin&#64;app.com</strong> added a comment - October 23, 2024 17:00</div>
+
+          <div class="">I can confirm that. Action must be taken on the documentary corpus</div>
+        </div>
+
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>JohnDoe&#64;app.com</strong> added a comment - October 23, 2024 17:23</div>
+
+          <div class="">Looks like the infomration is missing in the source documents</div>
+        </div>
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>admin&#64;app.com</strong> added a comment - October 23, 2024 17:00</div>
+
+          <div class="">I can confirm that. Action must be taken on the documentary corpus</div>
+        </div>
+
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>JohnDoe&#64;app.com</strong> added a comment - October 23, 2024 17:23</div>
+
+          <div class="">Looks like the infomration is missing in the source documents</div>
+        </div>
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>admin&#64;app.com</strong> added a comment - October 23, 2024 17:00</div>
+
+          <div class="">I can confirm that. Action must be taken on the documentary corpus</div>
+        </div>
+
+        <div class="px-2 py-2 border-bottom">
+          <div class="text-muted"><strong>JohnDoe&#64;app.com</strong> added a comment - October 23, 2024 17:23</div>
+
+          <div class="">Looks like the infomration is missing in the source documents</div>
+        </div>
+      </div>
+    </tock-form-control>
+
+    <tock-form-control
+      label="Add a comment"
+      name="addcomment"
+    >
+      <textarea
+        nbInput
+        fullWidth
+        fieldSize="small"
+      ></textarea>
+    </tock-form-control>
+  </nb-card-body>
+</nb-card>

--- a/bot/admin/web/src/app/shared/components/report/report.component.spec.ts
+++ b/bot/admin/web/src/app/shared/components/report/report.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReportComponent } from './report.component';
+
+describe('ReportComponent', () => {
+  let component: ReportComponent;
+  let fixture: ComponentFixture<ReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReportComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(ReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/shared/components/report/report.component.ts
+++ b/bot/admin/web/src/app/shared/components/report/report.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ActionReport } from '../../model/dialog-data';
+import { NbDialogRef } from '@nebular/theme';
+
+@Component({
+  selector: 'tock-report',
+  templateUrl: './report.component.html',
+  styleUrl: './report.component.scss'
+})
+export class ReportComponent implements OnInit {
+  loading: boolean = true;
+
+  @Input() actionReport: ActionReport;
+
+  constructor(private dialogRef: NbDialogRef<ReportComponent>) {}
+
+  ngOnInit(): void {
+    this.loading = false;
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.html
@@ -52,35 +52,14 @@
     <tock-chat-ui
       *ngIf="displayedDialog?.actions"
       height="calc(100vh - 320px)"
-      padding="1em 0.5em 1em 1em"
+      padding="1em 0em 1em 1em"
     >
-      <tock-chat-ui-message
-        *ngFor="let action of displayedDialog.actions"
-        [message]="action.message"
-        [replay]="true"
-        [reply]="action.isBot()"
-        [sender]="getUserName(action)"
-        [avatar]="getUserAvatar(action)"
-        [date]="action.date"
-        [ngClass]="{ currentsentence: isCurrentSentence(action), pointer: !action.isBot() }"
-        (click)="searchSentence(action)"
-      >
-        <div
-          *ngIf="$any(action).metadata.isGenAiRagAnswer"
-          class="mt-3 text-right"
-        >
-          <button
-            nbButton
-            size="tiny"
-            status="warning"
-            type="button"
-            (click)="createFaq(action, displayedDialog.actions)"
-          >
-            <nb-icon icon="chat-left-text"></nb-icon>
-            Create a FAQ with this question/answer pair
-          </button>
-        </div>
-      </tock-chat-ui-message>
+      <tock-chat-ui-dialog-logger
+        [dialog]="displayedDialog"
+        [userMessageIsClickable]="true"
+        (onMessageClicked)="searchSentence($event)"
+        [highlightedAction]="getCurrentSentenceAction()"
+      ></tock-chat-ui-dialog-logger>
     </tock-chat-ui>
   </nb-card-body>
 </nb-card>

--- a/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentence-training/sentence-training-dialog/sentence-training-dialog.component.ts
@@ -72,7 +72,7 @@ export class SentenceTrainingDialogComponent implements OnChanges, OnDestroy {
   scrollToCurrent(): void {
     window.setTimeout(() => {
       const nativeElement: HTMLElement = this.elementRef.nativeElement;
-      const found: Element | null = nativeElement.querySelector('.currentsentence');
+      const found: Element | null = nativeElement.querySelector('.highlightedAction');
       if (found) {
         found.scrollIntoView({
           behavior: 'smooth',
@@ -99,41 +99,16 @@ export class SentenceTrainingDialogComponent implements OnChanges, OnDestroy {
     return false;
   }
 
-  getUserName(action: ActionReport): string {
-    return getDialogMessageUserQualifier(action.isBot());
-  }
-
-  getUserAvatar(action: ActionReport): string {
-    return getDialogMessageUserAvatar(action.isBot());
+  getCurrentSentenceAction(): ActionReport {
+    return this.displayedDialog?.actions.find((action) => {
+      return this.isCurrentSentence(action);
+    });
   }
 
   searchSentence(action: ActionReport): void {
     if (action.isBot()) return;
     if (action.message.isSentence()) {
       this.onSearchSentence.emit(action.message);
-    }
-  }
-
-  createFaq(action: ActionReport, actionsStack: ActionReport[]) {
-    const actionIndex = actionsStack.findIndex((act) => act === action);
-    if (actionIndex > 0) {
-      const answerSentence = action.message as unknown as SentenceWithFootnotes;
-      const answer = answerSentence.text;
-
-      let question;
-      const questionAction = actionsStack[actionIndex - 1];
-
-      if (questionAction.message.isDebug()) {
-        const actionDebug = questionAction.message as unknown as Debug;
-        question = actionDebug.data.condense_question || actionDebug.data.user_question;
-      } else if (!questionAction.isBot()) {
-        const questionSentence = questionAction.message as unknown as Sentence;
-        question = questionSentence.text;
-      }
-
-      if (question && answer) {
-        this.router.navigate(['faq/management'], { state: { question, answer } });
-      }
     }
   }
 

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -75,6 +75,7 @@
       <tock-chat-ui
         maxHeight="calc(100vh - 450px)"
         padding="0.2em 0 0 0"
+        [mayScroll]="true"
         #chatUi
       >
         <tock-chat-ui-message

--- a/bot/admin/web/src/app/shared/model/dialog-data.ts
+++ b/bot/admin/web/src/app/shared/model/dialog-data.ts
@@ -50,7 +50,7 @@ export class ActionReport {
     public playerId: PlayerId,
     public date: Date,
     public message: BotMessage,
-    public id: String,
+    public id: string,
     public test: boolean,
     public connectorType?: ConnectorType,
     public applicationId?: string

--- a/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
+++ b/bot/admin/web/src/app/test/dialog/bot-dialog.component.html
@@ -62,6 +62,7 @@
   <nb-card-body [nbSpinner]="loading">
     <tock-chat-ui
       height="calc(100vh - 450px)"
+      [mayScroll]="true"
       #chatUi
     >
       <tock-chat-ui-message

--- a/bot/admin/web/src/app/test/model/test.ts
+++ b/bot/admin/web/src/app/test/model/test.ts
@@ -202,7 +202,7 @@ export class TestActionReport {
     public playerId: PlayerId,
     public date: Date,
     public messages: BotMessage[],
-    public id: String,
+    public id: string,
     public userInterfaceType: UserInterfaceType,
     public connectorType?: ConnectorType
   ) {}

--- a/bot/admin/web/src/app/test/plan/test-plan.component.ts
+++ b/bot/admin/web/src/app/test/plan/test-plan.component.ts
@@ -25,6 +25,7 @@ import { NbToastrService } from '@nebular/theme';
 import { APP_BASE_HREF } from '@angular/common';
 import { getDialogMessageUserAvatar, getDialogMessageUserQualifier } from '../../shared/utils';
 import { SelectBotEvent } from '../../shared/components';
+import { take } from 'rxjs';
 
 @Component({
   selector: 'tock-bot-test-plan',
@@ -203,12 +204,15 @@ export class TestPlanComponent implements OnInit {
   }
 
   showExecutions(plan: TestPlan) {
-    this.test.getTestPlanExecutions(plan._id).subscribe((e) => {
-      plan.testPlanExecutions = e;
-      //fill errors
-      e.forEach((e) => e.dialogs.forEach((d) => plan.fillDialogExecutionReport(d)));
-      plan.displayExecutions = true;
-    });
+    this.test
+      .getTestPlanExecutions(plan._id)
+      .pipe(take(1))
+      .subscribe((e) => {
+        plan.testPlanExecutions = e;
+        //fill errors
+        e.forEach((e) => e.dialogs.forEach((d) => plan.fillDialogExecutionReport(d)));
+        plan.displayExecutions = true;
+      });
   }
 
   /**
@@ -219,7 +223,10 @@ export class TestPlanComponent implements OnInit {
    * @param testExecutionId - Identifier of the test plan execution
    */
   getExecutionStatus(testPlanId: string, testExecutionId: string) {
-    this.test.getTestPlanExecutionStatus(testPlanId, testExecutionId).subscribe((e) => (this.testExecutionStatus = e.status));
+    this.test
+      .getTestPlanExecutionStatus(testPlanId, testExecutionId)
+      .pipe(take(1))
+      .subscribe((e) => (this.testExecutionStatus = e.status));
   }
 
   hideExecutions(plan: TestPlan) {

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -301,3 +301,7 @@ nb-menu {
     }
   }
 }
+
+.cdk-overlay-connected-position-bounding-box {
+  z-index: 1200;
+}


### PR DESCRIPTION
- Adds the ability to display logs for a single dialog in a view with a single url
- Sets the studio to the correct namespace/application pair when the url of a dialog log view is called
- Scroll and visually identify the targeted message (conveyed by url fragment)
- Graphical refactoring of dialog log display + creation of a dedicated component

![image](https://github.com/user-attachments/assets/6baaf1c8-9273-4f2a-b512-e76f105078a5)
