### PR TITLE
[Fix] Unit tests

### DIFF
--- a/bot/admin/server/src/test/kotlin/AbstractTest.kt
+++ b/bot/admin/server/src/test/kotlin/AbstractTest.kt
@@ -19,6 +19,7 @@ package ai.tock.bot.admin
 import ai.tock.bot.admin.answer.AnswerConfigurationType
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfigurationDAO
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
 import ai.tock.bot.admin.dialog.DialogReportDAO
 import ai.tock.bot.admin.model.BotStoryDefinitionConfiguration
@@ -69,6 +70,7 @@ abstract class AbstractTest {
                 bind<ModelTester>() with provider { mockk<ModelTester>(relaxed = true) }
                 bind<BotVectorStoreConfigurationDAO>() with provider { mockk<BotVectorStoreConfigurationDAO>(relaxed = true) }
                 bind<VectorStoreProviderService>() with provider { mockk<VectorStoreProviderService>(relaxed = true) }
+                bind<BotDocumentCompressorConfigurationDAO>() with provider { mockk<BotDocumentCompressorConfigurationDAO>(relaxed = true) }
             }
             return module
         }

--- a/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
+++ b/bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt
@@ -51,8 +51,8 @@ internal class WebConnectorResponseTest {
             responses = listOf(
                 WebMessageContent(
                     text = "Text with 2 footnotes", footnotes = listOf(
-                        Footnote("e122e97a5cc7", "title 1", url = "https://doc.tock.ai", content = "content 1", score = 0.965521F),
-                        Footnote("fcad492fdb99", "title 2", url = "https://github.com/theopenconversationkit/tock", content = "content 2", score = 0.965521F)
+                        Footnote("e122e97a5cc7", "title 1", url = "https://doc.tock.ai", content = "content 1", score = null),
+                        Footnote("fcad492fdb99", "title 2", url = "https://github.com/theopenconversationkit/tock", content = "content 2", score = null)
                     )
                 )
             )

--- a/bot/engine/src/test/kotlin/engine/BotEngineTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotEngineTest.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.engine
 
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfigurationDAO
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfigurationDAO
 import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
@@ -87,6 +88,7 @@ abstract class BotEngineTest {
     val storyDefinitionConfigurationDAO: StoryDefinitionConfigurationDAO = mockk(relaxed = true)
     val featureDAO: FeatureDAO = mockk(relaxed = true)
     val botObservabilityConfigurationDAO : BotObservabilityConfigurationDAO = mockk(relaxed = true)
+    val botDocumentCompressorConfigurationDAO : BotDocumentCompressorConfigurationDAO = mockk(relaxed = true)
 
     val entityA = Entity(EntityType("a"), "a")
     val entityAValue = NlpEntityValue(0, 1, entityA, null, false)
@@ -137,6 +139,7 @@ abstract class BotEngineTest {
             bind<BotRAGConfigurationDAO>() with provider { botRAGConfigurationDAO }
             bind<BotVectorStoreConfigurationDAO>() with provider { botVectorStoreConfigurationDAO }
             bind<BotObservabilityConfigurationDAO>() with provider { botObservabilityConfigurationDAO }
+            bind<BotDocumentCompressorConfigurationDAO>() with provider { botDocumentCompressorConfigurationDAO }
         }
     }
 


### PR DESCRIPTION
This pull request includes changes to add support for the `BotDocumentCompressorConfigurationDAO` in the test configurations. The most important changes include importing the new DAO and binding it in the respective test classes.

Add support for `BotDocumentCompressorConfigurationDAO`:

* [`bot/admin/server/src/test/kotlin/AbstractTest.kt`](diffhunk://#diff-79ed95974fa044e4ca6cbeb00c5e310fe37130e61d0c18553819121ef539bf56R22): Imported `BotDocumentCompressorConfigurationDAO` and added a binding for it in the `AbstractTest` class. [[1]](diffhunk://#diff-79ed95974fa044e4ca6cbeb00c5e310fe37130e61d0c18553819121ef539bf56R22) [[2]](diffhunk://#diff-79ed95974fa044e4ca6cbeb00c5e310fe37130e61d0c18553819121ef539bf56R73)
* [`bot/engine/src/test/kotlin/engine/BotEngineTest.kt`](diffhunk://#diff-2c488b398e68469b054208b0f48eccc669ad1aefbdeeefd78d94d4780336ad04R21): Imported `BotDocumentCompressorConfigurationDAO` and added a binding for it in the `BotEngineTest` class. [[1]](diffhunk://#diff-2c488b398e68469b054208b0f48eccc669ad1aefbdeeefd78d94d4780336ad04R21) [[2]](diffhunk://#diff-2c488b398e68469b054208b0f48eccc669ad1aefbdeeefd78d94d4780336ad04R91) [[3]](diffhunk://#diff-2c488b398e68469b054208b0f48eccc669ad1aefbdeeefd78d94d4780336ad04R142)

Other changes:

* [`bot/connector-web/src/test/kotlin/WebConnectorResponseTest.kt`](diffhunk://#diff-5bcd4b033dc30f1b1d33443ab21b160ebf8e8ff98cd3b4de61e9fe341abb8a82L54-R55): Updated `WebConnectorResponseTest` to set the `score` field of `Footnote` to `null` instead of a float value.