### PR TITLE
[DERCBOT-1401] Fix output documents

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/export_run_results.py
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/export_run_results.py
@@ -132,7 +132,7 @@ def append_runs_langfuse(dataset_item, _runs_names):
                 [f'[{doc["metadata"]["title"]}]({doc["metadata"]["source"]}) : {doc["page_content"]}'
                  f'\n################################################################################'
                  f'################################################################################' for doc in
-                 trace.output["source_documents"]]))
+                 trace.output["documents"]]))
 
     return csv_line
 
@@ -276,7 +276,7 @@ def append_runs_langsmith(dataset_example, _session_ids):
             csv_line.append('')
         else:
             csv_line.append(run["outputs"]["answer"])
-            csv_line.append(','.join([doc["metadata"]["url"] for doc in run["outputs"]["source_documents"]]))
+            csv_line.append(','.join([doc["metadata"]["url"] for doc in run["outputs"]["documents"]]))
 
     return csv_line
 


### PR DESCRIPTION
This pull request includes changes to the `gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/export_run_results.py` file to update the key names in the `trace.output` and `run["outputs"]` dictionaries. The most important changes are:

Key name updates:

* Modified the key name from `source_documents` to `documents` in the `append_runs_langfuse` function.
* Modified the key name from `source_documents` to `documents` in the `append_runs_langsmith` function.