### PR TITLE
[DERCBOT-1314] Add documentsRequired Setting to BotRAGConfiguration

### DIFF
--- a/bot/admin/server/src/main/kotlin/model/BotRAGConfigurationDTO.kt
+++ b/bot/admin/server/src/main/kotlin/model/BotRAGConfigurationDTO.kt
@@ -39,6 +39,7 @@ data class BotRAGConfigurationDTO(
     val indexName: String? = null,
     val noAnswerSentence: String,
     val noAnswerStoryId: String? = null,
+    val documentsRequired: Boolean = true,
 ) {
     constructor(configuration: BotRAGConfiguration) : this(
         id = configuration._id.toString(),
@@ -50,7 +51,8 @@ data class BotRAGConfigurationDTO(
         indexSessionId = configuration.indexSessionId,
         indexName = configuration.generateIndexName(),
         noAnswerSentence = configuration.noAnswerSentence,
-        noAnswerStoryId = configuration.noAnswerStoryId
+        noAnswerStoryId = configuration.noAnswerStoryId,
+        documentsRequired = configuration.documentsRequired,
     )
 
     fun toBotRAGConfiguration(): BotRAGConfiguration =
@@ -73,7 +75,8 @@ data class BotRAGConfigurationDTO(
             ),
             indexSessionId = indexSessionId,
             noAnswerSentence = noAnswerSentence,
-            noAnswerStoryId = noAnswerStoryId
+            noAnswerStoryId = noAnswerStoryId,
+            documentsRequired = documentsRequired,
         )
 }
 

--- a/bot/engine/src/main/kotlin/admin/bot/rag/BotRAGConfiguration.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/rag/BotRAGConfiguration.kt
@@ -30,4 +30,5 @@ data class BotRAGConfiguration(
     val indexSessionId: String? = null,
     val noAnswerSentence: String,
     val noAnswerStoryId: String? = null,
+    val documentsRequired: Boolean = true,
 )

--- a/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
+++ b/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
@@ -190,7 +190,8 @@ object RAGAnswerHandler : AbstractProactiveAnswerHandler {
                         documentIndexName = indexName,
                         documentSearchParams = documentSearchParams,
                         vectorStoreSetting = vectorStoreSetting,
-                        observabilitySetting = botDefinition.observabilityConfiguration?.setting
+                        observabilitySetting = botDefinition.observabilityConfiguration?.setting,
+                        documentsRequired = ragConfiguration.documentsRequired,
                     ), debug = action.metadata.debugEnabled || ragDebugEnabled
                 )
 

--- a/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/requests/RAGQuery.kt
+++ b/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/requests/RAGQuery.kt
@@ -32,7 +32,7 @@ data class RAGQuery(
     val documentSearchParams: DocumentSearchParamsBase,
     val vectorStoreSetting: VectorStoreSetting?,
     val observabilitySetting: ObservabilitySetting?,
-    val documentsRequired: Boolean? = true
+    val documentsRequired: Boolean = true,
 )
 
 data class ChatMessage(

--- a/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/requests/RAGQuery.kt
+++ b/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/requests/RAGQuery.kt
@@ -31,7 +31,8 @@ data class RAGQuery(
     val documentIndexName: String,
     val documentSearchParams: DocumentSearchParamsBase,
     val vectorStoreSetting: VectorStoreSetting?,
-    val observabilitySetting: ObservabilitySetting?
+    val observabilitySetting: ObservabilitySetting?,
+    val documentsRequired: Boolean? = true
 )
 
 data class ChatMessage(

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/routers/requests/requests.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/routers/requests/requests.py
@@ -16,6 +16,7 @@
 
 from typing import Any, Optional
 
+from pyasn1.type.univ import Boolean
 from pydantic import BaseModel, Field
 
 from gen_ai_orchestrator.models.contextual_compressor.compressor_types import (
@@ -176,6 +177,12 @@ class RagQuery(BaseQuery):
     compressor_setting: Optional[CompressorSetting] = Field(
         description='Compressor settings, to rerank relevant documents returned by retriever.',
         default=None,
+    )
+    documents_required: Optional[bool] = Field(
+        description='Specifies whether the presence of documents is mandatory for generating answers. '
+                    'If set to True, the system will only provide answers when relevant documents are found. '
+                    'If set to False, the system can respond without requiring document sources. Default is True.',
+        default=True,
     )
 
     model_config = {

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -133,7 +133,7 @@ async def execute_qa_chain(query: RagQuery, debug: bool) -> RagResponse:
     )
 
     # RAG Guard
-    __rag_guard(inputs, response)
+    __rag_guard(inputs, response, query.documents_required)
 
     # Guardrail
     if query.guardrail_setting:
@@ -238,7 +238,7 @@ def __find_input_variables(template):
     return variables
 
 
-def __rag_guard(inputs, response):
+def __rag_guard(inputs, response, documents_required):
     """
     If a 'no_answer' input was given as a rag setting,
     then the RAG system should give no further response when no source document has been found.
@@ -254,6 +254,7 @@ def __rag_guard(inputs, response):
         if (
             response['answer'] != inputs['no_answer']
             and response['source_documents'] == []
+            and documents_required
         ):
             message = 'The RAG gives an answer when no document has been found!'
             __rag_log(level=ERROR, message=message, inputs=inputs, response=response)

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -240,14 +240,20 @@ def __find_input_variables(template):
 
 def __rag_guard(inputs, response, documents_required):
     """
-    If a 'no_answer' input was given as a rag setting,
-    then the RAG system should give no further response when no source document has been found.
-    And, when the RAG system responds with the 'no_answer' phrase,
-    then the source documents are removed from the response.
+    Validates the RAG system's response based on the presence or absence of source documents
+    and the `documentsRequired` setting.
+
+    - If `documentsRequired` is True, the RAG system must not provide an answer when no source
+      documents are found. If it does, an exception is raised.
+    - If `documentsRequired` is False, the RAG system can provide an answer even if no source
+      documents are found.
+    - If the RAG system responds with the `no_answer` phrase, any source documents in the
+      response are removed.
 
     Args:
         inputs: question answering prompt inputs
         response: the RAG response
+        documents_required (bool): Specifies whether documents are mandatory for the response.
     """
 
     if 'no_answer' in inputs:

--- a/gen-ai/orchestrator-server/src/main/python/server/tests/services/test_qa_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/tests/services/test_qa_chain.py
@@ -66,6 +66,7 @@ async def test_qa_chain(
             ],
             'k': 4,
         },
+        'documents_required': True,
     }
     query = QAQuery(**query_dict)
 


### PR DESCRIPTION
### Related Tickets
JIRA: **[DERCBOT-1314]**

### Description

This PR introduces a new boolean attribute `documentsRequired` to the `BotRAGConfiguration` and integrates it across the system. The `documentsRequired` attribute determines whether documents are mandatory for processing the RAG chain.

### Key Changes:
1. **Model Updates**:
    - Added `documentsRequired` to [`BotRAGConfiguration`](bot/engine/src/main/kotlin/admin/bot/rag/BotRAGConfiguration.kt) (default: `true`) and [`BotRAGConfigurationDTO`](bot/admin/server/src/main/kotlin/model/BotRAGConfigurationDTO.kt)
    - Ensured backward compatibility by handling cases where `documentsRequired` is absent in the database.

2. **Orchestrator Enhancements**:
    - Updated [`RAGQuery`](gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/requests/RAGQuery.kt) to include `documentsRequired` as an optional parameter.
    - Modified `__rag_guard` in [`rag_chain.py`](gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py) to respect the `documentsRequired` setting.

3. **Bot API Modifications**:
    - Updated [`RAGAnswerHandler`](bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt) to fetch the `documentsRequired` setting from the bot configuration and pass it to the RAG query.

### Testing :
- We can block the retrieval of documents by adding a filter to [`pgvectors_params.py`](gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/models/vector_stores/pgvector/pgvector_params.py) as so: 

```
    def to_dict(self):
        return {
            'k': self.k,
            'filter': {'tag1': 'vector stores'},
        }
```
- Then we are free to test if an answer is still provided while no retrieval of document is made.
