### PR TITLE
[DERCBOT-1274] In addition to the dialogs, bring up NLP stats

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -209,6 +209,11 @@ object BotAdminService {
                         }
                     )
                 }
+
+                // Add nlp stats
+                searchResult.copy(
+                    nlpStats = dialogReportDAO.getNlpStats(searchResult.dialogs.map { it.id }, query.namespace)
+                )
             }
     }
 

--- a/bot/engine/src/main/kotlin/admin/dialog/DialogReportQueryResult.kt
+++ b/bot/engine/src/main/kotlin/admin/dialog/DialogReportQueryResult.kt
@@ -16,6 +16,8 @@
 
 package ai.tock.bot.admin.dialog
 
+import ai.tock.bot.engine.nlp.NlpStats
+
 /**
  *
  */
@@ -23,5 +25,6 @@ data class DialogReportQueryResult(
     val total: Long,
     val start: Long = 0,
     val end: Long = 0,
-    val dialogs: List<DialogReport> = emptyList()
+    val dialogs: List<DialogReport> = emptyList(),
+    val nlpStats: List<NlpStats> = emptyList()
 )

--- a/bot/engine/src/main/kotlin/engine/nlp/NlpStats.kt
+++ b/bot/engine/src/main/kotlin/engine/nlp/NlpStats.kt
@@ -14,27 +14,20 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.admin.dialog
+package ai.tock.bot.engine.nlp
 
 import ai.tock.bot.engine.action.Action
 import ai.tock.bot.engine.dialog.Dialog
-import ai.tock.bot.engine.nlp.NlpCallStats
-import ai.tock.bot.engine.nlp.NlpStats
 import org.litote.kmongo.Id
+import java.time.Instant
 
 /**
- *
+ * Stats about nlp call.
  */
-interface DialogReportDAO {
-
-    fun search(query: DialogReportQuery): DialogReportQueryResult
-    fun intents(namespace: String,nlpModel : String): Set<String>
-
-    fun findBotDialogStats(query: DialogReportQuery): RatingReportQueryResult?
-
-    fun getDialog(id: Id<Dialog>): DialogReport?
-
-    fun getNlpCallStats(actionId: Id<Action>, namespace: String): NlpCallStats?
-
-    fun getNlpStats(dialogIds: List<Id<Dialog>>, namespace: String): List<NlpStats>
-}
+data class NlpStats(
+    val dialogId: Id<Dialog>,
+    val actionId: Id<Action>,
+    val stats: NlpCallStats,
+    val appNamespace: String,
+    val date: Instant
+)

--- a/bot/storage-mongo/src/main/kotlin/NlpStatsCol.kt
+++ b/bot/storage-mongo/src/main/kotlin/NlpStatsCol.kt
@@ -19,6 +19,7 @@ package ai.tock.bot.mongo
 import ai.tock.bot.engine.action.Action
 import ai.tock.bot.engine.dialog.Dialog
 import ai.tock.bot.engine.nlp.NlpCallStats
+import ai.tock.bot.engine.nlp.NlpStats
 import org.litote.jackson.data.JacksonData
 import org.litote.kmongo.Data
 import org.litote.kmongo.Id
@@ -38,4 +39,6 @@ internal data class NlpStatsCol(
     val stats: NlpCallStats,
     val appNamespace: String,
     val date: Instant = Instant.now()
-)
+) {
+    fun toNlpStats(): NlpStats = NlpStats(_id.dialogId, _id.actionId, stats, appNamespace, date)
+}

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -28,6 +28,7 @@ import ai.tock.bot.engine.dialog.Dialog
 import ai.tock.bot.engine.dialog.EntityStateValue
 import ai.tock.bot.engine.dialog.Snapshot
 import ai.tock.bot.engine.nlp.NlpCallStats
+import ai.tock.bot.engine.nlp.NlpStats
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.PlayerType
 import ai.tock.bot.engine.user.UserTimeline
@@ -364,6 +365,15 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
             logger.error(e)
             null
         }
+    }
+
+    override fun getNlpStats(dialogIds: List<Id<Dialog>>, namespace: String): List<NlpStats> {
+        return nlpStatsCol.find(
+            and(
+                NlpStatsCol::appNamespace eq namespace,
+                NlpStatsCol::_id / NlpStatsColId::dialogId `in` dialogIds
+            )
+        ).map { it.toNlpStats() }.toList()
     }
 
     override fun loadWithLastValidDialog(


### PR DESCRIPTION
This pull request introduces several changes to enhance the bot's functionality by adding NLP statistics. The changes span multiple files and include the addition of a new data class, methods, and imports to support this new feature.

Enhancements to NLP statistics:

* [`bot/admin/server/src/main/kotlin/BotAdminService.kt`](diffhunk://#diff-247695b29ea9fe29753c2a141fd2c331950837b442b867c2b0927360e27fdedeR212-R216): Added code to copy NLP statistics into the search result.
* [`bot/engine/src/main/kotlin/admin/dialog/DialogReportDAO.kt`](diffhunk://#diff-c073b7d4b7b8738d11f71567028b74de699b95e63895638183e2a5b064b2c4ffR38-R39): Added a new method `getNlpStats` to fetch NLP statistics for a list of dialog IDs.
* [`bot/engine/src/main/kotlin/admin/dialog/DialogReportQueryResult.kt`](diffhunk://#diff-c73521a6b1ad4f4705a7586470306b8eb8b30c42e61416833ae417cb4d59fc37R19-R29): Updated the `DialogReportQueryResult` data class to include a new field `nlpStats`.

New data class:

* [`bot/engine/src/main/kotlin/engine/nlp/NlpStats.kt`](diffhunk://#diff-664cdb26ea4820cca179145d64d59f6a6b7c6abbf0879733cae9a9991457847dR1-R33): Introduced a new data class `NlpStats` to store statistics about NLP calls.

Database integration:

* [`bot/storage-mongo/src/main/kotlin/NlpStatsCol.kt`](diffhunk://#diff-77f3e9035d1b605ebcc664c197bc82cb7f4f1b635dc7871c92823eb840628e74L41-R44): Added a method `toNlpStats` to convert `NlpStatsCol` to `NlpStats`.
* [`bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt`](diffhunk://#diff-d9d247697187ccf97184c090718c78be4af9e193e13f0a859a7761374ae35700R370-R378): Implemented the `getNlpStats` method to retrieve NLP statistics from the database.