### PR TITLE
[DERCBOT-1249] Search a single dialog

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -453,9 +453,14 @@ open class BotAdminVerticle : AdminVerticle() {
             }
         }
 
-        blockingJsonGet("/configuration/bots/:botId/rag", admin) { context  ->
-            RAGService.getRAGConfiguration(context.organization, context.path("botId"))
-                ?.let { BotRAGConfigurationDTO(it) }
+        blockingJsonGet("/configuration/bots/:botId/rag", admin) { context ->
+            val botId = context.path("botId")
+            if (front.getApplicationByNamespaceAndName(context.organization, botId) != null) {
+                RAGService.getRAGConfiguration(context.organization, botId)
+                    ?.let { BotRAGConfigurationDTO(it) }
+            } else {
+                unauthorized()
+            }
         }
 
         blockingDelete("/configuration/bots/:botId/rag", admin) { context  ->
@@ -471,10 +476,15 @@ open class BotAdminVerticle : AdminVerticle() {
         }
 
         blockingJsonGet("/configuration/bots/:botId/observability", admin) { context  ->
-            ObservabilityService.getObservabilityConfiguration(context.organization, context.path("botId"))
-                ?.let {
-                    BotObservabilityConfigurationDTO(it)
-                }
+            val botId = context.path("botId")
+            if (front.getApplicationByNamespaceAndName(context.organization, botId) != null) {
+                ObservabilityService.getObservabilityConfiguration(context.organization, botId)
+                    ?.let {
+                        BotObservabilityConfigurationDTO(it)
+                    }
+            } else {
+                unauthorized()
+            }
         }
 
         blockingDelete("/configuration/bots/:botId/observability", admin) { context  ->
@@ -490,10 +500,15 @@ open class BotAdminVerticle : AdminVerticle() {
         }
 
         blockingJsonGet("/configuration/bots/:botId/vector-store", admin) { context  ->
-            VectorStoreService.getVectorStoreConfiguration(context.organization, context.path("botId"))
-                ?.let {
-                    BotVectorStoreConfigurationDTO(it)
-                }
+            val botId = context.path("botId")
+            if (front.getApplicationByNamespaceAndName(context.organization, botId) != null) {
+                VectorStoreService.getVectorStoreConfiguration(context.organization, botId)
+                    ?.let {
+                        BotVectorStoreConfigurationDTO(it)
+                    }
+            } else {
+                unauthorized()
+            }
         }
 
         blockingDelete("/configuration/bots/:botId/vector-store", admin) { context  ->
@@ -1110,11 +1125,18 @@ open class BotAdminVerticle : AdminVerticle() {
             "/configuration/bots/:botId/sentence-generation/configuration",
             admin
         ) { context ->
-            SentenceGenerationService.getSentenceGenerationConfiguration(context.organization,
-                context.path("botId"))
-                ?.let {
-                    BotSentenceGenerationConfigurationDTO(it)
-                }
+            val botId = context.path("botId")
+            if (front.getApplicationByNamespaceAndName(context.organization, botId) != null) {
+                SentenceGenerationService.getSentenceGenerationConfiguration(
+                    context.organization,
+                    botId
+                )
+                    ?.let {
+                        BotSentenceGenerationConfigurationDTO(it)
+                    }
+            } else {
+                unauthorized()
+            }
         }
 
         blockingJsonGet(

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -540,54 +540,70 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
 
     override fun search(query: DialogReportQuery): DialogReportQueryResult {
         with(query) {
-            val applicationsIds = getApplicationIds(query.namespace, query.nlpModel)
+            val applicationsIds = getApplicationIds(query.namespace, query.nlpModel).filter { it.isNotEmpty() }
             if (applicationsIds.isEmpty()) {
                 return DialogReportQueryResult(0)
             }
-            val dialogIds = if (query.text.isNullOrBlank()) {
-                emptySet()
-            } else {
-                if (query.exactMatch) {
-                    dialogTextCol.find(Text eq textKey(query.text!!.trim())).map { it.dialogId }.toSet()
-                } else {
-                    dialogTextCol
-                        .find(Text.regex(textKey(query.text!!.trim()), "i"))
-                        .map { it.dialogId }
-                        .toSet()
+
+            if(dialogId != null){
+                // When a single dialog is requested, only the applicationId filter is applied
+                val dialog = dialogCol.findOne(
+                    and(
+                        DialogCol::_id eq dialogId!!.toId(),
+                        DialogCol::applicationIds `in` applicationsIds,
+                        DialogCol::namespace eq namespace,
+                    )
+                )?.toDialogReport()
+
+                return dialog?.let(::listOf).orEmpty().let {
+                    DialogReportQueryResult(1, 0, 1, it)
                 }
-            }
-            if (dialogIds.isEmpty() && !query.text.isNullOrBlank()) {
-                return DialogReportQueryResult(0, 0, 0, emptyList())
-            }
-            val filter = and(
-                DialogCol_.ApplicationIds `in` applicationsIds.filter { it.isNotEmpty() },
-                Namespace eq query.namespace,
-                if (query.playerId != null || query.displayTests) null else Test eq false,
-                if (query.playerId == null) null else PlayerIds.id eq query.playerId!!.id,
-                if (dialogIds.isEmpty()) null else _id `in` dialogIds,
-                if (from == null) null else DialogCol_.LastUpdateDate gt from?.toInstant(),
-                if (to == null) null else DialogCol_.LastUpdateDate lt to?.toInstant(),
-                if (connectorType == null) null else Stories.actions.state.targetConnectorType.id eq connectorType!!.id,
-                if (query.intentName.isNullOrBlank()) null else Stories.currentIntent.name_ eq query.intentName,
-                if (query.ratings.isNotEmpty()) DialogCol_.Rating `in` query.ratings.toSet() else null,
-                if (query.applicationId.isNullOrBlank()) null else  DialogCol_.ApplicationIds `in` setOf( query.applicationId),
-                if (query.isGenAiRagDialog == true) Stories.actions.botMetadata.isGenAiRagAnswer eq true else null
-            )
-            logger.debug { "dialog search query: $filter" }
-            val c = dialogCol.withReadPreference(secondaryPreferred())
-            val count = c.countDocuments(filter, defaultCountOptions)
-            return if (count > start) {
-                val list = c.find(filter)
-                    .skip(start.toInt())
-                    .limit(size)
-                    .descendingSort(LastUpdateDate)
-                    .run {
-                        map { it.toDialogReport() }
-                            .toList()
+            }else{
+                val dialogIds = if (query.text.isNullOrBlank()) {
+                    emptySet()
+                } else {
+                    if (query.exactMatch) {
+                        dialogTextCol.find(Text eq textKey(query.text!!.trim())).map { it.dialogId }.toSet()
+                    } else {
+                        dialogTextCol
+                            .find(Text.regex(textKey(query.text!!.trim()), "i"))
+                            .map { it.dialogId }
+                            .toSet()
                     }
-                DialogReportQueryResult(count, start, start + list.size, list)
-            } else {
-                DialogReportQueryResult(0, 0, 0, emptyList())
+                }
+                if (dialogIds.isEmpty() && !query.text.isNullOrBlank()) {
+                    return DialogReportQueryResult(0, 0, 0, emptyList())
+                }
+                val filter = and(
+                    DialogCol_.ApplicationIds `in` applicationsIds,
+                    Namespace eq query.namespace,
+                    if (query.playerId != null || query.displayTests) null else Test eq false,
+                    if (query.playerId == null) null else PlayerIds.id eq query.playerId!!.id,
+                    if (dialogIds.isEmpty()) null else _id `in` dialogIds,
+                    if (from == null) null else DialogCol_.LastUpdateDate gt from?.toInstant(),
+                    if (to == null) null else DialogCol_.LastUpdateDate lt to?.toInstant(),
+                    if (connectorType == null) null else Stories.actions.state.targetConnectorType.id eq connectorType!!.id,
+                    if (query.intentName.isNullOrBlank()) null else Stories.currentIntent.name_ eq query.intentName,
+                    if (query.ratings.isNotEmpty()) DialogCol_.Rating `in` query.ratings.toSet() else null,
+                    if (query.applicationId.isNullOrBlank()) null else  DialogCol_.ApplicationIds `in` setOf( query.applicationId),
+                    if (query.isGenAiRagDialog == true) Stories.actions.botMetadata.isGenAiRagAnswer eq true else null
+                )
+                logger.debug { "dialog search query: $filter" }
+                val c = dialogCol.withReadPreference(secondaryPreferred())
+                val count = c.countDocuments(filter, defaultCountOptions)
+                return if (count > start) {
+                    val list = c.find(filter)
+                        .skip(start.toInt())
+                        .limit(size)
+                        .descendingSort(LastUpdateDate)
+                        .run {
+                            map { it.toDialogReport() }
+                                .toList()
+                        }
+                    DialogReportQueryResult(count, start, start + list.size, list)
+                } else {
+                    DialogReportQueryResult(0, 0, 0, emptyList())
+                }
             }
         }
     }


### PR DESCRIPTION
I took the opportunity to secure access to Gen AI Endpoints.

This pull request includes several changes to improve the handling of bot configurations and dialog reports in the `bot/admin/server` and `bot/storage-mongo` modules. The most important changes focus on adding authorization checks and enhancing the search functionality.

Authorization checks for bot configurations:

* [`bot/admin/server/src/main/kotlin/BotAdminVerticle.kt`](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL457-R463): Added authorization checks to the `RAGService`, `ObservabilityService`, `VectorStoreService`, and `SentenceGenerationService` endpoints to ensure that the bot exists before fetching configurations. [[1]](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL457-R463) [[2]](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL474-R487) [[3]](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL493-R511) [[4]](diffhunk://#diff-7b5a0b9d2cc2c7c29eb635b0ed7bb471c5864c6e2512424b0df61abae72a5f5fL1113-R1139)

Enhancements to dialog report search:

* [`bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt`](diffhunk://#diff-d9d247697187ccf97184c090718c78be4af9e193e13f0a859a7761374ae35700L543-R561): Improved the `search` method by filtering out empty application IDs and handling single dialog requests more efficiently. Added a new check to return results based on the dialog ID if provided. [[1]](diffhunk://#diff-d9d247697187ccf97184c090718c78be4af9e193e13f0a859a7761374ae35700L543-R561) [[2]](diffhunk://#diff-d9d247697187ccf97184c090718c78be4af9e193e13f0a859a7761374ae35700L563-R578) [[3]](diffhunk://#diff-d9d247697187ccf97184c090718c78be4af9e193e13f0a859a7761374ae35700R609)