### PR TITLE
[Tock Studio] Refacto of Gen AI prompt settings

### DIFF
--- a/bot/admin/web/src/app/configuration/compressor-settings/compressor-settings.component.html
+++ b/bot/admin/web/src/app/configuration/compressor-settings/compressor-settings.component.html
@@ -58,80 +58,90 @@
   *ngIf="configurations?.length > 0"
 >
   <nb-card class="mt-1">
-    <nb-card-body [nbSpinner]="loading">
-      <h5 class="section-title">Compressor activation</h5>
-
-      <tock-form-control
-        name="enabled"
-        [controls]="enabled"
-        [showError]="isSubmitted"
-        [hasMargin]="false"
-      >
-        <nb-toggle
-          formControlName="enabled"
-          class="mt-1"
-        >
-          <span *ngIf="enabled.value">Compressor activated</span>
-          <span *ngIf="!enabled.value">Compressor deactivated</span>
-        </nb-toggle>
-      </tock-form-control>
-
-      <h5 class="section-title">Compressor provider</h5>
-
-      <tock-form-control
-        name="compressorProvider"
-        [controls]="compressorProvider"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="compressorProvider"
-          name="compressorProvider"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let provider of providersConfigurations"
-            [value]="provider.key"
+    <nb-card-body
+      [nbSpinner]="loading"
+      class="pb-0"
+    >
+      <nb-card class="mt-2">
+        <nb-card-header>Compressor activation</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="enabled"
+            [controls]="enabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
           >
-            {{ provider.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
-
-      <div
-        *ngIf="currentCompressorProvider"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentCompressorProvider.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            <nb-toggle
+              formControlName="enabled"
+              class="mt-1"
             >
-              <tock-ai-settings-engine-config-param-input
-                parentGroup="setting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-              ></tock-ai-settings-engine-config-param-input>
+              <span *ngIf="enabled.value">Compressor activated</span>
+              <span *ngIf="!enabled.value">Compressor deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card>
+        <nb-card-header>Compressor provider</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="compressorProvider"
+            [controls]="compressorProvider"
+            [required]="true"
+            [showError]="isSubmitted"
+          >
+            <nb-radio-group
+              formControlName="compressorProvider"
+              name="compressorProvider"
+              class="d-flex"
+            >
+              <nb-radio
+                *ngFor="let provider of providersConfigurations"
+                [value]="provider.key"
+              >
+                {{ provider.label }}
+              </nb-radio>
+            </nb-radio-group>
+          </tock-form-control>
+
+          <div
+            *ngIf="currentCompressorProvider"
+            class="mt-2 mb-2"
+          >
+            <div class="row mb-1">
+              <ng-container *ngFor="let param of currentCompressorProvider.params">
+                <div
+                  class="col-6 px-3"
+                  [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                >
+                  <tock-ai-settings-engine-config-param-input
+                    parentGroup="setting"
+                    [configurationParam]="param"
+                    [form]="form"
+                    [isSubmitted]="isSubmitted"
+                  ></tock-ai-settings-engine-config-param-input>
+                </div>
+              </ng-container>
             </div>
-          </ng-container>
-        </div>
-      </div>
+          </div>
+        </nb-card-body>
+      </nb-card>
 
-      <ng-container *ngIf="settingsBackup">
-        <h5 class="section-title mt-2">Settings deletion</h5>
-
-        <button
-          nbButton
-          status="danger"
-          nbTooltip="Delete settings"
-          (click)="confirmSettingsDeletion()"
-        >
-          <nb-icon icon="trash"></nb-icon>
-          DELETE SETTINGS
-        </button>
-      </ng-container>
+      <nb-card *ngIf="settingsBackup">
+        <nb-card-header>Settings deletion</nb-card-header>
+        <nb-card-body>
+          <button
+            nbButton
+            status="danger"
+            nbTooltip="Delete settings"
+            (click)="confirmSettingsDeletion()"
+          >
+            <nb-icon icon="trash"></nb-icon>
+            DELETE SETTINGS
+          </button>
+        </nb-card-body>
+      </nb-card>
     </nb-card-body>
   </nb-card>
 </form>

--- a/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.html
+++ b/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.html
@@ -58,80 +58,90 @@
   *ngIf="configurations?.length > 0"
 >
   <nb-card class="mt-1">
-    <nb-card-body [nbSpinner]="loading">
-      <h5 class="section-title">Observability activation</h5>
-
-      <tock-form-control
-        name="enabled"
-        [controls]="enabled"
-        [showError]="isSubmitted"
-        [hasMargin]="false"
-      >
-        <nb-toggle
-          formControlName="enabled"
-          class="mt-1"
-        >
-          <span *ngIf="enabled.value">Observability activated</span>
-          <span *ngIf="!enabled.value">Observability deactivated</span>
-        </nb-toggle>
-      </tock-form-control>
-
-      <h5 class="section-title">Observability provider</h5>
-
-      <tock-form-control
-        name="observabilityProvider"
-        [controls]="observabilityProvider"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="observabilityProvider"
-          name="observabilityProvider"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let provider of providersConfigurations"
-            [value]="provider.key"
+    <nb-card-body
+      [nbSpinner]="loading"
+      class="pb-0"
+    >
+      <nb-card class="mt-2">
+        <nb-card-header>Observability activation</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="enabled"
+            [controls]="enabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
           >
-            {{ provider.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
-
-      <div
-        *ngIf="currentObservabilityProvider"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentObservabilityProvider.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            <nb-toggle
+              formControlName="enabled"
+              class="mt-1"
             >
-              <tock-ai-settings-engine-config-param-input
-                parentGroup="setting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-              ></tock-ai-settings-engine-config-param-input>
+              <span *ngIf="enabled.value">Observability activated</span>
+              <span *ngIf="!enabled.value">Observability deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card>
+        <nb-card-header>Observability provider</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="observabilityProvider"
+            [controls]="observabilityProvider"
+            [required]="true"
+            [showError]="isSubmitted"
+          >
+            <nb-radio-group
+              formControlName="observabilityProvider"
+              name="observabilityProvider"
+              class="d-flex"
+            >
+              <nb-radio
+                *ngFor="let provider of providersConfigurations"
+                [value]="provider.key"
+              >
+                {{ provider.label }}
+              </nb-radio>
+            </nb-radio-group>
+          </tock-form-control>
+
+          <div
+            *ngIf="currentObservabilityProvider"
+            class="mt-2 mb-2"
+          >
+            <div class="row mb-1">
+              <ng-container *ngFor="let param of currentObservabilityProvider.params">
+                <div
+                  class="col-6 px-3"
+                  [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                >
+                  <tock-ai-settings-engine-config-param-input
+                    parentGroup="setting"
+                    [configurationParam]="param"
+                    [form]="form"
+                    [isSubmitted]="isSubmitted"
+                  ></tock-ai-settings-engine-config-param-input>
+                </div>
+              </ng-container>
             </div>
-          </ng-container>
-        </div>
-      </div>
+          </div>
+        </nb-card-body>
+      </nb-card>
 
-      <ng-container *ngIf="settingsBackup">
-        <h5 class="section-title mt-2">Settings deletion</h5>
-
-        <button
-          nbButton
-          status="danger"
-          nbTooltip="Delete settings"
-          (click)="confirmSettingsDeletion()"
-        >
-          <nb-icon icon="trash"></nb-icon>
-          DELETE SETTINGS
-        </button>
-      </ng-container>
+      <nb-card *ngIf="settingsBackup">
+        <nb-card-header>Settings deletion</nb-card-header>
+        <nb-card-body>
+          <button
+            nbButton
+            status="danger"
+            nbTooltip="Delete settings"
+            (click)="confirmSettingsDeletion()"
+          >
+            <nb-icon icon="trash"></nb-icon>
+            DELETE SETTINGS
+          </button>
+        </nb-card-body>
+      </nb-card>
     </nb-card-body>
   </nb-card>
 </form>

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/models/engines-configuration.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/models/engines-configuration.ts
@@ -3,7 +3,9 @@ import {
   EnginesConfiguration,
   AiEngineProvider,
   OllamaLlmModelsList,
-  OpenAIModelsList
+  OpenAIModelsList,
+  ProvidersConfigurationParam,
+  PromptDefinitionFormatter
 } from '../../../shared/model/ai-settings';
 
 export const DefaultPrompt: string = `# Sentences generation instructions
@@ -38,6 +40,25 @@ Answer in '{{locale}}' (language locale).
 ## Generated sentences
 `;
 
+export const SentenceGeneration_prompt: ProvidersConfigurationParam[] = [
+  {
+    key: 'formatter',
+    label: 'Prompt template format',
+    type: 'radio',
+    source: [PromptDefinitionFormatter.jinja2, PromptDefinitionFormatter.fstring],
+    defaultValue: PromptDefinitionFormatter.jinja2,
+    inputScale: 'fullwidth'
+  },
+  {
+    key: 'template',
+    label: 'Prompt template',
+    type: 'prompt',
+    inputScale: 'fullwidth',
+    defaultValue: DefaultPrompt,
+    rows: 16
+  }
+];
+
 export const EngineConfigurations: EnginesConfiguration[] = [
   {
     label: 'OpenAi',
@@ -46,8 +67,7 @@ export const EngineConfigurations: EnginesConfiguration[] = [
       { key: 'apiKey', label: 'Api key', type: 'obfuscated', confirmExport: true },
       { key: 'baseUrl', label: 'Base url', type: 'text', defaultValue: 'https://api.openai.com/v1' },
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
     ]
   },
   {
@@ -59,8 +79,7 @@ export const EngineConfigurations: EnginesConfiguration[] = [
       { key: 'deploymentName', label: 'Deployment name', type: 'text' },
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
       { key: 'apiBase', label: 'Base url', type: 'obfuscated' },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
     ]
   },
   {
@@ -69,8 +88,7 @@ export const EngineConfigurations: EnginesConfiguration[] = [
     params: [
       { key: 'baseUrl', label: 'Base url', type: 'text', defaultValue: 'http://localhost:11434' },
       { key: 'model', label: 'Model', type: 'openlist', source: OllamaLlmModelsList, defaultValue: 'llama2' },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05, defaultValue: 0.7 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05, defaultValue: 0.7 }
     ]
   }
 ];

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/models/sentence-generation-settings.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/models/sentence-generation-settings.ts
@@ -1,4 +1,4 @@
-import { llmSetting } from '../../../shared/model/ai-settings';
+import { PromptDefinition, llmSetting } from '../../../shared/model/ai-settings';
 
 export interface SentenceGenerationSettings {
   id: string;
@@ -7,4 +7,5 @@ export interface SentenceGenerationSettings {
   enabled: boolean;
 
   llmSetting: llmSetting;
+  prompt: PromptDefinition;
 }

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.html
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.html
@@ -74,95 +74,105 @@
   *ngIf="configurations?.length > 0"
 >
   <nb-card class="mt-1">
-    <nb-card-body [nbSpinner]="loading">
-      <h5 class="section-title">Sentence generation activation</h5>
-
-      <tock-form-control
-        name="enabled"
-        [controls]="enabled"
-        [showError]="isSubmitted"
-        [hasMargin]="false"
-      >
-        <nb-toggle
-          formControlName="enabled"
-          class="mt-1"
-        >
-          <span *ngIf="enabled.value">Sentence generation activated</span>
-          <span *ngIf="!enabled.value">Sentence generation deactivated</span>
-        </nb-toggle>
-      </tock-form-control>
-
-      <h5 class="section-title">LLM engine</h5>
-
-      <tock-form-control
-        name="llmEngine"
-        [controls]="llmEngine"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="llmEngine"
-          name="llmEngine"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let engine of engineConfigurations"
-            [value]="engine.key"
+    <nb-card-body
+      [nbSpinner]="loading"
+      class="pb-0"
+    >
+      <nb-card class="mt-2">
+        <nb-card-header>Sentence generation activation</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="enabled"
+            [controls]="enabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
           >
-            {{ engine.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
-
-      <div
-        *ngIf="currentLlmEngine"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentLlmEngine.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            <nb-toggle
+              formControlName="enabled"
+              class="mt-1"
             >
-              <tock-ai-settings-engine-config-param-input
-                parentGroup="llmSetting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-                [defaultPrompt]="defaultPrompt"
-              ></tock-ai-settings-engine-config-param-input>
+              <span *ngIf="enabled.value">Sentence generation activated</span>
+              <span *ngIf="!enabled.value">Sentence generation deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card>
+        <nb-card-header>LLM engine</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="llmEngine"
+            [controls]="llmEngine"
+            [required]="true"
+            [showError]="isSubmitted"
+          >
+            <nb-radio-group
+              formControlName="llmEngine"
+              name="llmEngine"
+              class="d-flex"
+            >
+              <nb-radio
+                *ngFor="let engine of engineConfigurations"
+                [value]="engine.key"
+              >
+                {{ engine.label }}
+              </nb-radio>
+            </nb-radio-group>
+          </tock-form-control>
+
+          <div
+            *ngIf="currentLlmEngine"
+            class="mt-2 mb-2"
+          >
+            <div class="row mb-1">
+              <ng-container *ngFor="let param of currentLlmEngine.params">
+                <div
+                  class="col-6 px-3"
+                  [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                >
+                  <tock-ai-settings-engine-config-param-input
+                    parentGroup="llmSetting"
+                    [configurationParam]="param"
+                    [form]="form"
+                    [isSubmitted]="isSubmitted"
+                    [defaultPrompt]="defaultPrompt"
+                  ></tock-ai-settings-engine-config-param-input>
+                </div>
+              </ng-container>
             </div>
-          </ng-container>
-        </div>
-      </div>
+          </div>
 
-      <tock-form-control
-        label="Number of sentences to generate"
-        name="nbSentences"
-        [controls]="nbSentences"
-        [showError]="isSubmitted"
-      >
-        <tock-slider
-          [min]="1"
-          [max]="20"
-          [step]="1"
-          formControlName="nbSentences"
-        ></tock-slider>
-      </tock-form-control>
+          <tock-form-control
+            label="Number of sentences to generate"
+            name="nbSentences"
+            [controls]="nbSentences"
+            [showError]="isSubmitted"
+          >
+            <tock-slider
+              [min]="1"
+              [max]="20"
+              [step]="1"
+              formControlName="nbSentences"
+            ></tock-slider>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
 
-      <ng-container *ngIf="settingsBackup">
-        <h5 class="section-title mt-2">Settings deletion</h5>
-
-        <button
-          nbButton
-          status="danger"
-          nbTooltip="Delete settings"
-          (click)="confirmSettingsDeletion()"
-        >
-          <nb-icon icon="trash"></nb-icon>
-          DELETE SETTINGS
-        </button>
-      </ng-container>
+      <nb-card *ngIf="settingsBackup">
+        <nb-card-header>Settings deletion</nb-card-header>
+        <nb-card-body>
+          <button
+            nbButton
+            status="danger"
+            nbTooltip="Delete settings"
+            (click)="confirmSettingsDeletion()"
+          >
+            <nb-icon icon="trash"></nb-icon>
+            DELETE SETTINGS
+          </button>
+        </nb-card-body>
+      </nb-card>
     </nb-card-body>
   </nb-card>
 </form>

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.html
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.html
@@ -99,17 +99,17 @@
       </nb-card>
 
       <nb-card>
-        <nb-card-header>LLM engine</nb-card-header>
+        <nb-card-header>Configuration</nb-card-header>
         <nb-card-body>
           <tock-form-control
-            name="llmEngine"
-            [controls]="llmEngine"
+            name="llmProvider"
+            [controls]="llmProvider"
             [required]="true"
             [showError]="isSubmitted"
           >
             <nb-radio-group
-              formControlName="llmEngine"
-              name="llmEngine"
+              formControlName="llmProvider"
+              name="llmProvider"
               class="d-flex"
             >
               <nb-radio
@@ -122,11 +122,11 @@
           </tock-form-control>
 
           <div
-            *ngIf="currentLlmEngine"
+            *ngIf="currentLlmProvider"
             class="mt-2 mb-2"
           >
             <div class="row mb-1">
-              <ng-container *ngFor="let param of currentLlmEngine.params">
+              <ng-container *ngFor="let param of currentLlmProvider.params">
                 <div
                   class="col-6 px-3"
                   [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
@@ -137,6 +137,21 @@
                     [form]="form"
                     [isSubmitted]="isSubmitted"
                     [defaultPrompt]="defaultPrompt"
+                  ></tock-ai-settings-engine-config-param-input>
+                </div>
+              </ng-container>
+
+              <ng-container *ngFor="let param of sentenceGeneration_prompt">
+                <div
+                  class="col-12 px-3"
+                  *ngIf="shouldDisplayPromptParam('prompt', param)"
+                >
+                  <tock-ai-settings-engine-config-param-input
+                    parentGroup="prompt"
+                    [configurationParam]="param"
+                    [form]="form"
+                    [isSubmitted]="isSubmitted"
+                    [defaultPrompt]="$any(param.defaultValue)"
                   ></tock-ai-settings-engine-config-param-input>
                 </div>
               </ng-container>

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
@@ -5,7 +5,7 @@ import { DefaultPrompt, EngineConfigurations, SentenceGeneration_prompt } from '
 import { SentenceGenerationSettings } from './models/sentence-generation-settings';
 import { StateService } from '../../core-nlp/state.service';
 import { RestService } from '../../core-nlp/rest/rest.service';
-import { NbDialogService, NbToastrService, NbWindowService } from '@nebular/theme';
+import { NbDialogRef, NbDialogService, NbToastrService, NbWindowService } from '@nebular/theme';
 import { BotConfigurationService } from '../../core/bot-configuration.service';
 import {
   AiEngineSettingKeyName,
@@ -130,7 +130,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     return this.isSubmitted ? this.form.valid : this.form.dirty;
   }
 
-  shouldDisplayPromptParam(parentGroup, param) {
+  shouldDisplayPromptParam(parentGroup: string, param: ProvidersConfigurationParam) {
     // Goal : We want templates to use the Jinja2 format by default.
     if (param.key === 'formatter') {
       // We only care about the “formatter” param
@@ -167,7 +167,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  resetFormGroupControls(group: string) {
+  resetFormGroupControls(group: string): void {
     const existingGroupKeys = Object.keys(this.form.controls[group].controls);
     existingGroupKeys.forEach((key) => {
       this.form.controls[group].removeControl(key);
@@ -179,7 +179,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     return this.rest.get<SentenceGenerationSettings>(url, (settings: SentenceGenerationSettings) => settings);
   }
 
-  initForm(settings: SentenceGenerationSettings) {
+  initForm(settings: SentenceGenerationSettings): void {
     this.initFormSettings(settings.llmSetting.provider);
     this.form.patchValue({
       llmProvider: settings.llmSetting.provider
@@ -270,7 +270,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
 
   sensitiveParams: { label: string; key: string; include: boolean; param: ProvidersConfigurationParam }[];
 
-  exportSettings() {
+  exportSettings(): void {
     this.sensitiveParams = [];
 
     const shouldConfirm =
@@ -294,18 +294,18 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  exportConfirmationModalRef;
+  exportConfirmationModalRef: NbDialogRef<any>;
 
-  closeExportConfirmationModal() {
+  closeExportConfirmationModal(): void {
     this.exportConfirmationModalRef.close();
   }
 
-  confirmExportSettings() {
+  confirmExportSettings(): void {
     this.downloadSettings();
     this.closeExportConfirmationModal();
   }
 
-  downloadSettings() {
+  downloadSettings(): void {
     const formValue: SentenceGenerationSettings = deepCopy(this.form.value) as unknown as SentenceGenerationSettings;
     delete formValue['llmProvider'];
     delete formValue['id'];
@@ -338,15 +338,15 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     });
   }
 
-  importModalRef;
+  importModalRef: NbDialogRef<any>;
 
-  importSettings() {
+  importSettings(): void {
     this.isImportSubmitted = false;
     this.importForm.reset();
     this.importModalRef = this.nbDialogService.open(this.importModal);
   }
 
-  closeImportModal() {
+  closeImportModal(): void {
     this.importModalRef.close();
   }
 
@@ -367,7 +367,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
   }
 
-  submitImportSettings() {
+  submitImportSettings(): void {
     this.isImportSubmitted = true;
     if (this.canSaveImport) {
       const file = this.fileSource.value[0];
@@ -398,7 +398,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  confirmSettingsDeletion() {
+  confirmSettingsDeletion(): void {
     const confirmAction = 'Delete';
     const cancelAction = 'Cancel';
 
@@ -420,7 +420,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     });
   }
 
-  deleteSettings() {
+  deleteSettings(): void {
     const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/configuration`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Observable, Subject, debounceTime, takeUntil } from 'rxjs';
 import { BotApplicationConfiguration } from '../../core/model/configuration';
-import { DefaultPrompt, EngineConfigurations } from './models/engines-configuration';
+import { DefaultPrompt, EngineConfigurations, SentenceGeneration_prompt } from './models/engines-configuration';
 import { SentenceGenerationSettings } from './models/sentence-generation-settings';
 import { StateService } from '../../core-nlp/state.service';
 import { RestService } from '../../core-nlp/rest/rest.service';
@@ -11,7 +11,8 @@ import {
   AiEngineSettingKeyName,
   EnginesConfiguration,
   AiEngineProvider,
-  ProvidersConfigurationParam
+  ProvidersConfigurationParam,
+  PromptDefinitionFormatter
 } from '../../shared/model/ai-settings';
 import { deepCopy, getExportFileName, readFileAsText } from '../../shared/utils';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
@@ -23,8 +24,9 @@ interface GenAiSettingsForm {
   id: FormControl<string>;
   enabled: FormControl<boolean>;
   nbSentences: FormControl<number>;
-  llmEngine: FormControl<AiEngineProvider>;
+  llmProvider: FormControl<AiEngineProvider>;
   llmSetting: FormGroup<any>;
+  prompt: FormGroup<any>;
 }
 
 @Component({
@@ -38,6 +40,8 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   configurations: BotApplicationConfiguration[];
 
   engineConfigurations = EngineConfigurations;
+
+  sentenceGeneration_prompt = SentenceGeneration_prompt;
 
   defaultPrompt = DefaultPrompt;
 
@@ -65,7 +69,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form
-      .get('llmEngine')
+      .get('llmProvider')
       .valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((engine: AiEngineProvider) => {
         this.initFormSettings(engine);
@@ -77,7 +81,9 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
       // Reset form on configuration change
       this.form.reset();
       // Reset formGroup control too, if any
-      this.resetFormGroupControls();
+      this.resetFormGroupControls('llmSetting');
+
+      this.initFormPrompt();
 
       this.loading = true;
       this.configurations = confs;
@@ -105,8 +111,9 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     enabled: new FormControl({ value: undefined, disabled: !this.canBeActivated() }),
     nbSentences: new FormControl(10),
 
-    llmEngine: new FormControl(undefined, [Validators.required]),
-    llmSetting: new FormGroup<any>({})
+    llmProvider: new FormControl(undefined, [Validators.required]),
+    llmSetting: new FormGroup<any>({}),
+    prompt: new FormGroup<any>({})
   });
 
   get enabled(): FormControl {
@@ -115,12 +122,34 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   get nbSentences(): FormControl {
     return this.form.get('nbSentences') as FormControl;
   }
-  get llmEngine(): FormControl {
-    return this.form.get('llmEngine') as FormControl;
+  get llmProvider(): FormControl {
+    return this.form.get('llmProvider') as FormControl;
   }
 
   get canSave(): boolean {
     return this.isSubmitted ? this.form.valid : this.form.dirty;
+  }
+
+  shouldDisplayPromptParam(parentGroup, param) {
+    // Goal : We want templates to use the Jinja2 format by default.
+    if (param.key === 'formatter') {
+      // We only care about the “formatter” param
+      if (this.form.get(parentGroup).get(param.key).value === PromptDefinitionFormatter.jinja2) {
+        // If the format is already Jinja2, we can hide the choice control
+        return false;
+      }
+    }
+    return true;
+  }
+
+  initFormPrompt(): void {
+    this.resetFormGroupControls('prompt');
+
+    let params = SentenceGeneration_prompt;
+
+    params.forEach((param) => {
+      this.form.controls['prompt'].addControl(param.key, new FormControl(param.defaultValue, Validators.required));
+    });
   }
 
   initFormSettings(provider: AiEngineProvider): void {
@@ -128,7 +157,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
 
     if (requiredConfiguration) {
       // Purge existing controls that may contain values incompatible with a new control with the same name after engine change
-      this.resetFormGroupControls();
+      this.resetFormGroupControls('llmSetting');
 
       requiredConfiguration.params.forEach((param) => {
         this.form.controls['llmSetting'].addControl(param.key, new FormControl(param.defaultValue, Validators.required));
@@ -138,10 +167,10 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  resetFormGroupControls() {
-    const existingGroupKeys = Object.keys(this.form.controls['llmSetting'].controls);
+  resetFormGroupControls(group: string) {
+    const existingGroupKeys = Object.keys(this.form.controls[group].controls);
     existingGroupKeys.forEach((key) => {
-      this.form.controls['llmSetting'].removeControl(key);
+      this.form.controls[group].removeControl(key);
     });
   }
 
@@ -153,9 +182,16 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   initForm(settings: SentenceGenerationSettings) {
     this.initFormSettings(settings.llmSetting.provider);
     this.form.patchValue({
-      llmEngine: settings.llmSetting.provider
+      llmProvider: settings.llmSetting.provider
     });
     this.form.patchValue(settings);
+
+    this.initFormPrompt();
+
+    this.form.patchValue({
+      prompt: settings.prompt
+    });
+
     this.form.markAsPristine();
   }
 
@@ -171,8 +207,8 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  get currentLlmEngine(): EnginesConfiguration {
-    return EngineConfigurations.find((e) => e.key === this.llmEngine.value);
+  get currentLlmProvider(): EnginesConfiguration {
+    return EngineConfigurations.find((e) => e.key === this.llmProvider.value);
   }
 
   cancel(): void {
@@ -187,7 +223,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
       formValue.namespace = this.state.currentApplication.namespace;
       formValue.botId = this.state.currentApplication.name;
 
-      delete formValue['llmEngine'];
+      delete formValue['llmProvider'];
 
       const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/configuration`;
       this.rest.post(url, formValue, null, null, true).subscribe({
@@ -223,7 +259,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   }
 
   get hasExportableData(): boolean {
-    if (this.llmEngine.value) return true;
+    if (this.llmProvider.value) return true;
 
     const formValue: SentenceGenerationSettings = deepCopy(this.form.value) as unknown as SentenceGenerationSettings;
 
@@ -238,14 +274,14 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
     this.sensitiveParams = [];
 
     const shouldConfirm =
-      this.llmEngine.value &&
-      this.currentLlmEngine.params.some((entry) => {
+      this.llmProvider.value &&
+      this.currentLlmProvider.params.some((entry) => {
         return entry.confirmExport;
       });
 
     if (shouldConfirm) {
-      [{ label: 'LLM engine', key: AiEngineSettingKeyName.llmSetting, params: this.currentLlmEngine.params }].forEach((engine) => {
-        this.currentLlmEngine.params.forEach((entry) => {
+      [{ label: 'LLM engine', key: AiEngineSettingKeyName.llmSetting, params: this.currentLlmProvider.params }].forEach((engine) => {
+        this.currentLlmProvider.params.forEach((entry) => {
           if (entry.confirmExport) {
             this.sensitiveParams.push({ label: 'LLM engine', key: engine.key, include: false, param: entry });
           }
@@ -271,7 +307,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
 
   downloadSettings() {
     const formValue: SentenceGenerationSettings = deepCopy(this.form.value) as unknown as SentenceGenerationSettings;
-    delete formValue['llmEngine'];
+    delete formValue['llmProvider'];
     delete formValue['id'];
     delete formValue['enabled'];
 

--- a/bot/admin/web/src/app/configuration/vector-db-settings/models/providers-configuration.ts
+++ b/bot/admin/web/src/app/configuration/vector-db-settings/models/providers-configuration.ts
@@ -19,18 +19,7 @@ export const ProvidersConfigurations: VectorDbProvidersConfiguration[] = [
       { key: 'host', label: 'Host', type: 'text', defaultValue: 'localhost' },
       { key: 'port', label: 'Port', type: 'number', numberControlType: 'input', min: 1, max: 65535, step: 1, defaultValue: '9200' },
       { key: 'username', label: 'User name', type: 'obfuscated', defaultValue: 'admin' },
-      { key: 'password', label: 'Password', type: 'obfuscated', defaultValue: 'admin', confirmExport: true },
-      {
-        key: 'k',
-        label: 'k-nearest neighbors',
-        type: 'number',
-        numberControlType: 'input',
-        min: 1,
-        max: 100,
-        step: 1,
-        defaultValue: 4,
-        information: 'Maximum number of nearest neighbors to return in search queries'
-      }
+      { key: 'password', label: 'Password', type: 'obfuscated', defaultValue: 'admin', confirmExport: true }
     ]
   },
   {
@@ -41,17 +30,6 @@ export const ProvidersConfigurations: VectorDbProvidersConfiguration[] = [
       { key: 'port', label: 'Port', type: 'number', numberControlType: 'input', min: 1, max: 65535, step: 1, defaultValue: '5432' },
       { key: 'username', label: 'User name', type: 'obfuscated', defaultValue: 'postgres' },
       { key: 'password', label: 'Password', type: 'obfuscated', defaultValue: 'ChangeMe', confirmExport: true },
-      {
-        key: 'k',
-        label: 'k-nearest neighbors',
-        type: 'number',
-        numberControlType: 'input',
-        min: 1,
-        max: 100,
-        step: 1,
-        defaultValue: 4,
-        information: 'Maximum number of nearest neighbors to return in search queries'
-      },
       {
         key: 'database',
         label: 'Database',

--- a/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.html
+++ b/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.html
@@ -67,82 +67,92 @@
   *ngIf="configurations?.length > 0"
 >
   <nb-card class="mt-2">
-    <nb-card-body [nbSpinner]="loading">
-      <h5 class="section-title">Vector DB activation</h5>
-
-      <tock-form-control
-        name="enabled"
-        [controls]="enabled"
-        [showError]="isSubmitted"
-        [hasMargin]="false"
-      >
-        <nb-toggle
-          formControlName="enabled"
-          class="mt-1"
-        >
-          <span *ngIf="enabled.value">Vector DB activated</span>
-          <span *ngIf="!enabled.value">Vector DB deactivated</span>
-        </nb-toggle>
-      </tock-form-control>
-
-      <h5 class="section-title">
-        Vector DB provider for application <i>{{ state.currentApplication.name }}</i>
-      </h5>
-
-      <tock-form-control
-        name="vectorDbProvider"
-        [controls]="vectorDbProvider"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="vectorDbProvider"
-          name="vectorDbProvider"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let provider of providersConfigurations"
-            [value]="provider.key"
+    <nb-card-body
+      [nbSpinner]="loading"
+      class="pb-0"
+    >
+      <nb-card class="mt-2">
+        <nb-card-header>Vector DB activation</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="enabled"
+            [controls]="enabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
           >
-            {{ provider.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
-
-      <div
-        *ngIf="currentVectorDbProvider"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentVectorDbProvider.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            <nb-toggle
+              formControlName="enabled"
+              class="mt-1"
             >
-              <tock-ai-settings-engine-config-param-input
-                parentGroup="setting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-              ></tock-ai-settings-engine-config-param-input>
+              <span *ngIf="enabled.value">Vector DB activated</span>
+              <span *ngIf="!enabled.value">Vector DB deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card>
+        <nb-card-header>
+          Vector DB provider for application <i>{{ state.currentApplication.name }}</i>
+        </nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="vectorDbProvider"
+            [controls]="vectorDbProvider"
+            [required]="true"
+            [showError]="isSubmitted"
+          >
+            <nb-radio-group
+              formControlName="vectorDbProvider"
+              name="vectorDbProvider"
+              class="d-flex"
+            >
+              <nb-radio
+                *ngFor="let provider of providersConfigurations"
+                [value]="provider.key"
+              >
+                {{ provider.label }}
+              </nb-radio>
+            </nb-radio-group>
+          </tock-form-control>
+
+          <div
+            *ngIf="currentVectorDbProvider"
+            class="mt-2 mb-2"
+          >
+            <div class="row mb-1">
+              <ng-container *ngFor="let param of currentVectorDbProvider.params">
+                <div
+                  class="col-6 px-3"
+                  [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                >
+                  <tock-ai-settings-engine-config-param-input
+                    parentGroup="setting"
+                    [configurationParam]="param"
+                    [form]="form"
+                    [isSubmitted]="isSubmitted"
+                  ></tock-ai-settings-engine-config-param-input>
+                </div>
+              </ng-container>
             </div>
-          </ng-container>
-        </div>
-      </div>
+          </div>
+        </nb-card-body>
+      </nb-card>
 
-      <ng-container *ngIf="settingsBackup">
-        <h5 class="section-title mt-2">Settings deletion</h5>
-
-        <button
-          nbButton
-          status="danger"
-          nbTooltip="Delete settings"
-          (click)="confirmSettingsDeletion()"
-        >
-          <nb-icon icon="trash"></nb-icon>
-          DELETE SETTINGS
-        </button>
-      </ng-container>
+      <nb-card *ngIf="settingsBackup">
+        <nb-card-header>Settings deletion</nb-card-header>
+        <nb-card-body>
+          <button
+            nbButton
+            status="danger"
+            nbTooltip="Delete settings"
+            (click)="confirmSettingsDeletion()"
+          >
+            <nb-icon icon="trash"></nb-icon>
+            DELETE SETTINGS
+          </button>
+        </nb-card-body>
+      </nb-card>
     </nb-card-body>
   </nb-card>
 </form>

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.html
@@ -4,7 +4,7 @@
   [nbSpinner]="loading"
 >
   <nb-card-header>
-    <div class="d-flex justify-content-between align-items-start">
+    <div class="d-flex justify-content-between align-items-center">
       <div class="ellipsis initial-capitalize">
         {{ faq?.id ? faq.title : 'New faq' }}
       </div>

--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -7,7 +7,8 @@ import {
   OllamaLlmModelsList,
   OpenAIEmbeddingModel,
   OpenAIModelsList,
-  ProvidersConfigurationParam
+  ProvidersConfigurationParam,
+  PromptDefinitionFormatter
 } from '../../../shared/model/ai-settings';
 
 export const QuestionCondensingDefaultPrompt: string = `Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be nderstood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is.`;
@@ -46,8 +47,8 @@ export const QuestionCondensing_prompt: ProvidersConfigurationParam[] = [
     key: 'formatter',
     label: 'Prompt template format',
     type: 'radio',
-    source: ['jinja2', 'f-string'],
-    defaultValue: 'jinja2',
+    source: [PromptDefinitionFormatter.jinja2, PromptDefinitionFormatter.fstring],
+    defaultValue: PromptDefinitionFormatter.jinja2,
     inputScale: 'fullwidth'
   },
   {
@@ -56,7 +57,7 @@ export const QuestionCondensing_prompt: ProvidersConfigurationParam[] = [
     type: 'prompt',
     inputScale: 'fullwidth',
     defaultValue: QuestionCondensingDefaultPrompt,
-    information: 'LangChain ChatPromptTemplate'
+    information: "See LangChain's ChatPromptTemplate for more infos"
   }
 ];
 
@@ -65,8 +66,8 @@ export const QuestionAnswering_prompt: ProvidersConfigurationParam[] = [
     key: 'formatter',
     label: 'Prompt template format',
     type: 'radio',
-    source: ['jinja2', 'f-string'],
-    defaultValue: 'jinja2',
+    source: [PromptDefinitionFormatter.jinja2, PromptDefinitionFormatter.fstring],
+    defaultValue: PromptDefinitionFormatter.jinja2,
     inputScale: 'fullwidth'
   },
   {
@@ -150,11 +151,11 @@ export const EnginesConfigurations: {
   [K in Extract<
     AiEngineSettingKeyName,
     | AiEngineSettingKeyName.questionAnsweringLlmSetting
-    | AiEngineSettingKeyName.condenseQuestionLlmSetting
+    | AiEngineSettingKeyName.questionCondensingLlmSetting
     | AiEngineSettingKeyName.emSetting
   >]: EnginesConfiguration[];
 } = {
-  condenseQuestionLlmSetting: EnginesConfigurations_Llm,
+  questionCondensingLlmSetting: EnginesConfigurations_Llm,
   questionAnsweringLlmSetting: EnginesConfigurations_Llm,
   emSetting: EnginesConfigurations_Embedding
 };

--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -75,7 +75,8 @@ export const QuestionAnswering_prompt: ProvidersConfigurationParam[] = [
     label: 'Prompt template',
     type: 'prompt',
     inputScale: 'fullwidth',
-    defaultValue: QuestionAnsweringDefaultPrompt
+    defaultValue: QuestionAnsweringDefaultPrompt,
+    rows: 16
   }
 ];
 
@@ -88,7 +89,6 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
       { key: 'baseUrl', label: 'Base url', type: 'text', defaultValue: 'https://api.openai.com/v1' },
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
       { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
-      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   },
   {
@@ -101,7 +101,6 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
       { key: 'apiBase', label: 'Base url', type: 'obfuscated' },
       { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
-      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   },
   {
@@ -111,7 +110,6 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
       { key: 'baseUrl', label: 'BaseUrl', type: 'text', defaultValue: 'http://localhost:11434' },
       { key: 'model', label: 'Model', type: 'openlist', source: OllamaLlmModelsList, defaultValue: 'llama2' },
       { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05, defaultValue: 0.7 }
-      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   }
 ];

--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -29,33 +29,54 @@ Your tone is empathetic, informative and polite.
 ## Additional instructions
 
 Use the following pieces of retrieved context to answer the question.
-If you dont know the answer, answer (exactly) with "{no_answer}".
-Answer in {locale}.
+If you dont know the answer, answer (exactly) with "{{no_answer}}".
+Answer in {{locale}}.
 
 ## Context
 
-{context}
+{{context}}
 
 ## Question
 
-{question}
+{{question}}
 `;
 
-export const QuestionCondensing_prompt_ConfigurationParam: ProvidersConfigurationParam = {
-  key: 'template',
-  label: 'Condensing prompt',
-  type: 'prompt',
-  inputScale: 'fullwidth',
-  defaultValue: QuestionCondensingDefaultPrompt
-};
+export const QuestionCondensing_prompt: ProvidersConfigurationParam[] = [
+  {
+    key: 'formatter',
+    label: 'Prompt template format',
+    type: 'radio',
+    source: ['jinja2', 'f-string'],
+    defaultValue: 'jinja2',
+    inputScale: 'fullwidth'
+  },
+  {
+    key: 'template',
+    label: 'Prompt template',
+    type: 'prompt',
+    inputScale: 'fullwidth',
+    defaultValue: QuestionCondensingDefaultPrompt,
+    information: 'LangChain ChatPromptTemplate'
+  }
+];
 
-export const QuestionAnswering_prompt_ConfigurationParam: ProvidersConfigurationParam = {
-  key: 'template',
-  label: 'Answering prompt',
-  type: 'prompt',
-  inputScale: 'fullwidth',
-  defaultValue: QuestionAnsweringDefaultPrompt
-};
+export const QuestionAnswering_prompt: ProvidersConfigurationParam[] = [
+  {
+    key: 'formatter',
+    label: 'Prompt template format',
+    type: 'radio',
+    source: ['jinja2', 'f-string'],
+    defaultValue: 'jinja2',
+    inputScale: 'fullwidth'
+  },
+  {
+    key: 'template',
+    label: 'Prompt template',
+    type: 'prompt',
+    inputScale: 'fullwidth',
+    defaultValue: QuestionAnsweringDefaultPrompt
+  }
+];
 
 const EnginesConfigurations_Llm: EnginesConfiguration[] = [
   {

--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -6,10 +6,13 @@ import {
   OllamaEmModelsList,
   OllamaLlmModelsList,
   OpenAIEmbeddingModel,
-  OpenAIModelsList
+  OpenAIModelsList,
+  ProvidersConfigurationParam
 } from '../../../shared/model/ai-settings';
 
-export const DefaultPrompt: string = `# TOCK (The Open Conversation Kit) chatbot
+export const QuestionCondensingDefaultPrompt: string = `Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be nderstood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is.`;
+
+export const QuestionAnsweringDefaultPrompt: string = `# TOCK (The Open Conversation Kit) chatbot
 
 ## General context
 
@@ -38,6 +41,22 @@ Answer in {locale}.
 {question}
 `;
 
+export const QuestionCondensing_prompt_ConfigurationParam: ProvidersConfigurationParam = {
+  key: 'template',
+  label: 'Condensing prompt',
+  type: 'prompt',
+  inputScale: 'fullwidth',
+  defaultValue: QuestionCondensingDefaultPrompt
+};
+
+export const QuestionAnswering_prompt_ConfigurationParam: ProvidersConfigurationParam = {
+  key: 'template',
+  label: 'Answering prompt',
+  type: 'prompt',
+  inputScale: 'fullwidth',
+  defaultValue: QuestionAnsweringDefaultPrompt
+};
+
 const EnginesConfigurations_Llm: EnginesConfiguration[] = [
   {
     label: 'OpenAI',
@@ -46,8 +65,8 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
       { key: 'apiKey', label: 'Api key', type: 'obfuscated', confirmExport: true },
       { key: 'baseUrl', label: 'Base url', type: 'text', defaultValue: 'https://api.openai.com/v1' },
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
+      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   },
   {
@@ -59,8 +78,8 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
       { key: 'deploymentName', label: 'Deployment name', type: 'text' },
       { key: 'model', label: 'Model name', type: 'openlist', source: OpenAIModelsList },
       { key: 'apiBase', label: 'Base url', type: 'obfuscated' },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05 }
+      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   },
   {
@@ -69,8 +88,8 @@ const EnginesConfigurations_Llm: EnginesConfiguration[] = [
     params: [
       { key: 'baseUrl', label: 'BaseUrl', type: 'text', defaultValue: 'http://localhost:11434' },
       { key: 'model', label: 'Model', type: 'openlist', source: OllamaLlmModelsList, defaultValue: 'llama2' },
-      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05, defaultValue: 0.7 },
-      { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
+      { key: 'temperature', label: 'Temperature', type: 'number', inputScale: 'fullwidth', min: 0, max: 1, step: 0.05, defaultValue: 0.7 }
+      // { key: 'prompt', label: 'Prompt', type: 'prompt', inputScale: 'fullwidth', defaultValue: DefaultPrompt }
     ]
   }
 ];
@@ -106,7 +125,15 @@ const EnginesConfigurations_Embedding: EnginesConfiguration[] = [
   }
 ];
 
-export const EnginesConfigurations: { [K in AiEngineSettingKeyName]: EnginesConfiguration[] } = {
-  llmSetting: EnginesConfigurations_Llm,
+export const EnginesConfigurations: {
+  [K in Extract<
+    AiEngineSettingKeyName,
+    | AiEngineSettingKeyName.questionAnsweringLlmSetting
+    | AiEngineSettingKeyName.condenseQuestionLlmSetting
+    | AiEngineSettingKeyName.emSetting
+  >]: EnginesConfiguration[];
+} = {
+  condenseQuestionLlmSetting: EnginesConfigurations_Llm,
+  questionAnsweringLlmSetting: EnginesConfigurations_Llm,
   emSetting: EnginesConfigurations_Embedding
 };

--- a/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
@@ -1,4 +1,4 @@
-import { emSetting, llmSetting } from '../../../shared/model/ai-settings';
+import { emSetting, llmSetting, promptDefinition } from '../../../shared/model/ai-settings';
 
 export interface RagSettings {
   id: string;
@@ -9,7 +9,12 @@ export interface RagSettings {
   noAnswerSentence: string;
   noAnswerStoryId: string | null;
 
-  llmSetting: llmSetting;
+  condenseQuestionLlmSetting: llmSetting;
+  condenseQuestionPrompt: promptDefinition;
+
+  questionAnsweringLlmSetting: llmSetting;
+  questionAnsweringPrompt: promptDefinition;
+
   emSetting: emSetting;
 
   indexSessionId: string;

--- a/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
@@ -6,11 +6,14 @@ export interface RagSettings {
   botId: string;
   enabled: boolean;
 
+  debugEnabled: boolean;
+
   noAnswerSentence: string;
   noAnswerStoryId: string | null;
 
-  condenseQuestionLlmSetting: llmSetting;
-  condenseQuestionPrompt: promptDefinition;
+  questionCondensingLlmSetting: llmSetting;
+  questionCondensingPrompt: promptDefinition;
+  maxMessagesFromHistory: number;
 
   questionAnsweringLlmSetting: llmSetting;
   questionAnsweringPrompt: promptDefinition;
@@ -19,6 +22,8 @@ export interface RagSettings {
 
   indexSessionId: string;
   indexName: string;
+
+  maxDocumentsRetrieved: number;
 
   documentsRequired: boolean;
 }

--- a/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/rag-settings.ts
@@ -1,4 +1,4 @@
-import { emSetting, llmSetting, promptDefinition } from '../../../shared/model/ai-settings';
+import { emSetting, llmSetting, PromptDefinition } from '../../../shared/model/ai-settings';
 
 export interface RagSettings {
   id: string;
@@ -12,11 +12,11 @@ export interface RagSettings {
   noAnswerStoryId: string | null;
 
   questionCondensingLlmSetting: llmSetting;
-  questionCondensingPrompt: promptDefinition;
+  questionCondensingPrompt: PromptDefinition;
   maxMessagesFromHistory: number;
 
   questionAnsweringLlmSetting: llmSetting;
-  questionAnsweringPrompt: promptDefinition;
+  questionAnsweringPrompt: PromptDefinition;
 
   emSetting: emSetting;
 

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -74,294 +74,375 @@
   *ngIf="configurations?.length > 0"
 >
   <nb-card class="mt-1">
-    <nb-card-body [nbSpinner]="loading">
-      <h5 class="section-title">RAG activation</h5>
-
-      <tock-form-control
-        name="enabled"
-        [controls]="enabled"
-        [showError]="isSubmitted"
-        [hasMargin]="false"
-      >
-        <nb-toggle
-          formControlName="enabled"
-          class="mt-1"
-        >
-          <span *ngIf="enabled.value">Rag activated</span>
-          <span *ngIf="!enabled.value">Rag deactivated</span>
-        </nb-toggle>
-      </tock-form-control>
-
-      <h5 class="section-title">Question condensing</h5>
-
-      <tock-form-control
-        name="condenseQuestionLlmEngine"
-        [controls]="condenseQuestionLlmEngine"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="condenseQuestionLlmEngine"
-          name="condenseQuestionLlmEngine"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.condenseQuestionLlmSetting]"
-            [value]="engine.key"
+    <nb-card-body
+      [nbSpinner]="loading"
+      class="pt-4"
+    >
+      <nb-card class="mb-3">
+        <nb-card-header>RAG activation</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            name="enabled"
+            [controls]="enabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
           >
-            {{ engine.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
-
-      <div
-        *ngIf="currentCondenseQuestionLlmEngine"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentCondenseQuestionLlmEngine.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            <nb-toggle
+              formControlName="enabled"
+              class="mt-1"
             >
-              <tock-ai-settings-engine-config-param-input
-                [parentGroup]="engineSettingKeyName.condenseQuestionLlmSetting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-              ></tock-ai-settings-engine-config-param-input>
-            </div>
-          </ng-container>
-          <div class="col-12 px-3">
-            <tock-ai-settings-engine-config-param-input
-              parentGroup="condenseQuestionPrompt"
-              [configurationParam]="questionCondensing_prompt_ConfigurationParam"
-              [form]="form"
-              [isSubmitted]="isSubmitted"
-              [defaultPrompt]="$any(questionCondensing_prompt_ConfigurationParam.defaultValue)"
-            ></tock-ai-settings-engine-config-param-input>
-          </div>
-        </div>
-      </div>
+              <span *ngIf="enabled.value">Rag activated</span>
+              <span *ngIf="!enabled.value">Rag deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
 
-      <h5 class="section-title">Question answering</h5>
-
-      <tock-form-control
-        name="questionAnsweringLlmEngine"
-        [controls]="questionAnsweringLlmEngine"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="questionAnsweringLlmEngine"
-          name="questionAnsweringLlmEngine"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.questionAnsweringLlmSetting]"
-            [value]="engine.key"
+      <nb-card class="mb-3">
+        <nb-card-header>Question condensing</nb-card-header>
+        <nb-card-body class="p-0">
+          <nb-accordion
+            multi
+            class="shadow-none"
           >
-            {{ engine.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionConsensingConfiguration')">
+              <nb-accordion-item-header>Configuration</nb-accordion-item-header>
+              <nb-accordion-item-body>
+                <tock-form-control
+                  name="condenseQuestionLlmEngine"
+                  [controls]="condenseQuestionLlmEngine"
+                  [required]="true"
+                  [showError]="isSubmitted"
+                >
+                  <nb-radio-group
+                    formControlName="condenseQuestionLlmEngine"
+                    name="condenseQuestionLlmEngine"
+                    class="d-flex"
+                  >
+                    <nb-radio
+                      *ngFor="let engine of enginesConfigurations[engineSettingKeyName.condenseQuestionLlmSetting]"
+                      [value]="engine.key"
+                    >
+                      {{ engine.label }}
+                    </nb-radio>
+                  </nb-radio-group>
+                </tock-form-control>
 
-      <div
-        *ngIf="currentQuestionAnsweringLlmEngine"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <ng-container *ngFor="let param of currentQuestionAnsweringLlmEngine.params">
-            <div
-              class="col-6 px-3"
-              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                <div
+                  *ngIf="currentCondenseQuestionLlmEngine"
+                  class="mt-2"
+                >
+                  <div class="row">
+                    <ng-container *ngFor="let param of currentCondenseQuestionLlmEngine.params">
+                      <div
+                        class="col-6 px-3"
+                        [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                      >
+                        <tock-ai-settings-engine-config-param-input
+                          [parentGroup]="engineSettingKeyName.condenseQuestionLlmSetting"
+                          [configurationParam]="param"
+                          [form]="form"
+                          [isSubmitted]="isSubmitted"
+                        ></tock-ai-settings-engine-config-param-input>
+                      </div>
+                    </ng-container>
+                  </div>
+                </div>
+              </nb-accordion-item-body>
+            </nb-accordion-item>
+
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionConsensingPprompt')">
+              <nb-accordion-item-header>Prompt</nb-accordion-item-header>
+              <nb-accordion-item-body>
+                <div class="row">
+                  <ng-container *ngFor="let param of questionCondensing_prompt">
+                    <div
+                      class="col-12 px-3"
+                      *ngIf="shouldDisplayPromptParam('condenseQuestionPrompt', param)"
+                    >
+                      <tock-ai-settings-engine-config-param-input
+                        parentGroup="condenseQuestionPrompt"
+                        [configurationParam]="param"
+                        [form]="form"
+                        [isSubmitted]="isSubmitted"
+                        [defaultPrompt]="$any(param.defaultValue)"
+                      ></tock-ai-settings-engine-config-param-input>
+                    </div>
+                  </ng-container>
+                </div>
+              </nb-accordion-item-body>
+            </nb-accordion-item>
+          </nb-accordion>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card class="mb-3">
+        <nb-card-header>Question answering</nb-card-header>
+        <nb-card-body class="p-0">
+          <nb-accordion
+            multi
+            class="shadow-none"
+          >
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionAnsweringConfiguration')">
+              <nb-accordion-item-header>Configuration</nb-accordion-item-header>
+              <nb-accordion-item-body>
+                <tock-form-control
+                  name="questionAnsweringLlmEngine"
+                  [controls]="questionAnsweringLlmEngine"
+                  [required]="true"
+                  [showError]="isSubmitted"
+                >
+                  <nb-radio-group
+                    formControlName="questionAnsweringLlmEngine"
+                    name="questionAnsweringLlmEngine"
+                    class="d-flex"
+                  >
+                    <nb-radio
+                      *ngFor="let engine of enginesConfigurations[engineSettingKeyName.questionAnsweringLlmSetting]"
+                      [value]="engine.key"
+                    >
+                      {{ engine.label }}
+                    </nb-radio>
+                  </nb-radio-group>
+                </tock-form-control>
+
+                <div
+                  *ngIf="currentQuestionAnsweringLlmEngine"
+                  class="mt-2"
+                >
+                  <div class="row">
+                    <ng-container *ngFor="let param of currentQuestionAnsweringLlmEngine.params">
+                      <div
+                        class="col-6 px-3"
+                        [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                      >
+                        <tock-ai-settings-engine-config-param-input
+                          [parentGroup]="engineSettingKeyName.questionAnsweringLlmSetting"
+                          [configurationParam]="param"
+                          [form]="form"
+                          [isSubmitted]="isSubmitted"
+                        ></tock-ai-settings-engine-config-param-input>
+                      </div>
+                    </ng-container>
+                  </div>
+                </div>
+              </nb-accordion-item-body>
+            </nb-accordion-item>
+
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionAnsweringPrompt')">
+              <nb-accordion-item-header>Prompt</nb-accordion-item-header>
+              <nb-accordion-item-body>
+                <div class="row">
+                  <ng-container *ngFor="let param of questionAnswering_prompt">
+                    <div
+                      class="col-12 px-3"
+                      *ngIf="shouldDisplayPromptParam('questionAnsweringPrompt', param)"
+                    >
+                      <tock-ai-settings-engine-config-param-input
+                        parentGroup="questionAnsweringPrompt"
+                        [configurationParam]="param"
+                        [form]="form"
+                        [isSubmitted]="isSubmitted"
+                        [defaultPrompt]="$any(param.defaultValue)"
+                      ></tock-ai-settings-engine-config-param-input>
+                    </div>
+                  </ng-container>
+                </div>
+              </nb-accordion-item-body>
+            </nb-accordion-item>
+          </nb-accordion>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card class="mb-3">
+        <nb-card-header>Embedding</nb-card-header>
+        <nb-card-body class="p-0">
+          <nb-accordion
+            multi
+            class="shadow-none"
+          >
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('embeddingConfiguration')">
+              <nb-accordion-item-header>Configuration</nb-accordion-item-header>
+              <nb-accordion-item-body>
+                <tock-form-control
+                  name="emEngine"
+                  [controls]="emEngine"
+                  [required]="true"
+                  [showError]="isSubmitted"
+                >
+                  <nb-radio-group
+                    formControlName="emEngine"
+                    name="emEngine"
+                    class="d-flex"
+                  >
+                    <nb-radio
+                      *ngFor="let engine of enginesConfigurations[engineSettingKeyName.emSetting]"
+                      [value]="engine.key"
+                    >
+                      {{ engine.label }}
+                    </nb-radio>
+                  </nb-radio-group>
+                </tock-form-control>
+
+                <div
+                  *ngIf="currentEmEngine"
+                  class="mt-2"
+                >
+                  <div class="row">
+                    <div
+                      class="col-6 px-3"
+                      *ngFor="let param of currentEmEngine.params"
+                    >
+                      <tock-ai-settings-engine-config-param-input
+                        [parentGroup]="engineSettingKeyName.emSetting"
+                        [configurationParam]="param"
+                        [form]="form"
+                        [isSubmitted]="isSubmitted"
+                      ></tock-ai-settings-engine-config-param-input>
+                    </div>
+                  </div>
+                </div>
+              </nb-accordion-item-body>
+            </nb-accordion-item>
+          </nb-accordion>
+        </nb-card-body>
+      </nb-card>
+
+      <nb-card class="mb-3">
+        <nb-card-header>Indexing session</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            label="Vector database index name"
+            name="indexName"
+            [controls]="indexName"
+            [required]="false"
+            [boldLabel]="false"
+          >
+            <input
+              nbInput
+              fullWidth
+              formControlName="indexName"
+              readonly
+            />
+          </tock-form-control>
+
+          <tock-form-control
+            label="Indexing session id"
+            name="indexingSessionId"
+            [controls]="indexSessionId"
+            [required]="false"
+            [showError]="isSubmitted"
+            [boldLabel]="false"
+          >
+            <input
+              nbInput
+              fullWidth
+              formControlName="indexSessionId"
+            />
+          </tock-form-control>
+
+          <tock-form-control
+            label="Documents required"
+            name="documentsRequired"
+            [controls]="documentsRequired"
+            [required]="false"
+            [boldLabel]="false"
+            information="Allowing the LLM to answer even if no documents have been found allows to make small talk and answer more general questions."
+          >
+            <nb-toggle
+              formControlName="documentsRequired"
+              class="nb-toggle-small"
             >
-              <tock-ai-settings-engine-config-param-input
-                [parentGroup]="engineSettingKeyName.questionAnsweringLlmSetting"
-                [configurationParam]="param"
-                [form]="form"
-                [isSubmitted]="isSubmitted"
-              ></tock-ai-settings-engine-config-param-input>
-            </div>
-          </ng-container>
-          <div class="col-12 px-3">
-            <tock-ai-settings-engine-config-param-input
-              parentGroup="questionAnsweringPrompt"
-              [configurationParam]="questionAnswering_prompt_ConfigurationParam"
-              [form]="form"
-              [isSubmitted]="isSubmitted"
-              [defaultPrompt]="$any(questionAnswering_prompt_ConfigurationParam.defaultValue)"
-            ></tock-ai-settings-engine-config-param-input>
-          </div>
-        </div>
-      </div>
+              <span *ngIf="documentsRequired.value">Don't allow undocumented answers</span>
+              <span *ngIf="!documentsRequired.value">Allow undocumented answers</span>
+            </nb-toggle>
+          </tock-form-control>
+        </nb-card-body>
+      </nb-card>
 
-      <h5 class="section-title mt-2">Embedding engine</h5>
-
-      <tock-form-control
-        name="emEngine"
-        [controls]="emEngine"
-        [required]="true"
-        [showError]="isSubmitted"
-      >
-        <nb-radio-group
-          formControlName="emEngine"
-          name="emEngine"
-          class="d-flex"
-        >
-          <nb-radio
-            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.emSetting]"
-            [value]="engine.key"
+      <nb-card class="mb-3">
+        <nb-card-header>Conversation flow</nb-card-header>
+        <nb-card-body>
+          <tock-form-control
+            label="No answer sentence"
+            name="noAnswerSentence"
+            [controls]="noAnswerSentence"
+            [required]="true"
+            [showError]="isSubmitted"
+            [boldLabel]="false"
+            information="Phrase to be displayed to the user if no response could be given to his request"
           >
-            {{ engine.label }}
-          </nb-radio>
-        </nb-radio-group>
-      </tock-form-control>
+            <input
+              nbInput
+              fullWidth
+              formControlName="noAnswerSentence"
+            />
+          </tock-form-control>
 
-      <div
-        *ngIf="currentEmEngine"
-        class="mt-2 mb-2"
-      >
-        <div class="row mb-1">
-          <div
-            class="col-6 px-3"
-            *ngFor="let param of currentEmEngine.params"
+          <tock-form-control
+            label="Unanswered story redirection"
+            name="noAnswerStoryId"
+            [controls]="noAnswerStoryId"
+            [showError]="isSubmitted"
+            [boldLabel]="false"
+            information="Story to redirect the user to if no answer is given to the request"
           >
-            <tock-ai-settings-engine-config-param-input
-              [parentGroup]="engineSettingKeyName.emSetting"
-              [configurationParam]="param"
-              [form]="form"
-              [isSubmitted]="isSubmitted"
-            ></tock-ai-settings-engine-config-param-input>
-          </div>
-        </div>
-      </div>
+            <nb-form-field>
+              <input
+                nbInput
+                fullWidth
+                autocomplete="off"
+                type="text"
+                [value]="getCurrentStoryLabel"
+                [nbAutocomplete]="storiesautocomplete"
+                (input)="filterStoriesList($any($event.target).value)"
+                (change)="onStoryChange($any($event.target).value)"
+                (focus)="storyInputFocus()"
+                (blur)="storyInputBlur($event)"
+              />
+              <button
+                nbSuffix
+                nbButton
+                ghost
+                nbTooltip="Delete unanswered story redirection"
+                (click)="removeNoAnswerStoryId()"
+                *ngIf="getCurrentStoryLabel !== ''"
+              >
+                <nb-icon icon="x-lg"></nb-icon>
+              </button>
+            </nb-form-field>
+          </tock-form-control>
 
-      <h5 class="section-title mt-2">Indexing session</h5>
+          <nb-autocomplete
+            #storiesautocomplete
+            optionsListClass="option-list--break-word"
+            (selectedChange)="storySelectedChange($event)"
+          >
+            <nb-option
+              *ngFor="let option of filteredStories$ | async"
+              [value]="option.storyId"
+              [disabled]="!isStoryEnabled(option)"
+            >
+              {{ option.name }} <span *ngIf="!isStoryEnabled(option)"> &nbsp;(disabled)</span>
+            </nb-option>
+          </nb-autocomplete>
+        </nb-card-body>
+      </nb-card>
 
-      <tock-form-control
-        label="Vector database index name"
-        name="indexName"
-        [controls]="indexName"
-        [required]="false"
-        [boldLabel]="false"
-      >
-        <input
-          nbInput
-          fullWidth
-          formControlName="indexName"
-          readonly
-        />
-      </tock-form-control>
-
-      <tock-form-control
-        label="Indexing session id"
-        name="indexingSessionId"
-        [controls]="indexSessionId"
-        [required]="false"
-        [showError]="isSubmitted"
-        [boldLabel]="false"
-      >
-        <input
-          nbInput
-          fullWidth
-          formControlName="indexSessionId"
-        />
-      </tock-form-control>
-
-      <tock-form-control
-        label="Documents required"
-        name="documentsRequired"
-        [controls]="documentsRequired"
-        [required]="false"
-        [boldLabel]="false"
-        information="Allowing the LLM to answer even if no documents have been found allows to make small talk and answer more general questions."
-      >
-        <nb-checkbox formControlName="documentsRequired">
-          <span *ngIf="documentsRequired.value">Don't allow undocumented answers.</span>
-          <span *ngIf="!documentsRequired.value">Allow undocumented answers.</span>
-        </nb-checkbox>
-      </tock-form-control>
-
-      <h5 class="section-title mt-2">Conversation flow</h5>
-
-      <tock-form-control
-        label="No answer sentence"
-        name="noAnswerSentence"
-        [controls]="noAnswerSentence"
-        [required]="true"
-        [showError]="isSubmitted"
-        [boldLabel]="false"
-        information="Phrase to be displayed to the user if no response could be given to his request"
-      >
-        <input
-          nbInput
-          fullWidth
-          formControlName="noAnswerSentence"
-        />
-      </tock-form-control>
-
-      <tock-form-control
-        label="Unanswered story redirection"
-        name="noAnswerStoryId"
-        [controls]="noAnswerStoryId"
-        [showError]="isSubmitted"
-        [boldLabel]="false"
-        information="Story to redirect the user to if no answer is given to the request"
-      >
-        <nb-form-field>
-          <input
-            nbInput
-            fullWidth
-            autocomplete="off"
-            type="text"
-            [value]="getCurrentStoryLabel"
-            [nbAutocomplete]="storiesautocomplete"
-            (input)="filterStoriesList($any($event.target).value)"
-            (change)="onStoryChange($any($event.target).value)"
-            (focus)="storyInputFocus()"
-            (blur)="storyInputBlur($event)"
-          />
+      <nb-card *ngIf="settingsBackup">
+        <nb-card-header>Settings deletion</nb-card-header>
+        <nb-card-body>
           <button
-            nbSuffix
             nbButton
-            ghost
-            nbTooltip="Delete unanswered story redirection"
-            (click)="removeNoAnswerStoryId()"
-            *ngIf="getCurrentStoryLabel !== ''"
+            status="danger"
+            nbTooltip="Delete settings"
+            (click)="confirmSettingsDeletion()"
           >
-            <nb-icon icon="x-lg"></nb-icon>
+            <nb-icon icon="trash"></nb-icon>
+            DELETE SETTINGS
           </button>
-        </nb-form-field>
-      </tock-form-control>
-
-      <nb-autocomplete
-        #storiesautocomplete
-        optionsListClass="option-list--break-word"
-        (selectedChange)="storySelectedChange($event)"
-      >
-        <nb-option
-          *ngFor="let option of filteredStories$ | async"
-          [value]="option.storyId"
-          [disabled]="!isStoryEnabled(option)"
-        >
-          {{ option.name }} <span *ngIf="!isStoryEnabled(option)"> &nbsp;(disabled)</span>
-        </nb-option>
-      </nb-autocomplete>
-
-      <ng-container *ngIf="settingsBackup">
-        <h5 class="section-title mt-2">Settings deletion</h5>
-
-        <button
-          nbButton
-          status="danger"
-          nbTooltip="Delete settings"
-          (click)="confirmSettingsDeletion()"
-        >
-          <nb-icon icon="trash"></nb-icon>
-          DELETE SETTINGS
-        </button>
-      </ng-container>
+        </nb-card-body>
+      </nb-card>
     </nb-card-body>
   </nb-card>
 </form>

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -76,11 +76,11 @@
   <nb-card class="mt-1">
     <nb-card-body
       [nbSpinner]="loading"
-      class="pt-4"
+      class="pb-0"
     >
-      <nb-card class="mb-3">
+      <nb-card class="mt-2 mb-3">
         <nb-card-header>RAG activation</nb-card-header>
-        <nb-card-body>
+        <nb-card-body class="d-flex gap-2 align-items-start">
           <tock-form-control
             name="enabled"
             [controls]="enabled"
@@ -93,6 +93,22 @@
             >
               <span *ngIf="enabled.value">Rag activated</span>
               <span *ngIf="!enabled.value">Rag deactivated</span>
+            </nb-toggle>
+          </tock-form-control>
+
+          <tock-form-control
+            name="debugEnabled"
+            [controls]="debugEnabled"
+            [showError]="isSubmitted"
+            [hasMargin]="false"
+          >
+            <nb-toggle
+              formControlName="debugEnabled"
+              class="nb-toggle-small mt-2"
+              status="basic"
+            >
+              <span *ngIf="debugEnabled.value">Debug activated</span>
+              <span *ngIf="!debugEnabled.value">Debug deactivated</span>
             </nb-toggle>
           </tock-form-control>
         </nb-card-body>
@@ -109,18 +125,18 @@
               <nb-accordion-item-header>Configuration</nb-accordion-item-header>
               <nb-accordion-item-body>
                 <tock-form-control
-                  name="condenseQuestionLlmEngine"
-                  [controls]="condenseQuestionLlmEngine"
+                  name="questionCondensingLlmProvider"
+                  [controls]="questionCondensingLlmProvider"
                   [required]="true"
                   [showError]="isSubmitted"
                 >
                   <nb-radio-group
-                    formControlName="condenseQuestionLlmEngine"
-                    name="condenseQuestionLlmEngine"
+                    formControlName="questionCondensingLlmProvider"
+                    name="questionCondensingLlmProvider"
                     class="d-flex"
                   >
                     <nb-radio
-                      *ngFor="let engine of enginesConfigurations[engineSettingKeyName.condenseQuestionLlmSetting]"
+                      *ngFor="let engine of enginesConfigurations[engineSettingKeyName.questionCondensingLlmSetting]"
                       [value]="engine.key"
                     >
                       {{ engine.label }}
@@ -129,17 +145,17 @@
                 </tock-form-control>
 
                 <div
-                  *ngIf="currentCondenseQuestionLlmEngine"
+                  *ngIf="currentQuestionCondensingConfig"
                   class="mt-2"
                 >
                   <div class="row">
-                    <ng-container *ngFor="let param of currentCondenseQuestionLlmEngine.params">
+                    <ng-container *ngFor="let param of currentQuestionCondensingConfig.params">
                       <div
                         class="col-6 px-3"
                         [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
                       >
                         <tock-ai-settings-engine-config-param-input
-                          [parentGroup]="engineSettingKeyName.condenseQuestionLlmSetting"
+                          [parentGroup]="engineSettingKeyName.questionCondensingLlmSetting"
                           [configurationParam]="param"
                           [form]="form"
                           [isSubmitted]="isSubmitted"
@@ -151,17 +167,17 @@
               </nb-accordion-item-body>
             </nb-accordion-item>
 
-            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionConsensingPprompt')">
+            <nb-accordion-item [expanded]="isAccordionItemsExpanded('questionCondensingPrompt')">
               <nb-accordion-item-header>Prompt</nb-accordion-item-header>
               <nb-accordion-item-body>
                 <div class="row">
                   <ng-container *ngFor="let param of questionCondensing_prompt">
                     <div
                       class="col-12 px-3"
-                      *ngIf="shouldDisplayPromptParam('condenseQuestionPrompt', param)"
+                      *ngIf="shouldDisplayPromptParam('questionCondensingPrompt', param)"
                     >
                       <tock-ai-settings-engine-config-param-input
-                        parentGroup="condenseQuestionPrompt"
+                        parentGroup="questionCondensingPrompt"
                         [configurationParam]="param"
                         [form]="form"
                         [isSubmitted]="isSubmitted"
@@ -169,6 +185,29 @@
                       ></tock-ai-settings-engine-config-param-input>
                     </div>
                   </ng-container>
+
+                  <div class="col-6 px-3">
+                    <tock-form-control
+                      label="Max number of messages in history"
+                      name="maxMessagesFromHistory"
+                      [controls]="maxMessagesFromHistory"
+                      [required]="false"
+                      [showError]="isSubmitted"
+                      [boldLabel]="false"
+                      information="Number of messages in the dialog history to be taken into account when condensing the question. Zero = no history."
+                    >
+                      <input
+                        type="number"
+                        step="1"
+                        min="0"
+                        max="20"
+                        nbInput
+                        fieldSize="small"
+                        fullWidth
+                        formControlName="maxMessagesFromHistory"
+                      />
+                    </tock-form-control>
+                  </div>
                 </div>
               </nb-accordion-item-body>
             </nb-accordion-item>
@@ -187,14 +226,14 @@
               <nb-accordion-item-header>Configuration</nb-accordion-item-header>
               <nb-accordion-item-body>
                 <tock-form-control
-                  name="questionAnsweringLlmEngine"
-                  [controls]="questionAnsweringLlmEngine"
+                  name="questionAnsweringLlmProvider"
+                  [controls]="questionAnsweringLlmProvider"
                   [required]="true"
                   [showError]="isSubmitted"
                 >
                   <nb-radio-group
-                    formControlName="questionAnsweringLlmEngine"
-                    name="questionAnsweringLlmEngine"
+                    formControlName="questionAnsweringLlmProvider"
+                    name="questionAnsweringLlmProvider"
                     class="d-flex"
                   >
                     <nb-radio
@@ -207,11 +246,11 @@
                 </tock-form-control>
 
                 <div
-                  *ngIf="currentQuestionAnsweringLlmEngine"
+                  *ngIf="currentQuestionAnsweringConfig"
                   class="mt-2"
                 >
                   <div class="row">
-                    <ng-container *ngFor="let param of currentQuestionAnsweringLlmEngine.params">
+                    <ng-container *ngFor="let param of currentQuestionAnsweringConfig.params">
                       <div
                         class="col-6 px-3"
                         [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
@@ -265,14 +304,14 @@
               <nb-accordion-item-header>Configuration</nb-accordion-item-header>
               <nb-accordion-item-body>
                 <tock-form-control
-                  name="emEngine"
-                  [controls]="emEngine"
+                  name="emProvider"
+                  [controls]="emProvider"
                   [required]="true"
                   [showError]="isSubmitted"
                 >
                   <nb-radio-group
-                    formControlName="emEngine"
-                    name="emEngine"
+                    formControlName="emProvider"
+                    name="emProvider"
                     class="d-flex"
                   >
                     <nb-radio
@@ -285,13 +324,13 @@
                 </tock-form-control>
 
                 <div
-                  *ngIf="currentEmEngine"
+                  *ngIf="currentEmConfig"
                   class="mt-2"
                 >
                   <div class="row">
                     <div
                       class="col-6 px-3"
-                      *ngFor="let param of currentEmEngine.params"
+                      *ngFor="let param of currentEmConfig.params"
                     >
                       <tock-ai-settings-engine-config-param-input
                         [parentGroup]="engineSettingKeyName.emSetting"
@@ -341,22 +380,47 @@
             />
           </tock-form-control>
 
-          <tock-form-control
-            label="Documents required"
-            name="documentsRequired"
-            [controls]="documentsRequired"
-            [required]="false"
-            [boldLabel]="false"
-            information="Allowing the LLM to answer even if no documents have been found allows to make small talk and answer more general questions."
-          >
-            <nb-toggle
-              formControlName="documentsRequired"
-              class="nb-toggle-small"
-            >
-              <span *ngIf="documentsRequired.value">Don't allow undocumented answers</span>
-              <span *ngIf="!documentsRequired.value">Allow undocumented answers</span>
-            </nb-toggle>
-          </tock-form-control>
+          <div class="row">
+            <div class="col-6">
+              <tock-form-control
+                label="Max documents retrieved"
+                name="maxDocumentsRetrieved"
+                [controls]="maxDocumentsRetrieved"
+                [required]="false"
+                [boldLabel]="false"
+                information="Maximum number of documents to return in vector queries."
+              >
+                <input
+                  type="number"
+                  step="1"
+                  min="0"
+                  max="50"
+                  nbInput
+                  fieldSize="small"
+                  fullWidth
+                  formControlName="maxDocumentsRetrieved"
+                />
+              </tock-form-control>
+            </div>
+            <div class="col-6">
+              <tock-form-control
+                label="Documents required"
+                name="documentsRequired"
+                [controls]="documentsRequired"
+                [required]="false"
+                [boldLabel]="false"
+                information="Allow the LLM to respond even if no documents were retrieved. Allows to make small talk and answer more general questions."
+              >
+                <nb-toggle
+                  formControlName="documentsRequired"
+                  class="nb-toggle-small mt-1"
+                >
+                  <span *ngIf="documentsRequired.value">Don't allow undocumented answers</span>
+                  <span *ngIf="!documentsRequired.value">Allow undocumented answers</span>
+                </nb-toggle>
+              </tock-form-control>
+            </div>
+          </div>
         </nb-card-body>
       </nb-card>
 

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -151,8 +151,8 @@
                   <div class="row">
                     <ng-container *ngFor="let param of currentQuestionCondensingConfig.params">
                       <div
-                        class="col-6 px-3"
-                        [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                        class="col-12 px-3"
+                        [ngClass]="{ 'col-lg-6': param.inputScale !== 'fullwidth' }"
                       >
                         <tock-ai-settings-engine-config-param-input
                           [parentGroup]="engineSettingKeyName.questionCondensingLlmSetting"
@@ -252,8 +252,8 @@
                   <div class="row">
                     <ng-container *ngFor="let param of currentQuestionAnsweringConfig.params">
                       <div
-                        class="col-6 px-3"
-                        [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+                        class="col-12 px-3"
+                        [ngClass]="{ 'col-lg-6': param.inputScale !== 'fullwidth' }"
                       >
                         <tock-ai-settings-engine-config-param-input
                           [parentGroup]="engineSettingKeyName.questionAnsweringLlmSetting"
@@ -329,7 +329,8 @@
                 >
                   <div class="row">
                     <div
-                      class="col-6 px-3"
+                      class="col-12 px-3"
+                      [ngClass]="{ 'col-lg-6': param.inputScale !== 'fullwidth' }"
                       *ngFor="let param of currentEmConfig.params"
                     >
                       <tock-ai-settings-engine-config-param-input
@@ -350,38 +351,42 @@
       <nb-card class="mb-3">
         <nb-card-header>Indexing session</nb-card-header>
         <nb-card-body>
-          <tock-form-control
-            label="Vector database index name"
-            name="indexName"
-            [controls]="indexName"
-            [required]="false"
-            [boldLabel]="false"
-          >
-            <input
-              nbInput
-              fullWidth
-              formControlName="indexName"
-              readonly
-            />
-          </tock-form-control>
-
-          <tock-form-control
-            label="Indexing session id"
-            name="indexingSessionId"
-            [controls]="indexSessionId"
-            [required]="false"
-            [showError]="isSubmitted"
-            [boldLabel]="false"
-          >
-            <input
-              nbInput
-              fullWidth
-              formControlName="indexSessionId"
-            />
-          </tock-form-control>
-
           <div class="row">
-            <div class="col-6">
+            <div class="col-12 col-lg-6 px-3">
+              <tock-form-control
+                label="Indexing session id"
+                name="indexingSessionId"
+                [controls]="indexSessionId"
+                [required]="false"
+                [showError]="isSubmitted"
+                [boldLabel]="false"
+              >
+                <input
+                  nbInput
+                  fullWidth
+                  formControlName="indexSessionId"
+                />
+              </tock-form-control>
+            </div>
+
+            <div class="col-12 col-lg-6 px-3">
+              <tock-form-control
+                label="Vector database index name"
+                name="indexName"
+                [controls]="indexName"
+                [required]="false"
+                [boldLabel]="false"
+              >
+                <input
+                  nbInput
+                  fullWidth
+                  formControlName="indexName"
+                  readonly
+                />
+              </tock-form-control>
+            </div>
+
+            <div class="col-6 px-3">
               <tock-form-control
                 label="Max documents retrieved"
                 name="maxDocumentsRetrieved"
@@ -402,7 +407,8 @@
                 />
               </tock-form-control>
             </div>
-            <div class="col-6">
+
+            <div class="col-6 px-3">
               <tock-form-control
                 label="Documents required"
                 name="documentsRequired"
@@ -427,69 +433,74 @@
       <nb-card class="mb-3">
         <nb-card-header>Conversation flow</nb-card-header>
         <nb-card-body>
-          <tock-form-control
-            label="No answer sentence"
-            name="noAnswerSentence"
-            [controls]="noAnswerSentence"
-            [required]="true"
-            [showError]="isSubmitted"
-            [boldLabel]="false"
-            information="Phrase to be displayed to the user if no response could be given to his request"
-          >
-            <input
-              nbInput
-              fullWidth
-              formControlName="noAnswerSentence"
-            />
-          </tock-form-control>
-
-          <tock-form-control
-            label="Unanswered story redirection"
-            name="noAnswerStoryId"
-            [controls]="noAnswerStoryId"
-            [showError]="isSubmitted"
-            [boldLabel]="false"
-            information="Story to redirect the user to if no answer is given to the request"
-          >
-            <nb-form-field>
-              <input
-                nbInput
-                fullWidth
-                autocomplete="off"
-                type="text"
-                [value]="getCurrentStoryLabel"
-                [nbAutocomplete]="storiesautocomplete"
-                (input)="filterStoriesList($any($event.target).value)"
-                (change)="onStoryChange($any($event.target).value)"
-                (focus)="storyInputFocus()"
-                (blur)="storyInputBlur($event)"
-              />
-              <button
-                nbSuffix
-                nbButton
-                ghost
-                nbTooltip="Delete unanswered story redirection"
-                (click)="removeNoAnswerStoryId()"
-                *ngIf="getCurrentStoryLabel !== ''"
+          <div class="row">
+            <div class="col-12 px-3">
+              <tock-form-control
+                label="No answer sentence"
+                name="noAnswerSentence"
+                [controls]="noAnswerSentence"
+                [required]="true"
+                [showError]="isSubmitted"
+                [boldLabel]="false"
+                information="Phrase to be displayed to the user if no response could be given to his request"
               >
-                <nb-icon icon="x-lg"></nb-icon>
-              </button>
-            </nb-form-field>
-          </tock-form-control>
+                <input
+                  nbInput
+                  fullWidth
+                  formControlName="noAnswerSentence"
+                />
+              </tock-form-control>
+            </div>
+            <div class="col-12 px-3">
+              <tock-form-control
+                label="Unanswered story redirection"
+                name="noAnswerStoryId"
+                [controls]="noAnswerStoryId"
+                [showError]="isSubmitted"
+                [boldLabel]="false"
+                information="Story to redirect the user to if no answer is given to the request"
+              >
+                <nb-form-field>
+                  <input
+                    nbInput
+                    fullWidth
+                    autocomplete="off"
+                    type="text"
+                    [value]="getCurrentStoryLabel"
+                    [nbAutocomplete]="storiesautocomplete"
+                    (input)="filterStoriesList($any($event.target).value)"
+                    (change)="onStoryChange($any($event.target).value)"
+                    (focus)="storyInputFocus()"
+                    (blur)="storyInputBlur($event)"
+                  />
+                  <button
+                    nbSuffix
+                    nbButton
+                    ghost
+                    nbTooltip="Delete unanswered story redirection"
+                    (click)="removeNoAnswerStoryId()"
+                    *ngIf="getCurrentStoryLabel !== ''"
+                  >
+                    <nb-icon icon="x-lg"></nb-icon>
+                  </button>
+                </nb-form-field>
+              </tock-form-control>
 
-          <nb-autocomplete
-            #storiesautocomplete
-            optionsListClass="option-list--break-word"
-            (selectedChange)="storySelectedChange($event)"
-          >
-            <nb-option
-              *ngFor="let option of filteredStories$ | async"
-              [value]="option.storyId"
-              [disabled]="!isStoryEnabled(option)"
-            >
-              {{ option.name }} <span *ngIf="!isStoryEnabled(option)"> &nbsp;(disabled)</span>
-            </nb-option>
-          </nb-autocomplete>
+              <nb-autocomplete
+                #storiesautocomplete
+                optionsListClass="option-list--break-word"
+                (selectedChange)="storySelectedChange($event)"
+              >
+                <nb-option
+                  *ngFor="let option of filteredStories$ | async"
+                  [value]="option.storyId"
+                  [disabled]="!isStoryEnabled(option)"
+                >
+                  {{ option.name }} <span *ngIf="!isStoryEnabled(option)"> &nbsp;(disabled)</span>
+                </nb-option>
+              </nb-autocomplete>
+            </div>
+          </div>
         </nb-card-body>
       </nb-card>
 

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -106,9 +106,10 @@
               formControlName="debugEnabled"
               class="nb-toggle-small mt-2"
               status="basic"
+              nbTooltip="Include Rag debug info in dialog logs (Analytics > Dialogs)"
             >
-              <span *ngIf="debugEnabled.value">Debug activated</span>
-              <span *ngIf="!debugEnabled.value">Debug deactivated</span>
+              <span *ngIf="debugEnabled.value">Dialogs debug activated</span>
+              <span *ngIf="!debugEnabled.value">Dialogs debug deactivated</span>
             </nb-toggle>
           </tock-form-control>
         </nb-card-body>

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -92,21 +92,21 @@
         </nb-toggle>
       </tock-form-control>
 
-      <h5 class="section-title">LLM engine</h5>
+      <h5 class="section-title">Question condensing</h5>
 
       <tock-form-control
-        name="llmEngine"
-        [controls]="llmEngine"
+        name="condenseQuestionLlmEngine"
+        [controls]="condenseQuestionLlmEngine"
         [required]="true"
         [showError]="isSubmitted"
       >
         <nb-radio-group
-          formControlName="llmEngine"
-          name="llmEngine"
+          formControlName="condenseQuestionLlmEngine"
+          name="condenseQuestionLlmEngine"
           class="d-flex"
         >
           <nb-radio
-            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.llmSetting]"
+            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.condenseQuestionLlmSetting]"
             [value]="engine.key"
           >
             {{ engine.label }}
@@ -115,24 +115,84 @@
       </tock-form-control>
 
       <div
-        *ngIf="currentLlmEngine"
+        *ngIf="currentCondenseQuestionLlmEngine"
         class="mt-2 mb-2"
       >
         <div class="row mb-1">
-          <ng-container *ngFor="let param of currentLlmEngine.params">
+          <ng-container *ngFor="let param of currentCondenseQuestionLlmEngine.params">
             <div
               class="col-6 px-3"
               [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
             >
               <tock-ai-settings-engine-config-param-input
-                [parentGroup]="engineSettingKeyName.llmSetting"
+                [parentGroup]="engineSettingKeyName.condenseQuestionLlmSetting"
                 [configurationParam]="param"
                 [form]="form"
                 [isSubmitted]="isSubmitted"
-                [defaultPrompt]="defaultPrompt"
               ></tock-ai-settings-engine-config-param-input>
             </div>
           </ng-container>
+          <div class="col-12 px-3">
+            <tock-ai-settings-engine-config-param-input
+              parentGroup="condenseQuestionPrompt"
+              [configurationParam]="questionCondensing_prompt_ConfigurationParam"
+              [form]="form"
+              [isSubmitted]="isSubmitted"
+              [defaultPrompt]="$any(questionCondensing_prompt_ConfigurationParam.defaultValue)"
+            ></tock-ai-settings-engine-config-param-input>
+          </div>
+        </div>
+      </div>
+
+      <h5 class="section-title">Question answering</h5>
+
+      <tock-form-control
+        name="questionAnsweringLlmEngine"
+        [controls]="questionAnsweringLlmEngine"
+        [required]="true"
+        [showError]="isSubmitted"
+      >
+        <nb-radio-group
+          formControlName="questionAnsweringLlmEngine"
+          name="questionAnsweringLlmEngine"
+          class="d-flex"
+        >
+          <nb-radio
+            *ngFor="let engine of enginesConfigurations[engineSettingKeyName.questionAnsweringLlmSetting]"
+            [value]="engine.key"
+          >
+            {{ engine.label }}
+          </nb-radio>
+        </nb-radio-group>
+      </tock-form-control>
+
+      <div
+        *ngIf="currentQuestionAnsweringLlmEngine"
+        class="mt-2 mb-2"
+      >
+        <div class="row mb-1">
+          <ng-container *ngFor="let param of currentQuestionAnsweringLlmEngine.params">
+            <div
+              class="col-6 px-3"
+              [ngClass]="{ 'col-12': param.inputScale === 'fullwidth' }"
+            >
+              <tock-ai-settings-engine-config-param-input
+                [parentGroup]="engineSettingKeyName.questionAnsweringLlmSetting"
+                [configurationParam]="param"
+                [form]="form"
+                [isSubmitted]="isSubmitted"
+              ></tock-ai-settings-engine-config-param-input>
+            </div>
+          </ng-container>
+          <div class="col-12 px-3">
+            <tock-ai-settings-engine-config-param-input
+              parentGroup="questionAnsweringPrompt"
+              [configurationParam]="questionAnswering_prompt_ConfigurationParam"
+              [form]="form"
+              [isSubmitted]="isSubmitted"
+              [defaultPrompt]="$any(questionAnswering_prompt_ConfigurationParam.defaultValue)"
+            ></tock-ai-settings-engine-config-param-input>
+          </div>
         </div>
       </div>
 

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
@@ -572,7 +572,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
 
     const shouldConfirm =
       (this.questionCondensingLlmProvider.value || this.questionAnsweringLlmProvider.value || this.emProvider.value) &&
-      [(this.currentQuestionCondensingConfig.params, this.currentQuestionAnsweringConfig.params, this.currentEmConfig.params)].some(
+      [(this.currentQuestionCondensingConfig?.params, this.currentQuestionAnsweringConfig?.params, this.currentEmConfig?.params)].some(
         (engine) => {
           return engine.some((entry) => {
             return entry.confirmExport;
@@ -585,16 +585,16 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
         {
           label: 'Question condensing LLM engine',
           key: AiEngineSettingKeyName.questionCondensingLlmSetting,
-          params: this.currentQuestionCondensingConfig.params
+          params: this.currentQuestionCondensingConfig?.params
         },
         {
           label: 'Question answering LLM engine',
           key: AiEngineSettingKeyName.questionAnsweringLlmSetting,
-          params: this.currentQuestionAnsweringConfig.params
+          params: this.currentQuestionAnsweringConfig?.params
         },
-        { label: 'Embedding engine', key: AiEngineSettingKeyName.emSetting, params: this.currentEmConfig.params }
+        { label: 'Embedding engine', key: AiEngineSettingKeyName.emSetting, params: this.currentEmConfig?.params }
       ].forEach((engine) => {
-        engine.params.forEach((entry) => {
+        engine.params?.forEach((entry) => {
           if (entry.confirmExport) {
             this.sensitiveParams.push({ label: engine.label, key: engine.key, include: false, param: entry });
           }
@@ -625,6 +625,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
     delete formValue['emProvider'];
     delete formValue['id'];
     delete formValue['enabled'];
+    delete formValue['indexName'];
 
     if (this.sensitiveParams?.length) {
       this.sensitiveParams.forEach((sensitiveParam) => {

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
@@ -42,7 +42,7 @@
         <textarea
           nbInput
           fullWidth
-          rows="8"
+          rows="16"
           fieldSize="small"
           [formControl]="$any(form.get(parentGroup).get(configurationParam.key))"
         ></textarea>

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
@@ -1,7 +1,7 @@
 <div [formGroup]="form">
   <div [formGroupName]="parentGroup">
     <tock-form-control
-      [label]="configurationParam.label"
+      [label]="getFormControlLabel()"
       [name]="configurationParam.key"
       [controls]="getFormControl()"
       [required]="true"
@@ -42,7 +42,7 @@
         <textarea
           nbInput
           fullWidth
-          rows="16"
+          [rows]="configurationParam.rows || 6"
           fieldSize="small"
           [formControl]="$any(form.get(parentGroup).get(configurationParam.key))"
         ></textarea>

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
@@ -58,6 +58,21 @@
         </div>
       </ng-container>
 
+      <ng-container *ngIf="configurationParam.type === 'radio'">
+        <nb-radio-group
+          [formControl]="$any(form.get(parentGroup).get(configurationParam.key))"
+          class="d-flex"
+          name="{{ parentGroup }}-{{ configurationParam.key }}"
+        >
+          <nb-radio
+            *ngFor="let source of configurationParam.source"
+            [value]="source"
+          >
+            {{ source }}
+          </nb-radio>
+        </nb-radio-group>
+      </ng-container>
+
       <ng-container *ngIf="configurationParam.type === 'list'">
         <nb-select
           fullWidth

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { ProvidersConfigurationParam } from '../../model/ai-settings';
+import { PromptDefinitionFormatter, ProvidersConfigurationParam } from '../../model/ai-settings';
 
 @Component({
   selector: 'tock-ai-settings-engine-config-param-input',
@@ -22,7 +22,24 @@ export class AiSettingsEngineConfigParamInputComponent {
     return this.form.get(this.parentGroup).get(this.configurationParam.key) as FormControl;
   }
 
+  getFormControlLabel() {
+    let label = this.configurationParam.label;
+    if (this.configurationParam.type === 'prompt' && this.configurationParam.key === 'template') {
+      const formatter = this.form.get(this.parentGroup).get('formatter').value;
+
+      if (formatter === PromptDefinitionFormatter.jinja2) {
+        label += ' (Jinja2 format)';
+      }
+      if (formatter === PromptDefinitionFormatter.fstring) {
+        label += ' (f-string format | deprecated)';
+      }
+    }
+
+    return label;
+  }
+
   restoreDefaultPrompt(): void {
+    this.form.get(this.parentGroup).get('formatter').setValue(PromptDefinitionFormatter.jinja2);
     this.form.get(this.parentGroup).get('template').setValue(this.defaultPrompt);
     this.form.get(this.parentGroup).get('template').markAsDirty();
   }

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
@@ -23,8 +23,8 @@ export class AiSettingsEngineConfigParamInputComponent {
   }
 
   restoreDefaultPrompt(): void {
-    this.form.get(this.parentGroup).get('prompt').setValue(this.defaultPrompt);
-    this.form.get(this.parentGroup).get('prompt').markAsDirty();
+    this.form.get(this.parentGroup).get('template').setValue(this.defaultPrompt);
+    this.form.get(this.parentGroup).get('template').markAsDirty();
   }
 
   showInput(event: FocusEvent): void {

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -58,7 +58,7 @@
           <nb-checkbox
             [(ngModel)]="debug"
             nbTooltip="Get debug infos of RAG responses"
-            >Debug</nb-checkbox
+            >Rag debug</nb-checkbox
           >
 
           <nb-checkbox
@@ -117,9 +117,8 @@
       <div class="d-flex gap-1 flex-grow-1">
         <textarea
           #textareaAutocompleteDirectiveRef
-          [ngStyle]="{ height: getUserMessageInputHeight() }"
-          rows="1"
           class="w-100 nb-autocomplete-position-top"
+          rows="1"
           nbInput
           fullWidth
           fieldSize="medium"

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.ts
@@ -207,6 +207,7 @@ export class TestDialogComponent implements OnInit, OnDestroy {
     if (event) {
       const targetEvent = event.target as HTMLInputElement;
       results = results.filter((sentence: string) => sentence.toLowerCase().includes(targetEvent.value.trim().toLowerCase()));
+      this.updateMessageInputHeight(targetEvent);
     }
 
     this.userMessageAutocompleteValues = of(results);
@@ -214,14 +215,15 @@ export class TestDialogComponent implements OnInit, OnDestroy {
     if (event && event.key !== 'Escape') this.textareaAutocompleteDirectiveRef.updatePosition();
   }
 
-  getUserAvatar(isBot: boolean): string {
-    return getDialogMessageUserAvatar(isBot);
+  updateMessageInputHeight(element): void {
+    if (element) {
+      element.style.height = 'auto';
+      element.style.height = Math.min(element.scrollHeight + 2, 250) + 'px';
+    }
   }
 
-  getUserMessageInputHeight(): string {
-    const lineHeight = 1.5;
-    const padding = 2 * 0.5;
-    return lineHeight * this.userMessage.split(/\n/).length + padding + 'rem';
+  getUserAvatar(isBot: boolean): string {
+    return getDialogMessageUserAvatar(isBot);
   }
 
   onUserMessageChange(value: string): void {
@@ -249,6 +251,10 @@ export class TestDialogComponent implements OnInit, OnDestroy {
     }
     m = m.trim();
     this.talk(new Sentence(0, [], m));
+
+    setTimeout(() => {
+      this.textareaAutocompleteDirectiveRef.hide();
+    });
   }
 
   talkRequest(query: BotDialogRequest, debug: boolean = false, sourceWithContent: boolean = false): Observable<BotDialogResponse> {

--- a/bot/admin/web/src/app/shared/model/ai-settings.ts
+++ b/bot/admin/web/src/app/shared/model/ai-settings.ts
@@ -20,8 +20,15 @@ export enum AiEngineProvider {
 }
 
 export enum AiEngineSettingKeyName {
+  condenseQuestionLlmSetting = 'condenseQuestionLlmSetting',
+  questionAnsweringLlmSetting = 'questionAnsweringLlmSetting',
   llmSetting = 'llmSetting',
   emSetting = 'emSetting'
+}
+
+export interface promptDefinition {
+  formatter: 'jinja2' | 'f-string';
+  template: string;
 }
 
 export interface llmSetting {
@@ -35,7 +42,7 @@ export interface llmSetting {
   apiVersion?: String;
 
   temperature?: Number;
-  prompt?: String;
+  // prompt?: String;
 }
 
 export interface emSetting {

--- a/bot/admin/web/src/app/shared/model/ai-settings.ts
+++ b/bot/admin/web/src/app/shared/model/ai-settings.ts
@@ -10,6 +10,7 @@ export interface ProvidersConfigurationParam {
   min?: number;
   max?: number;
   step?: number;
+  rows?: number;
   confirmExport?: boolean;
 }
 
@@ -36,7 +37,7 @@ export enum PromptDefinitionFormatter {
   fstring = 'f-string'
 }
 
-export interface promptDefinition {
+export interface PromptDefinition {
   formatter: PromptDefinitionFormatter;
   template: string;
 }

--- a/bot/admin/web/src/app/shared/model/ai-settings.ts
+++ b/bot/admin/web/src/app/shared/model/ai-settings.ts
@@ -1,7 +1,7 @@
 export interface ProvidersConfigurationParam {
   label: string;
   key: string;
-  type: 'text' | 'prompt' | 'list' | 'openlist' | 'number' | 'obfuscated';
+  type: 'text' | 'prompt' | 'list' | 'openlist' | 'number' | 'obfuscated' | 'radio';
   numberControlType?: 'slider' | 'input';
   source?: string[];
   inputScale?: 'default' | 'fullwidth';

--- a/bot/admin/web/src/app/shared/model/ai-settings.ts
+++ b/bot/admin/web/src/app/shared/model/ai-settings.ts
@@ -20,14 +20,24 @@ export enum AiEngineProvider {
 }
 
 export enum AiEngineSettingKeyName {
-  condenseQuestionLlmSetting = 'condenseQuestionLlmSetting',
+  questionCondensingLlmSetting = 'questionCondensingLlmSetting',
   questionAnsweringLlmSetting = 'questionAnsweringLlmSetting',
   llmSetting = 'llmSetting',
   emSetting = 'emSetting'
 }
 
+export enum PromptTypeKeyName {
+  questionCondensingPrompt = 'questionCondensingPrompt',
+  questionAnsweringPrompt = 'questionAnsweringPrompt'
+}
+
+export enum PromptDefinitionFormatter {
+  jinja2 = 'jinja2',
+  fstring = 'f-string'
+}
+
 export interface promptDefinition {
-  formatter: 'jinja2' | 'f-string';
+  formatter: PromptDefinitionFormatter;
   template: string;
 }
 
@@ -42,7 +52,6 @@ export interface llmSetting {
   apiVersion?: String;
 
   temperature?: Number;
-  // prompt?: String;
 }
 
 export interface emSetting {

--- a/bot/admin/web/src/app/shared/utils/typescript.utils.ts
+++ b/bot/admin/web/src/app/shared/utils/typescript.utils.ts
@@ -12,4 +12,14 @@ export type ExtractFormControlTyping<T> = {
     : T[K];
 };
 
+export type ToFormType<T> = FormGroup<{
+  [K in keyof T]: T[K] extends object
+    ? T[K] extends Date
+      ? FormControl<T[K] | null>
+      : T[K] extends unknown[]
+      ? FormArray<ToFormType<T[K] extends (infer V)[] ? V : T[K]>>
+      : ToFormType<T[K]>
+    : FormControl<T[K] | null>;
+}>;
+
 export type GenericObject<T> = { [key: string]: T };

--- a/bot/admin/web/src/app/theme/styles/themes.scss
+++ b/bot/admin/web/src/app/theme/styles/themes.scss
@@ -27,8 +27,8 @@ $nb-themes: nb-register-theme(
 
     menu-item-icon-margin: 0 0.5rem 0 0,
 
-    card-header-text-font-size: 1.5rem,
-    card-header-text-line-height: 1.5,
+    card-header-text-font-size: 1.3rem,
+    card-header-text-line-height: 1.2,
     img-revert: invert(0%),
     select-min-width: 6rem,
 
@@ -68,8 +68,8 @@ $nb-themes: nb-register-theme(
 
     menu-item-icon-margin: 0 0.5rem 0 0,
 
-    card-header-text-font-size: 1.5rem,
-    card-header-text-line-height: 1.5,
+    card-header-text-font-size: 1.3rem,
+    card-header-text-line-height: 1.2,
     img-revert: invert(100%),
     select-min-width: 6rem,
 

--- a/bot/admin/web/src/app/theme/styles/themes.scss
+++ b/bot/admin/web/src/app/theme/styles/themes.scss
@@ -27,6 +27,8 @@ $nb-themes: nb-register-theme(
 
     menu-item-icon-margin: 0 0.5rem 0 0,
 
+    accordion-padding: 1rem 1.5rem,
+
     card-header-text-font-size: 1.3rem,
     card-header-text-line-height: 1.2,
     img-revert: invert(0%),
@@ -67,6 +69,8 @@ $nb-themes: nb-register-theme(
     layout-padding-top: 1rem,
 
     menu-item-icon-margin: 0 0.5rem 0 0,
+
+    accordion-padding: 1rem 1.5rem,
 
     card-header-text-font-size: 1.3rem,
     card-header-text-line-height: 1.2,

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -332,3 +332,33 @@ nb-menu {
 .nb-form-field-suffix-medium {
   justify-content: end;
 }
+
+.nb-toggle-small {
+  --toggle-height-small: 1.25rem;
+  --toggle-width-small: 1.95rem;
+  --toggle-switcher-size-small: 1.125rem;
+  --toggle-switcher-icon-size-small: 0.5rem;
+
+  .toggle-label {
+    margin-bottom: 0;
+  }
+
+  .toggle {
+    height: var(--toggle-height-small);
+    width: var(--toggle-width-small);
+
+    [dir='ltr'] &.checked .toggle-switcher {
+      left: calc(100% - var(--toggle-switcher-size-small) - var(--toggle-border-width) - var(--toggle-border-width));
+    }
+
+    .toggle-switcher {
+      width: var(--toggle-switcher-size-small);
+      height: var(--toggle-switcher-size-small);
+
+      nb-icon {
+        height: var(--toggle-switcher-icon-size-small);
+        width: var(--toggle-switcher-icon-size-small);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Works with https://github.com/theopenconversationkit/tock/pull/1827

- Exposure of RAG question condensation prompt and configuration
- Support for prompt template formats:
  - For existing prompts in f-string format, the option of switching to Jinja2 is offered, with prompt conversion.
  - If Jinja2 is the current format, the choice is not offered, as the f-string format is deprecated.
- Standardized UI for GEN AI settings screens