### PR TITLE
[Tock Studio] Fix answer label namespace case

### DIFF
--- a/bot/admin/web/src/app/bot/story/answer/simple-answer/simple-answer.component.ts
+++ b/bot/admin/web/src/app/bot/story/answer/simple-answer/simple-answer.component.ts
@@ -53,6 +53,10 @@ export class SimpleAnswerComponent implements OnInit {
   }
 
   updateLabel(answer: SimpleAnswer) {
+    // back returns an I18nLabel whose “namespace” attribute may have been turned to lowercase; we need to fix this.
+    // TODO : Fix back behavior
+    answer.label.namespace = this.state.currentApplication.namespace;
+
     this.bot.saveI18nLabel(answer.label).subscribe((_) =>
       this.dialog.notify(`Story label has been updated successfully.`, 'Label Updated', {
         duration: 3000,


### PR DESCRIPTION
During creation, the backend sets the namespace of answers labels to lowercase. This produces a bug when updating the label of a response whose namespace contains uppercase characters. This PR bypasses this bug until the backend behavior is corrected.