### PR TITLE
[Tock Studio] documentsRequired Rag option handling

### DIFF
--- a/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
@@ -14,4 +14,6 @@ export interface RagSettings {
 
   indexSessionId: string;
   indexName: string;
+
+  documentsRequired: boolean;
 }

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -209,6 +209,20 @@
         />
       </tock-form-control>
 
+      <tock-form-control
+        label="Documents required"
+        name="documentsRequired"
+        [controls]="documentsRequired"
+        [required]="false"
+        [boldLabel]="false"
+        information="Allowing the LLM to answer even if no documents have been found allows to make small talk and answer more general questions."
+      >
+        <nb-checkbox formControlName="documentsRequired">
+          <span *ngIf="documentsRequired.value">Don't allow undocumented answers.</span>
+          <span *ngIf="!documentsRequired.value">Allow undocumented answers.</span>
+        </nb-checkbox>
+      </tock-form-control>
+
       <h5 class="section-title mt-2">Conversation flow</h5>
 
       <tock-form-control

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
@@ -27,6 +27,8 @@ interface RagSettingsForm {
   indexSessionId: FormControl<string>;
   indexName: FormControl<string>;
 
+  documentsRequired: FormControl<boolean>;
+
   llmEngine: FormControl<AiEngineProvider>;
   llmSetting: FormGroup<any>;
   emEngine: FormControl<AiEngineProvider>;
@@ -133,6 +135,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
     noAnswerStoryId: new FormControl(undefined),
     indexSessionId: new FormControl(undefined),
     indexName: new FormControl(undefined),
+    documentsRequired: new FormControl(undefined),
     llmEngine: new FormControl(undefined, [Validators.required]),
     llmSetting: new FormGroup<any>({}),
     emEngine: new FormControl(undefined, [Validators.required]),
@@ -158,6 +161,10 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
 
   get indexSessionId(): FormControl {
     return this.form.get('indexSessionId') as FormControl;
+  }
+
+  get documentsRequired(): FormControl {
+    return this.form.get('documentsRequired') as FormControl;
   }
 
   get indexName(): FormControl {


### PR DESCRIPTION
Works with https://github.com/theopenconversationkit/tock/pull/1814

Checkbox added in Rag settings to control the documentsRequired option allowing the llm to answer even if the vector search returned no results