### PR TITLE
fixes #1557 web_connector: fix dropped messages after network failure

### DIFF
--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -156,9 +156,9 @@ and attempts to send them if and when the SSE connection is re-established.
 The `tock_web_sse_keepalive_delay` optional property can be used to configure the number of seconds between
 two SSE pings (default: 10).
 
-The `tock_web_sse_messages_ttl_hours` optional property can be used to configure the number of hours after which
-enqueued messages get deleted (default: 72). Note: this expiration only works on MongoDB v7.1.0 and up. Set to a
-negative value to disable.
+The `tock_web_sse_messages_ttl_days` optional property can be used to configure the number of days after which
+enqueued messages get deleted. Note: this expiration only works on MongoDB v7.1.0 and up. Set to a
+negative value to disable (default: -1).
 
 The `tock_web_sse_message_queue_max_count` optional property can be used to configure the maximum number of enqueued
 messages in the database. When a new message is enqueued past this limit, the oldest message gets deleted (default: 50000).

--- a/bot/connector-web/README.md
+++ b/bot/connector-web/README.md
@@ -156,6 +156,17 @@ and attempts to send them if and when the SSE connection is re-established.
 The `tock_web_sse_keepalive_delay` optional property can be used to configure the number of seconds between
 two SSE pings (default: 10).
 
+The `tock_web_sse_messages_ttl_hours` optional property can be used to configure the number of hours after which
+enqueued messages get deleted (default: 72). Note: this expiration only works on MongoDB v7.1.0 and up. Set to a
+negative value to disable.
+
+The `tock_web_sse_message_queue_max_count` optional property can be used to configure the maximum number of enqueued
+messages in the database. When a new message is enqueued past this limit, the oldest message gets deleted (default: 50000).
+
+The `tock_web_sse_message_queue_max_size_kb` optional property can be used to configure the maximum size in kilobytes
+of the message queue in the database. When a new message is enqueued past this limit, the oldest messages get deleted
+(default: `2 * tock_web_sse_message_queue_max_count`).
+
 #### Push messages
 
 When SSE is enabled, the web connector allows sending push messages through the

--- a/bot/connector-web/src/main/kotlin/channel/ChannelCallback.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelCallback.kt
@@ -16,5 +16,6 @@
 package ai.tock.bot.connector.web.channel
 
 import ai.tock.bot.connector.web.WebConnectorResponse
+import io.vertx.core.Future
 
-internal typealias ChannelCallback = (webConnectorResponse: WebConnectorResponse) -> Unit
+internal typealias ChannelCallback = (webConnectorResponse: WebConnectorResponse) -> Future<Void>

--- a/bot/connector-web/src/main/kotlin/channel/ChannelEvent.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelEvent.kt
@@ -17,6 +17,7 @@ package ai.tock.bot.connector.web.channel
 
 import ai.tock.bot.connector.web.WebConnectorResponse
 import com.fasterxml.jackson.annotation.JsonValue
+import io.vertx.core.Future
 import java.time.Instant
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
@@ -42,6 +43,6 @@ internal data class ChannelEvent(
         /**
          * @return `true` if the event has been handled successfully
          */
-        operator fun invoke(event: ChannelEvent): Boolean
+        operator fun invoke(event: ChannelEvent): Future<Boolean>
     }
 }

--- a/bot/connector-web/src/main/kotlin/channel/ChannelMongoDAO.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelMongoDAO.kt
@@ -52,7 +52,7 @@ internal object ChannelMongoDAO : ChannelDAO {
     private fun MongoDatabase.collectionExists(collectionName: String): Boolean =
         listCollectionNames().contains(collectionName)
 
-    private val messageQueueTtl = longProperty("tock_web_sse_message_queue_ttl_hours", 72)
+    private val messageQueueTtl = longProperty("tock_web_sse_message_queue_ttl_days", -1)
     private val messageQueueMaxCount = longProperty("tock_web_sse_message_queue_max_count", 50000)
     private val messageQueueMaxSize = longProperty("tock_web_sse_message_queue_max_size_kb", 2 * messageQueueMaxCount)
 
@@ -79,7 +79,7 @@ internal object ChannelMongoDAO : ChannelDAO {
                 webChannelResponseCol.ensureIndex(
                     ChannelEvent::enqueuedAt, indexOptions = IndexOptions().expireAfter(
                         messageQueueTtl,
-                        TimeUnit.MINUTES
+                        TimeUnit.DAYS
                     )
                 )
             }

--- a/bot/connector-web/src/main/kotlin/channel/ChannelMongoDAO.kt
+++ b/bot/connector-web/src/main/kotlin/channel/ChannelMongoDAO.kt
@@ -75,12 +75,13 @@ internal object ChannelMongoDAO : ChannelDAO {
         webChannelResponseCol = database.getCollection<ChannelEvent>(COLLECTION_NAME)
         try {
             webChannelResponseCol.ensureIndex(ChannelEvent::appId, ChannelEvent::recipientId, ChannelEvent::status)
-            val messageTtl = messageQueueTtl
-            if (messageTtl > 0) {
-                webChannelResponseCol.ensureIndex(ChannelEvent::enqueuedAt, indexOptions = IndexOptions().expireAfter(
-                    messageTtl,
-                    TimeUnit.MINUTES
-                ))
+            if (messageQueueTtl > 0) {
+                webChannelResponseCol.ensureIndex(
+                    ChannelEvent::enqueuedAt, indexOptions = IndexOptions().expireAfter(
+                        messageQueueTtl,
+                        TimeUnit.MINUTES
+                    )
+                )
             }
         } catch (e: Exception) {
             logger.error(e)

--- a/bot/connector-web/src/test/kotlin/ChannelsTest.kt
+++ b/bot/connector-web/src/test/kotlin/ChannelsTest.kt
@@ -28,6 +28,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
+import io.vertx.core.Future
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -66,6 +67,7 @@ internal class ChannelsTest {
         val responses = mutableListOf<WebConnectorResponse>()
         channels.register(appId, recipientId) {
             responses.add(it)
+            Future.succeededFuture()
         }
         assertEquals(expectedMissedResponses, responses)
         expectedNewResponses.forEach {


### PR DESCRIPTION
#1561 introduced a mechanism to re-send messages after a user disconnected and reconnected. The status update routine however did not wait for a message to actually be successfully sent, meaning some messages were still dropped if they were sent right after a network failure.

This PR fixes this oversight by waiting for write completion before updating the database. It also completes the leftover TODO from the initial implementation.

> [!WARNING]
> The new expiration feature requires MongoDB 7.1.0 and up. If we were to make it enabled by default, this should be mentioned in the version release changelog.