### PR TITLE
fixes #1852 whatsapp_connector: payload shortening for list messages, add connector documentation

### DIFF
--- a/bot/connector-whatsapp-cloud/README.md
+++ b/bot/connector-whatsapp-cloud/README.md
@@ -42,7 +42,7 @@ In order to connect your bot with a WhatsApp bot application, you need a Meta ap
 
 ## Proxy authentication
 
-TOCK uses the default proxy selector for calls to the Messenger API.
+TOCK uses the default proxy selector for calls to the WhatsApp API.
 If the bot is deployed behind an HTTP proxy that requires authentication to perform these calls,
 you will need to set credentials in the form of the `tock_proxy_user` and `tock_proxy_password` properties (only Basic auth is supported).
 These properties can be set either as Java system properties or as environment variables.

--- a/bot/connector-whatsapp-cloud/README.md
+++ b/bot/connector-whatsapp-cloud/README.md
@@ -1,0 +1,56 @@
+> **This connector is still in alpha phase of development**
+> 
+> Breaking changes may occur.
+
+## Prerequisites
+
+* You need to retrieve from Meta these values:
+
+    * **WhatsApp Phone Number id**: The WhatsApp id of the phone number from which the bot should send messages.
+    * **WhatsApp Business Account id**: The id of the WhatApp business account on which the app is registered.
+    * **Webhook verify token**: A token (choose what you want) used when registering the webhook in the Meta admin interface.
+    * **Call Token**: The token allowing the bot to send messages.
+
+* Then go to the *Configuration* -> *Bot Configurations* menu in Tock Studio, and create a new configuration with these parameters.
+  Set the `Mode` field to "subscribe".
+
+## Bot API
+
+* Take the bot demo url (ie  https://demo.tock.ai ) and use it in the webhook interface of WhatsApp Cloud settings, to specify:
+    * the url : https://demo.tock.ai/io/xxxx/new_assistant/whatsapp (where */io/xxxx/new_assistant/whatsapp* is the relative path of the connector)
+    * the webhook token you set
+
+-> The bot is ready!
+
+## Integrated mode
+
+In order to connect your bot with a WhatsApp bot application, you need a Meta application with "messages" webhook events activated (look at the [Meta documentation](https://developers.facebook.com/docs/whatsapp/webhooks)).
+
+* A secure ssl tunnel (for example [zrok](https://zrok.io/)) is required to test the bot in dev mode:
+
+```sh 
+    zrok share public 8080
+``` 
+
+* Take the zrok value (ie  https://xxxx.share.zrok.io ) and use it in the webhook interface of whatsapp settings, to specify :
+    * the url : https://xxxx.share.zrok.io/whatsapp (where `/whatsapp` is the relative path of the connector)
+    * the webhook token you set
+
+* The documentation of the whatsapp builders is available in [KDoc format](https://theopenconversationkit.github.io/tock/dokka/tock/ai.tock.bot.connector.whatsapp.cloud/index.html)
+
+-> The bot is ready !
+
+## Proxy authentication
+
+TOCK uses the default proxy selector for calls to the Messenger API.
+If the bot is deployed behind an HTTP proxy that requires authentication to perform these calls,
+you will need to set credentials in the form of the `tock_proxy_user` and `tock_proxy_password` properties (only Basic auth is supported).
+These properties can be set either as Java system properties or as environment variables.
+
+## Message limitations
+
+Whatsapp message factory methods will ensure the length of texts in messages is acceptable according to the WhatsApp API specification.
+By default, if a text is too long, it will be truncated and a warning will be logged. Similarly,
+if a message contains too many buttons, only the first ones will be displayed.
+However, you can set the `tock_whatsapp_error_on_invalid_messages`
+property to `true` to throw an error instead, which can notably be helpful when running automated tests.

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
@@ -527,7 +527,7 @@ fun <T : Bus<T>> T.whatsAppCloudQuickReply(
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     targetIntent: IntentAware,
-    step: String? = null,
+    step: String?,
     parameters: Map<String, String> = mapOf()
 ): QuickReply =
     whatsAppCloudQuickReply(title, null, targetIntent, step, parameters) { intent, s, params ->
@@ -552,12 +552,12 @@ fun <T : Bus<T>> T.whatsAppCloudQuickReply(
         SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
     }
 
-@Deprecated("Use step object directly instead of its name")
+@Deprecated("Use step object directly instead of its name", level = DeprecationLevel.HIDDEN)
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
     targetIntent: IntentAware,
-    step: String? = null,
+    step: String?,
     parameters: Map<String, String> = mapOf()
 ): QuickReply =
     whatsAppCloudQuickReply(title,subTitle, targetIntent, step, parameters) { intent, s, params ->

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
@@ -375,7 +375,7 @@ fun I18nTranslator.whatsAppCloudListMessage(
     header: CharSequence? = null,
     footer: CharSequence? = null,
 ): WhatsAppCloudBotInteractiveMessage =
-    whatsAppCloudListMessage(text, button, header, footer, sections.toList())
+    whatsAppCloudListMessage(text, button, sections.toList(), header, footer)
 
 /**
  * Creates an [Interactive List Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-list-messages)
@@ -395,12 +395,13 @@ fun I18nTranslator.whatsAppCloudListMessage(
  *
  * @see whatsAppCloudListSection
  */
+@JvmName("whatsAppCloudListMessageWithSections")
 fun I18nTranslator.whatsAppCloudListMessage(
     text: CharSequence,
     button: CharSequence,
+    sections: List<WhatsAppCloudBotActionSection>,
     header: CharSequence? = null,
     footer: CharSequence? = null,
-    sections: List<WhatsAppCloudBotActionSection>,
 ): WhatsAppCloudBotInteractiveMessage {
     return WhatsAppCloudBotInteractiveMessage(
         messagingProduct = "whatsapp",
@@ -611,7 +612,7 @@ fun I18nTranslator.whatsAppCloudNlpQuickReply(
 fun I18nTranslator.whatsAppBuildCloudTemplateMessage(
     templateName: String,
     languageCode: String,
-    components: List<WhatsappTemplateComponent>
+    components: List<Component>
 ) = whatsAppCloudTemplateMessage(templateName, languageCode, components)
 
 /**
@@ -622,7 +623,7 @@ fun I18nTranslator.whatsAppBuildCloudTemplateMessage(
 fun I18nTranslator.whatsAppCloudTemplateMessage(
     templateName: String,
     languageCode: String,
-    components: List<WhatsappTemplateComponent>
+    components: List<Component>
 ): WhatsAppCloudBotTemplateMessage {
     return WhatsAppCloudBotTemplateMessage(
         messagingProduct = "whatsapp",
@@ -640,7 +641,7 @@ fun I18nTranslator.whatsAppCloudTemplateMessage(
 @Deprecated("renamed", ReplaceWith("whatsAppCloudTemplateMessageCarousel(templateName, components, languageCode)"))
 fun I18nTranslator.whatsAppCloudBuildTemplateMessageCarousel(
     templateName: String,
-    components: List<WhatsappTemplateComponent.Card>,
+    components: List<Component.Card>,
     languageCode: String
 ) = whatsAppCloudTemplateMessageCarousel(templateName, components, languageCode)
 
@@ -651,7 +652,7 @@ fun I18nTranslator.whatsAppCloudBuildTemplateMessageCarousel(
  */
 fun I18nTranslator.whatsAppCloudTemplateMessageCarousel(
     templateName: String,
-    components: List<WhatsappTemplateComponent.Card>,
+    components: List<Component.Card>,
     languageCode: String
 ): WhatsAppCloudBotTemplateMessage {
     return WhatsAppCloudBotTemplateMessage(
@@ -663,12 +664,18 @@ fun I18nTranslator.whatsAppCloudTemplateMessageCarousel(
                 code = languageCode,
             ),
             components = listOf(
-                WhatsappTemplateComponent.Carousel(
+                Component.Carousel(
                     type = ComponentType.CAROUSEL,
                     cards = components
                 )
             )
         )
+    )
+}
+
+fun <T : Bus<T>> T.whatsAppCloudCardCarousel(cardIndex: Int, components: List<Component>): Component.Card {
+    return whatsAppCloudTemplateCard(
+        cardIndex, components
     )
 }
 
@@ -682,8 +689,8 @@ fun I18nTranslator.whatsAppCloudTemplateMessageCarousel(
  */
 fun <T : Bus<T>> T.whatsAppCloudTemplateCard(
     cardIndex: Int,
-    components: List<WhatsappTemplateComponent>
-): WhatsappTemplateComponent.Card = WhatsappTemplateComponent.Card(
+    components: List<Component>
+): Component.Card = Component.Card(
     cardIndex = cardIndex,
     components = components
 )
@@ -700,7 +707,7 @@ fun <T : Bus<T>> T.whatsAppCloudBodyTemplate(
  */
 fun <T : Bus<T>> T.whatsAppCloudTemplateBody(
     parameters: List<TextParameter>
-): WhatsappTemplateComponent.Body = WhatsappTemplateComponent.Body(
+): Component.Body = Component.Body(
     type = ComponentType.BODY,
     parameters = parameters
 )
@@ -725,7 +732,7 @@ fun whatsAppCloudButtonTemplate(
     index: Int,
     subType: ButtonSubType,
     parameters: List<PayloadParameter>
-): WhatsappTemplateComponent.Button = WhatsappTemplateComponent.Button(
+): Component.Button = Component.Button(
     type = ComponentType.BUTTON,
     subType = subType,
     index = index.toString(),
@@ -736,11 +743,20 @@ fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
     index: Int,
     textButton: String,
     payload: String?
-): WhatsappTemplateComponent.Button = whatsAppCloudButtonTemplate(
+): Component.Button = whatsAppCloudButtonTemplate(
     index, ButtonSubType.QUICK_REPLY, listOf(
         whatsAppCloudPayloadParameterTemplate(textButton, payload, ParameterType.PAYLOAD)
     )
 )
+
+@Deprecated("Use variant with Int index")
+fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
+    index: String,
+    title: CharSequence,
+    targetIntent: IntentAware,
+    step: StoryStep<out StoryHandlerDefinition>? = null,
+    parameters: Parameters = Parameters()
+) = whatsAppCloudPostbackButton(index.toInt(), title, targetIntent, step, parameters)
 
 fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
     index: Int,
@@ -748,7 +764,7 @@ fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
     targetIntent: IntentAware,
     step: StoryStep<out StoryHandlerDefinition>? = null,
     parameters: Parameters = Parameters()
-): WhatsappTemplateComponent.Button = whatsAppCloudPostbackButton(
+): Component.Button = whatsAppCloudPostbackButton(
     index = index,
     textButton = translate(title).toString(),
     // Add an index parameter to ensure that all buttons in the list have unique ids
@@ -759,7 +775,7 @@ fun <T : Bus<T>> T.whatsAppCloudNLPPostbackButton(
     index: Int,
     title: CharSequence,
     textToSend: CharSequence = title,
-): WhatsappTemplateComponent.Button = whatsAppCloudPostbackButton(
+): Component.Button = whatsAppCloudPostbackButton(
     index = index,
     textButton = translate(title).toString(),
     payload = SendChoice.encodeNlpChoiceId(translate(textToSend).toString()),
@@ -768,7 +784,7 @@ fun <T : Bus<T>> T.whatsAppCloudNLPPostbackButton(
 fun <T : Bus<T>> T.whatsAppCloudUrlButton(
     index: Int,
     textButton: String,
-): WhatsappTemplateComponent.Button = whatsAppCloudButtonTemplate(
+): Component.Button = whatsAppCloudButtonTemplate(
     index, ButtonSubType.URL, listOf(
         whatsAppCloudPayloadParameterTemplate(textButton, null, ParameterType.TEXT)
     )
@@ -793,7 +809,7 @@ fun whatsAppCloudHeaderTemplate(
 
 fun whatsAppCloudTemplateImageHeader(
     imageId: String
-): WhatsappTemplateComponent.Header = WhatsappTemplateComponent.Header(
+): Component.Header = Component.Header(
     type = ComponentType.HEADER,
     parameters = listOf(
         HeaderParameter.Image(

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
@@ -342,8 +342,8 @@ fun I18nTranslator.whatsAppCloudListMessage(
         WhatsAppCloudBotActionSection(rows = replies.map {
             WhatsAppBotRow(
                 id = it.payload,
-                title = it.title,
-                description = it.description
+                title = it.title.checkLength(WHATSAPP_ROW_TITLE_MAX_LENGTH),
+                description = it.description?.checkLength(WHATSAPP_ROW_DESCRIPTION_MAX_LENGTH)
             )
         }),
         header = header,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
@@ -39,17 +39,17 @@ private val logger = KotlinLogging.logger {}
 private val errorOnInvalidMessages = booleanProperty("tock_whatsapp_error_on_invalid_messages", false)
 
 internal const val WHATS_APP_CONNECTOR_TYPE_ID = "whatsapp_cloud"
-private const val WHATS_APP_BUTTONS_TITLE_MAX_LENGTH = 50
-private const val WHATS_APP_LIST_BODY_MAX_LENGTH = 4096
-private const val WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH = 1024
-private const val WHATS_APP_REPLY_BUTTONS_MAX_COUNT = 3
-private const val WHATS_APP_LIST_HEADER_MAX_LENGTH = 60
-private const val WHATS_APP_LIST_BUTTON_MAX_LENGTH = 20
-private const val WHATS_APP_SECTION_TITLE_MAX_LENGTH = 24
-private const val WHATS_APP_ROW_TITLE_MAX_LENGTH = 24
-private const val WHATS_APP_ROW_DESCRIPTION_MAX_LENGTH = 72
-private const val WHATS_APP_MAX_ROWS = 10
-private const val WHATS_APP_MAX_SECTIONS = 10
+const val WHATSAPP_BUTTONS_TITLE_MAX_LENGTH = 50
+const val WHATSAPP_LIST_BODY_MAX_LENGTH = 4096
+const val WHATSAPP_REPLY_BUTTON_BODY_MAX_LENGTH = 1024
+const val WHATSAPP_REPLY_BUTTONS_MAX_COUNT = 3
+const val WHATSAPP_LIST_HEADER_MAX_LENGTH = 60
+const val WHATSAPP_LIST_BUTTON_MAX_LENGTH = 20
+const val WHATSAPP_SECTION_TITLE_MAX_LENGTH = 24
+const val WHATSAPP_ROW_TITLE_MAX_LENGTH = 24
+const val WHATSAPP_ROW_DESCRIPTION_MAX_LENGTH = 72
+const val WHATSAPP_MAX_ROWS = 10
+const val WHATSAPP_MAX_SECTIONS = 10
 
 /**
  * The WhatsApp cloud connector type.
@@ -179,20 +179,20 @@ internal fun I18nTranslator.whatsAppCloudReplyButtonMessage(
     interactive = WhatsAppCloudBotInteractive(
         type = WhatsAppCloudBotInteractiveType.button,
         header = header,
-        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH)),
+        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATSAPP_REPLY_BUTTON_BODY_MAX_LENGTH)),
         footer = footer?.let {
             WhatsAppCloudBotFooter(
-                translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "message footer"),
+                translate(it).toString().checkLength(WHATSAPP_LIST_HEADER_MAX_LENGTH, "message footer"),
             )
         },
         action = WhatsAppCloudBotAction(
-            buttons = replies.checkCount(WHATS_APP_REPLY_BUTTONS_MAX_COUNT) { count ->
+            buttons = replies.checkCount(WHATSAPP_REPLY_BUTTONS_MAX_COUNT) { count ->
                 "$count is too many buttons for a reply button message"
             }.map {
                 WhatsAppCloudBotActionButton(
                     reply = WhatsAppCloudBotActionButtonReply(
                         id = it.payload,
-                        title = translate(it.title).toString().checkLength(WHATS_APP_BUTTONS_TITLE_MAX_LENGTH),
+                        title = translate(it.title).toString().checkLength(WHATSAPP_BUTTONS_TITLE_MAX_LENGTH),
                     )
                 )
             }
@@ -411,26 +411,26 @@ fun I18nTranslator.whatsAppCloudListMessage(
             header = header?.let {
                 WhatsAppCloudBotInteractiveHeader(
                     WhatsAppCloudBotHeaderType.text,
-                    text = translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "list message header")
+                    text = translate(it).toString().checkLength(WHATSAPP_LIST_HEADER_MAX_LENGTH, "list message header")
                 )
             },
             footer = footer?.let {
                 WhatsAppCloudBotFooter(
-                    translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "list message footer")
+                    translate(it).toString().checkLength(WHATSAPP_LIST_HEADER_MAX_LENGTH, "list message footer")
                 )
             },
-            body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_LIST_BODY_MAX_LENGTH, "list message body")),
+            body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATSAPP_LIST_BODY_MAX_LENGTH, "list message body")),
             action = WhatsAppCloudBotAction(
-                button = translate(button).toString().checkLength(WHATS_APP_LIST_BUTTON_MAX_LENGTH, "list message button text"),
+                button = translate(button).toString().checkLength(WHATSAPP_LIST_BUTTON_MAX_LENGTH, "list message button text"),
                 sections = sections,
             )
         )
     ).also {
-        if ((it.interactive.action?.sections?.flatMap { s -> s.rows ?: listOf() }?.count() ?: 0) > WHATS_APP_MAX_ROWS) {
-            error("a list message is limited to $WHATS_APP_MAX_ROWS rows across all sections.")
+        if ((it.interactive.action?.sections?.flatMap { s -> s.rows ?: listOf() }?.count() ?: 0) > WHATSAPP_MAX_ROWS) {
+            error("a list message is limited to $WHATSAPP_MAX_ROWS rows across all sections.")
         }
-        if ((it.interactive.action?.sections?.count() ?: 0) > WHATS_APP_MAX_SECTIONS) {
-            error("sections count in list message should not exceed $WHATS_APP_MAX_SECTIONS.")
+        if ((it.interactive.action?.sections?.count() ?: 0) > WHATSAPP_MAX_SECTIONS) {
+            error("sections count in list message should not exceed $WHATSAPP_MAX_SECTIONS.")
         }
     }
 }
@@ -464,11 +464,11 @@ fun I18nTranslator.whatsAppCloudListSection(title: CharSequence, vararg rows: Qu
  * @see whatsAppCloudQuickReply
  */
 fun I18nTranslator.whatsAppCloudListSection(title: CharSequence, rows: List<QuickReply>) = WhatsAppCloudBotActionSection(
-    title = translate(title).toString().checkLength(WHATS_APP_SECTION_TITLE_MAX_LENGTH),
+    title = translate(title).toString().checkLength(WHATSAPP_SECTION_TITLE_MAX_LENGTH),
     rows = rows.map { qr -> WhatsAppBotRow(
         id = qr.payload,
-        title = translate(qr.title).toString().checkLength(WHATS_APP_ROW_TITLE_MAX_LENGTH),
-        description = translate(qr.description).toString().checkLength(WHATS_APP_ROW_DESCRIPTION_MAX_LENGTH)
+        title = translate(qr.title).toString().checkLength(WHATSAPP_ROW_TITLE_MAX_LENGTH),
+        description = translate(qr.description).toString().checkLength(WHATSAPP_ROW_DESCRIPTION_MAX_LENGTH)
     ) }
 )
 
@@ -486,7 +486,7 @@ fun I18nTranslator.whatsAppCloudReplyLocationMessage(
     recipientType = WhatsAppCloudBotRecipientType.individual,
     interactive = WhatsAppCloudBotInteractive(
         type = WhatsAppCloudBotInteractiveType.location_request_message,
-        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH)),
+        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATSAPP_REPLY_BUTTON_BODY_MAX_LENGTH)),
         action = WhatsAppCloudBotAction(
             name = "send_location"
         )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppCloudBuilder.kt
@@ -32,17 +32,21 @@ import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.Bus
 import ai.tock.bot.engine.I18nTranslator
 import ai.tock.bot.engine.action.SendChoice
+import ai.tock.shared.booleanProperty
 import mu.KotlinLogging
-import java.util.*
 
 private val logger = KotlinLogging.logger {}
+private val errorOnInvalidMessages = booleanProperty("tock_whatsapp_error_on_invalid_messages", false)
 
 internal const val WHATS_APP_CONNECTOR_TYPE_ID = "whatsapp_cloud"
 private const val WHATS_APP_BUTTONS_TITLE_MAX_LENGTH = 50
-private const val WHATS_APP_BUTTONS_ID_MAX_LENGTH = 256
+private const val WHATS_APP_LIST_BODY_MAX_LENGTH = 4096
+private const val WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH = 1024
+private const val WHATS_APP_REPLY_BUTTONS_MAX_COUNT = 3
+private const val WHATS_APP_LIST_HEADER_MAX_LENGTH = 60
+private const val WHATS_APP_LIST_BUTTON_MAX_LENGTH = 20
 private const val WHATS_APP_SECTION_TITLE_MAX_LENGTH = 24
 private const val WHATS_APP_ROW_TITLE_MAX_LENGTH = 24
-private const val WHATS_APP_ROW_ID_MAX_LENGTH = 200
 private const val WHATS_APP_ROW_DESCRIPTION_MAX_LENGTH = 72
 private const val WHATS_APP_MAX_ROWS = 10
 private const val WHATS_APP_MAX_SECTIONS = 10
@@ -76,10 +80,10 @@ fun <T : Bus<T>> T.withWhatsAppCloud(messageProvider: () -> WhatsAppCloudConnect
 }
 
 /**
- * Creates a [WhatsAppBotTextMessage].
+ * Creates a basic [Text Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/text-messages).
  *
  * @param text the text sent
- * @param previewUrl is preview mode is used?
+ * @param previewUrl if set to `true`, WhatsApp will render a preview of the first URL in the message's [text]
  */
 fun BotBus.whatsAppCloudText(
     text: CharSequence,
@@ -90,13 +94,20 @@ fun BotBus.whatsAppCloudText(
         text = TextContent(translate(text).toString()),
         recipientType = WhatsAppCloudBotRecipientType.individual,
         userId = userId.id,
+        previewUrl = previewUrl,
     )
 
+/**
+ * Creates an [Image Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/image-messages)
+ *
+ * @param id the URL of the image
+ * @param caption a caption to display below the image
+ */
 fun BotBus.whatsAppCloudImage(
     id: String,
     link: String? = null,
     caption: CharSequence? = null,
-    ): WhatsAppCloudBotImageMessage =
+): WhatsAppCloudBotImageMessage =
     WhatsAppCloudBotImageMessage(
         messagingProduct = "whatsapp",
         image = WhatsAppCloudBotImage(
@@ -108,64 +119,79 @@ fun BotBus.whatsAppCloudImage(
         userId = userId.id,
     )
 
+/**
+ * Creates an [Interactive Reply Button Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-reply-buttons-messages)
+ *
+ * Limitations:
+ * - [text] is limited to 1024 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 20 characters
+ * - there can be **no** [quick reply description][QuickReply.description]
+ * - there can be a maximum of 3 [replies] in the message
+ *
+ * @param text the body of the message
+ * @param replies the replies to display below the message
+ * @param header an optional text header
+ * @param footer an optional text footer
+ */
 fun I18nTranslator.whatsAppCloudReplyButtonMessage(
     text: CharSequence,
     vararg replies: QuickReply,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
+): WhatsAppCloudBotInteractiveMessage =
+    whatsAppCloudReplyButtonMessage(text, replies.toList(), header, footer)
 
-    ): WhatsAppCloudBotInteractiveMessage =
-    whatsAppCloudReplyButtonMessage(text, replies.toList())
-
+/**
+ * Creates an [Interactive Reply Button Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-reply-buttons-messages)
+ *
+ * Limitations:
+ * - [text] is limited to 1024 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 20 characters
+ * - there can be **no** [quick reply description][QuickReply.description]
+ * - there can be a maximum of 3 [replies] in the message
+ *
+ * @param text the body of the message
+ * @param replies the replies to display below the message
+ * @param header an optional text header
+ * @param footer an optional text footer
+ */
 fun I18nTranslator.whatsAppCloudReplyButtonMessage(
     text: CharSequence,
     replies: List<QuickReply>,
-): WhatsAppCloudBotInteractiveMessage = WhatsAppCloudBotInteractiveMessage(
-    messagingProduct = "whatsapp",
-    recipientType = WhatsAppCloudBotRecipientType.individual,
-    interactive = WhatsAppCloudBotInteractive(
-        type = WhatsAppCloudBotInteractiveType.button,
-        body = WhatsAppCloudBotBody(translate(text).toString()),
-        action = WhatsAppCloudBotAction(
-            buttons = replies.map {
-                WhatsAppCloudBotActionButton(
-                    reply = WhatsAppCloudBotActionButtonReply(
-                        id = it.payload.checkLength(WHATS_APP_BUTTONS_ID_MAX_LENGTH),
-                        title = translate(it.title).toString().checkLength(WHATS_APP_BUTTONS_TITLE_MAX_LENGTH),
-                    )
-                )
-            }
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
+): WhatsAppCloudBotInteractiveMessage =
+    whatsAppCloudReplyButtonMessage(text, footer, replies, header = header?.let {
+        WhatsAppCloudBotInteractiveHeader(
+            WhatsAppCloudBotHeaderType.text,
+            text = translate(header).toString(),
         )
-    )
-)
+    })
 
-fun I18nTranslator.whatsAppCloudReplyImgButtonMessage(
-    imgUrl: String,
+internal fun I18nTranslator.whatsAppCloudReplyButtonMessage(
     text: CharSequence,
-    vararg replies: QuickReply,
-
-    ): WhatsAppCloudBotInteractiveMessage =
-    whatsAppCloudReplyImgButtonMessage(imgUrl, text, replies.toList())
-
-fun I18nTranslator.whatsAppCloudReplyImgButtonMessage(
-    imgUrl: String,
-    text: CharSequence,
+    footer: CharSequence?,
     replies: List<QuickReply>,
-): WhatsAppCloudBotInteractiveMessage = WhatsAppCloudBotInteractiveMessage(
+    header: WhatsAppCloudBotInteractiveHeader?
+) = WhatsAppCloudBotInteractiveMessage(
     messagingProduct = "whatsapp",
     recipientType = WhatsAppCloudBotRecipientType.individual,
     interactive = WhatsAppCloudBotInteractive(
         type = WhatsAppCloudBotInteractiveType.button,
-        header = WhatsAppCloudBotInteractiveHeader(
-            type = WhatsAppCloudBotHeaderType.image,
-            image = WhatsAppCloudBotMediaImage(
-                id = imgUrl
+        header = header,
+        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH)),
+        footer = footer?.let {
+            WhatsAppCloudBotFooter(
+                translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "message footer"),
             )
-        ),
-        body = WhatsAppCloudBotBody(translate(text).toString()),
+        },
         action = WhatsAppCloudBotAction(
-            buttons = replies.map {
+            buttons = replies.checkCount(WHATS_APP_REPLY_BUTTONS_MAX_COUNT) { count ->
+                "$count is too many buttons for a reply button message"
+            }.map {
                 WhatsAppCloudBotActionButton(
                     reply = WhatsAppCloudBotActionButtonReply(
-                        id = it.payload.checkLength(WHATS_APP_BUTTONS_ID_MAX_LENGTH),
+                        id = it.payload,
                         title = translate(it.title).toString().checkLength(WHATS_APP_BUTTONS_TITLE_MAX_LENGTH),
                     )
                 )
@@ -174,95 +200,284 @@ fun I18nTranslator.whatsAppCloudReplyImgButtonMessage(
     )
 )
 
+/**
+ * Creates an [Interactive Reply Button Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-reply-buttons-messages)
+ * with an image header
+ *
+ * Limitations:
+ * - [text] is limited to 1024 characters
+ * - [footer] is limited to 60 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 20 characters
+ * - there can be **no** [quick reply description][QuickReply.description]
+ * - there can be a maximum of 3 [replies] in the message
+ *
+ * Warning: this message type may appear after a delay (and possibly after subsequent messages),
+ * due to the image upload time
+ *
+ * @param imgUrl the URL of the image to display in the message header
+ * @param text the body of the message
+ * @param replies the replies to display below the message
+ * @param footer an optional text footer
+ */
+fun I18nTranslator.whatsAppCloudReplyImgButtonMessage(
+    imgUrl: String,
+    text: CharSequence,
+    vararg replies: QuickReply,
+    footer: CharSequence? = null,
+): WhatsAppCloudBotInteractiveMessage =
+    whatsAppCloudReplyImgButtonMessage(imgUrl, text, replies.toList(), footer)
+
+/**
+ * Creates an [Interactive Reply Button Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-reply-buttons-messages)
+ * with an image header
+ *
+ * Limitations:
+ * - [text] is limited to 1024 characters
+ * - [footer] is limited to 60 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 20 characters
+ * - there can be **no** [quick reply description][QuickReply.description]
+ * - there can be a maximum of 3 [replies] in the message
+ *
+ * Warning: this message type may appear after a delay (and possibly after subsequent messages),
+ * due to the image upload time
+ *
+ * @param imgUrl the URL of the image to display in the message header
+ * @param text the body of the message
+ * @param replies the replies to display below the message
+ * @param footer an optional text footer
+ */
+fun I18nTranslator.whatsAppCloudReplyImgButtonMessage(
+    imgUrl: String,
+    text: CharSequence,
+    replies: List<QuickReply>,
+    footer: CharSequence? = null,
+): WhatsAppCloudBotInteractiveMessage = whatsAppCloudReplyButtonMessage(text, footer, replies, WhatsAppCloudBotInteractiveHeader(
+    type = WhatsAppCloudBotHeaderType.image,
+    image = WhatsAppCloudBotMediaImage(
+        id = imgUrl
+    )
+))
+
+/**
+ * Creates an [Interactive Call-to-Action URL Button Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages)
+ *
+ * @param text the body of the message
+ * @param buttonTitle the text to display on the button
+ * @param url the URL to open when clicking on the button
+ * @param header an optional text header
+ * @param footer an optional text footer
+ */
 fun I18nTranslator.whatsAppCloudUrlButtonMessage(
-    text: CharSequence? = null,
-    textButton: String,
-    url: String
+    text: CharSequence,
+    buttonTitle: CharSequence,
+    url: String,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
 ): WhatsAppCloudBotInteractiveMessage = WhatsAppCloudBotInteractiveMessage(
     messagingProduct = "whatsapp",
     recipientType = WhatsAppCloudBotRecipientType.individual,
     interactive = WhatsAppCloudBotInteractive(
         type = WhatsAppCloudBotInteractiveType.cta_url,
+        header = header?.let { WhatsAppCloudBotInteractiveHeader(WhatsAppCloudBotHeaderType.text, text = translate(it).toString()) },
         body = WhatsAppCloudBotBody(translate(text).toString()),
+        footer = footer?.let { WhatsAppCloudBotFooter(translate(it).toString()) },
         action = WhatsAppCloudBotAction(
             name = "cta_url",
             parameters = ParametersUrl(
-                displayText = textButton,
+                displayText = translate(buttonTitle).toString(),
                 url = url
             )
         )
     )
 )
 
+/**
+ * Creates an [Interactive List Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-list-messages)
+ *
+ * Limitations:
+ * - [text] is limited to 4096 characters
+ * - [button] is limited to 20 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [replies] in the message
+ *
+ * Length limitations apply to the localized form of each text, if applicable
+ *
+ * @see whatsAppCloudQuickReply
+ */
 fun I18nTranslator.whatsAppCloudListMessage(
     text: CharSequence,
     button: CharSequence,
-    vararg replies: QuickReply
+    vararg replies: QuickReply,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
 ): WhatsAppCloudBotInteractiveMessage =
-    whatsAppCloudListMessage(text, button, replies.toList())
+    whatsAppCloudListMessage(text, button, replies.toList(), header, footer)
 
-
+/**
+ * Creates an [Interactive List Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-list-messages)
+ *
+ * Limitations:
+ * - [text] is limited to 4096 characters
+ * - [button] is limited to 20 characters
+ * - [header] is limited to 60 characters
+ * - [footer] is limited to 60 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [replies] in the message
+ *
+ * Length limitations apply to the localized form of each text, if applicable
+ *
+ * @see whatsAppCloudQuickReply
+ */
 fun I18nTranslator.whatsAppCloudListMessage(
     text: CharSequence,
     button: CharSequence,
-    replies: List<QuickReply>
+    replies: List<QuickReply>,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
 ): WhatsAppCloudBotInteractiveMessage =
-    whatsAppCloudCompleteListMessage(
-        text, button, WhatsAppCloudBotActionSection(rows = replies.map {
+    whatsAppCloudListMessage(
+        text, button,
+        WhatsAppCloudBotActionSection(rows = replies.map {
             WhatsAppBotRow(
                 id = it.payload,
                 title = it.title,
                 description = it.description
             )
-        })
+        }),
+        header = header,
+        footer = footer,
     )
 
-fun I18nTranslator.whatsAppCloudCompleteListMessage(
+/**
+ * Creates an [Interactive List Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-list-messages)
+ * divided into sections
+ *
+ * Limitations:
+ * - [text] is limited to 4096 characters
+ * - [button] is limited to 20 characters
+ * - [header] is limited to 60 characters
+ * - [footer] is limited to 60 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [sections] in the message
+ * - there can be a maximum of 10 replies across all [sections] in the message
+ *
+ * Length limitations apply to the localized form of each text, if applicable
+ *
+ * @see whatsAppCloudListSection
+ */
+fun I18nTranslator.whatsAppCloudListMessage(
     text: CharSequence,
     button: CharSequence,
-    vararg sections: WhatsAppCloudBotActionSection
-): WhatsAppCloudBotInteractiveMessage = whatsAppCloudCompleteListMessage(text, button, sections.toList())
+    vararg sections: WhatsAppCloudBotActionSection,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
+): WhatsAppCloudBotInteractiveMessage =
+    whatsAppCloudListMessage(text, button, header, footer, sections.toList())
 
-fun I18nTranslator.whatsAppCloudCompleteListMessage(
+/**
+ * Creates an [Interactive List Message](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-list-messages)
+ * divided into sections
+ *
+ * Limitations:
+ * - [text] is limited to 4096 characters
+ * - [button] is limited to 20 characters
+ * - [header] is limited to 60 characters
+ * - [footer] is limited to 60 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [sections] in the message
+ * - there can be a maximum of 10 replies across all [sections] in the message
+ *
+ * Length limitations apply to the localized form of each text, if applicable
+ *
+ * @see whatsAppCloudListSection
+ */
+fun I18nTranslator.whatsAppCloudListMessage(
     text: CharSequence,
     button: CharSequence,
+    header: CharSequence? = null,
+    footer: CharSequence? = null,
     sections: List<WhatsAppCloudBotActionSection>,
-): WhatsAppCloudBotInteractiveMessage = WhatsAppCloudBotInteractiveMessage(
-    messagingProduct = "whatsapp",
-    recipientType = WhatsAppCloudBotRecipientType.individual,
-    interactive = WhatsAppCloudBotInteractive(
-        type = WhatsAppCloudBotInteractiveType.list,
-        body = WhatsAppCloudBotBody(translate(text).toString()),
-        action = WhatsAppCloudBotAction(
-            button = translate(button).toString().checkLength(WHATS_APP_BUTTONS_TITLE_MAX_LENGTH),
-            sections = sections.map {
-                WhatsAppCloudBotActionSection(
-                    title = translate(it.title).toString().checkLength(WHATS_APP_SECTION_TITLE_MAX_LENGTH),
-                    rows = it.rows?.map { row ->
-                        WhatsAppBotRow(
-                            id = row.id.checkLength(WHATS_APP_ROW_ID_MAX_LENGTH),
-                            title = translate(row.title).toString().checkLength(WHATS_APP_ROW_TITLE_MAX_LENGTH),
-                            description = translate(row.description).toString()
-                                .checkLength(WHATS_APP_ROW_DESCRIPTION_MAX_LENGTH)
-                        )
-                    }
+): WhatsAppCloudBotInteractiveMessage {
+    return WhatsAppCloudBotInteractiveMessage(
+        messagingProduct = "whatsapp",
+        recipientType = WhatsAppCloudBotRecipientType.individual,
+        interactive = WhatsAppCloudBotInteractive(
+            type = WhatsAppCloudBotInteractiveType.list,
+            header = header?.let {
+                WhatsAppCloudBotInteractiveHeader(
+                    WhatsAppCloudBotHeaderType.text,
+                    text = translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "list message header")
                 )
-            }
+            },
+            footer = footer?.let {
+                WhatsAppCloudBotFooter(
+                    translate(it).toString().checkLength(WHATS_APP_LIST_HEADER_MAX_LENGTH, "list message footer")
+                )
+            },
+            body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_LIST_BODY_MAX_LENGTH, "list message body")),
+            action = WhatsAppCloudBotAction(
+                button = translate(button).toString().checkLength(WHATS_APP_LIST_BUTTON_MAX_LENGTH, "list message button text"),
+                sections = sections,
+            )
         )
-    )
-).also {
-    if ((it.interactive.action?.sections?.flatMap { s -> s.rows ?: listOf() }?.count() ?: 0) > WHATS_APP_MAX_ROWS) {
-        error("a list message is limited to $WHATS_APP_MAX_ROWS rows across all sections.")
-    }
-    if ((it.interactive.action?.sections?.count() ?: 0) > WHATS_APP_MAX_SECTIONS) {
-        error("sections count in list message should not exceed $WHATS_APP_MAX_SECTIONS.")
-    }
-    if ((it.interactive.action?.button?.count() ?: 0) > WHATS_APP_BUTTONS_TITLE_MAX_LENGTH) {
-        error("button text ${it.interactive.action?.button} should not exceed $WHATS_APP_BUTTONS_TITLE_MAX_LENGTH chars.")
+    ).also {
+        if ((it.interactive.action?.sections?.flatMap { s -> s.rows ?: listOf() }?.count() ?: 0) > WHATS_APP_MAX_ROWS) {
+            error("a list message is limited to $WHATS_APP_MAX_ROWS rows across all sections.")
+        }
+        if ((it.interactive.action?.sections?.count() ?: 0) > WHATS_APP_MAX_SECTIONS) {
+            error("sections count in list message should not exceed $WHATS_APP_MAX_SECTIONS.")
+        }
     }
 }
 
+/**
+ * Creates a section for an interactive list message
+ *
+ * Limitations:
+ * - [title] is limited to 24 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [rows] in the section
+ * - there can be a maximum of 10 [rows] across all sections in a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudQuickReply
+ */
+fun I18nTranslator.whatsAppCloudListSection(title: CharSequence, vararg rows: QuickReply) = whatsAppCloudListSection(title, listOf(*rows))
 
+/**
+ * Creates a section for an interactive list message
+ *
+ * Limitations:
+ * - [title] is limited to 24 characters
+ * - each [quick reply's title][QuickReply.title] is limited to 24 characters
+ * - each [quick reply's description][QuickReply.description] is limited to 72 characters
+ * - there can be a maximum of 10 [rows] in the section
+ * - there can be a maximum of 10 [rows] across all sections in a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudQuickReply
+ */
+fun I18nTranslator.whatsAppCloudListSection(title: CharSequence, rows: List<QuickReply>) = WhatsAppCloudBotActionSection(
+    title = translate(title).toString().checkLength(WHATS_APP_SECTION_TITLE_MAX_LENGTH),
+    rows = rows.map { qr -> WhatsAppBotRow(
+        id = qr.payload,
+        title = translate(qr.title).toString().checkLength(WHATS_APP_ROW_TITLE_MAX_LENGTH),
+        description = translate(qr.description).toString().checkLength(WHATS_APP_ROW_DESCRIPTION_MAX_LENGTH)
+    ) }
+)
+
+
+/**
+ * Creates a [Location Request Message](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-messages/location-request-messages)
+ *
+ * Limitations:
+ * - [text] is limited to 1024 characters
+ */
 fun I18nTranslator.whatsAppCloudReplyLocationMessage(
     text: CharSequence
 ): WhatsAppCloudBotInteractiveMessage = WhatsAppCloudBotInteractiveMessage(
@@ -270,7 +485,7 @@ fun I18nTranslator.whatsAppCloudReplyLocationMessage(
     recipientType = WhatsAppCloudBotRecipientType.individual,
     interactive = WhatsAppCloudBotInteractive(
         type = WhatsAppCloudBotInteractiveType.location_request_message,
-        body = WhatsAppCloudBotBody(translate(text).toString()),
+        body = WhatsAppCloudBotBody(translate(text).toString().checkLength(WHATS_APP_REPLY_BUTTON_BODY_MAX_LENGTH)),
         action = WhatsAppCloudBotAction(
             name = "send_location"
         )
@@ -278,6 +493,14 @@ fun I18nTranslator.whatsAppCloudReplyLocationMessage(
 )
 
 
+/**
+ * Creates a quick reply for a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudListSection
+ * @see whatsAppCloudReplyButtonMessage
+ * @see whatsAppCloudReplyImgButtonMessage
+ */
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     targetIntent: IntentAware,
@@ -285,6 +508,14 @@ fun <T : Bus<T>> T.whatsAppCloudQuickReply(
 ): QuickReply =
     whatsAppCloudQuickReply(title, targetIntent, stepName, parameters.toMap())
 
+/**
+ * Creates a quick reply for a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudListSection
+ * @see whatsAppCloudReplyButtonMessage
+ * @see whatsAppCloudReplyImgButtonMessage
+ */
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     targetIntent: IntentAware,
@@ -292,16 +523,36 @@ fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     vararg parameters: Pair<String, String>
 ): QuickReply = whatsAppCloudQuickReply(title, targetIntent.wrappedIntent(), step?.name, parameters.toMap())
 
+@Deprecated("Use step object directly instead of its name")
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     targetIntent: IntentAware,
     step: String? = null,
     parameters: Map<String, String> = mapOf()
 ): QuickReply =
-    whatsAppCloudQuickReply(title, targetIntent, step, parameters) { intent, s, params ->
+    whatsAppCloudQuickReply(title, null, targetIntent, step, parameters) { intent, s, params ->
         SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
     }
 
+/**
+ * Creates a quick reply for a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudListSection
+ * @see whatsAppCloudReplyButtonMessage
+ * @see whatsAppCloudReplyImgButtonMessage
+ */
+fun <T : Bus<T>> T.whatsAppCloudQuickReply(
+    title: CharSequence,
+    targetIntent: IntentAware,
+    step: StoryStep<*>? = null,
+    parameters: Map<String, String> = mapOf()
+): QuickReply =
+    whatsAppCloudQuickReply(title, null, targetIntent, step?.name, parameters) { intent, s, params ->
+        SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
+    }
+
+@Deprecated("Use step object directly instead of its name")
 fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
@@ -313,30 +564,41 @@ fun <T : Bus<T>> T.whatsAppCloudQuickReply(
         SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
     }
 
-private fun I18nTranslator.whatsAppCloudQuickReply(
+/**
+ * Creates a quick reply for a message
+ *
+ * @see whatsAppCloudListMessage
+ * @see whatsAppCloudListSection
+ * @see whatsAppCloudReplyButtonMessage
+ * @see whatsAppCloudReplyImgButtonMessage
+ */
+fun <T : Bus<T>> T.whatsAppCloudQuickReply(
     title: CharSequence,
+    subTitle: CharSequence? = null,
     targetIntent: IntentAware,
-    step: String? = null,
-    parameters: Map<String, String>,
-    payloadEncoder: (IntentAware, String?, Map<String, String>) -> String
-): QuickReply = QuickReply(
-    translate(title).toString(),
-    payloadEncoder.invoke(targetIntent, step, parameters)
-)
+    step: StoryStep<*>? = null,
+    parameters: Map<String, String> = mapOf()
+): QuickReply =
+    whatsAppCloudQuickReply(title,subTitle, targetIntent, step?.name, parameters) { intent, s, params ->
+        SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
+    }
 
-private fun I18nTranslator.whatsAppCloudQuickReply(
+private inline fun I18nTranslator.whatsAppCloudQuickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
     targetIntent: IntentAware,
     step: String? = null,
     parameters: Map<String, String>,
-    payloadEncoder: (IntentAware, String?, Map<String, String>) -> String
+    encodePayload: (IntentAware, String?, Map<String, String>) -> String
 ): QuickReply = QuickReply(
     translate(title).toString(),
-    payloadEncoder.invoke(targetIntent, step, parameters),
+    encodePayload(targetIntent, step, parameters),
     translate(subTitle).toString()
 )
 
+/**
+ * This quick reply does not use any custom payload, but the [textToSend] will we parsed by the NLP engine.
+ */
 fun I18nTranslator.whatsAppCloudNlpQuickReply(
     title: CharSequence,
     textToSend: CharSequence = title,
@@ -345,10 +607,22 @@ fun I18nTranslator.whatsAppCloudNlpQuickReply(
     SendChoice.encodeNlpChoiceId(translate(textToSend).toString()),
 )
 
-fun I18nTranslator.whatsAppCloudBuildTemplateMessage(
+@Deprecated("renamed", ReplaceWith("whatsAppBuildCloudTemplateMessage(templateName, languageCode, components)"))
+fun I18nTranslator.whatsAppBuildCloudTemplateMessage(
     templateName: String,
     languageCode: String,
-    components: List<Component>
+    components: List<WhatsappTemplateComponent>
+) = whatsAppCloudTemplateMessage(templateName, languageCode, components)
+
+/**
+ * Creates a [Template Message](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates)
+ *
+ * Note: this type of message incurs additional costs for each use
+ */
+fun I18nTranslator.whatsAppCloudTemplateMessage(
+    templateName: String,
+    languageCode: String,
+    components: List<WhatsappTemplateComponent>
 ): WhatsAppCloudBotTemplateMessage {
     return WhatsAppCloudBotTemplateMessage(
         messagingProduct = "whatsapp",
@@ -363,10 +637,21 @@ fun I18nTranslator.whatsAppCloudBuildTemplateMessage(
     )
 }
 
-
+@Deprecated("renamed", ReplaceWith("whatsAppCloudTemplateMessageCarousel(templateName, components, languageCode)"))
 fun I18nTranslator.whatsAppCloudBuildTemplateMessageCarousel(
     templateName: String,
-    components: List<Component.Card>,
+    components: List<WhatsappTemplateComponent.Card>,
+    languageCode: String
+) = whatsAppCloudTemplateMessageCarousel(templateName, components, languageCode)
+
+/**
+ * Creates a [Media Card Carousel Template](https://developers.facebook.com/docs/whatsapp/cloud-api/guides/send-message-templates/media-card-carousel-templates)
+ *
+ * Note: this type of message incurs additional costs for each use
+ */
+fun I18nTranslator.whatsAppCloudTemplateMessageCarousel(
+    templateName: String,
+    components: List<WhatsappTemplateComponent.Card>,
     languageCode: String
 ): WhatsAppCloudBotTemplateMessage {
     return WhatsAppCloudBotTemplateMessage(
@@ -378,7 +663,7 @@ fun I18nTranslator.whatsAppCloudBuildTemplateMessageCarousel(
                 code = languageCode,
             ),
             components = listOf(
-                Component.Carousel(
+                WhatsappTemplateComponent.Carousel(
                     type = ComponentType.CAROUSEL,
                     cards = components
                 )
@@ -387,23 +672,40 @@ fun I18nTranslator.whatsAppCloudBuildTemplateMessageCarousel(
     )
 }
 
-
-fun <T : Bus<T>> T.whatsAppCloudCardCarousel(
+/**
+ * Creates a Media Card for a Carousel Template
+ *
+ * @param cardIndex the index of the card within the carousel
+ * @param components the list of components making up the card
+ * @see whatsAppCloudTemplateMessageCarousel
+ * @see whatsAppCloudTemplateBody
+ */
+fun <T : Bus<T>> T.whatsAppCloudTemplateCard(
     cardIndex: Int,
-    components: List<Component>
-): Component.Card = Component.Card(
+    components: List<WhatsappTemplateComponent>
+): WhatsappTemplateComponent.Card = WhatsappTemplateComponent.Card(
     cardIndex = cardIndex,
     components = components
 )
 
+@Deprecated("renamed", ReplaceWith("whatsAppCloudTemplateCardBody(templateName, components, languageCode)"))
 fun <T : Bus<T>> T.whatsAppCloudBodyTemplate(
     parameters: List<TextParameter>
-): Component.Body = Component.Body(
+) = whatsAppCloudTemplateBody(parameters)
+
+/**
+ * Creates a body component for a template
+ *
+ * @see whatsAppCloudTemplateCard
+ */
+fun <T : Bus<T>> T.whatsAppCloudTemplateBody(
+    parameters: List<TextParameter>
+): WhatsappTemplateComponent.Body = WhatsappTemplateComponent.Body(
     type = ComponentType.BODY,
     parameters = parameters
 )
 
-@Deprecated("use whatsAppCloudTextParameterTemplate(typeParameter: ParameterType,textButton: CharSequence?) instead")
+@Deprecated("use whatsAppCloudTextParameterTemplate(textButton) instead")
 fun <T : Bus<T>> T.whatsAppCloudTextParameterTemplate(
     typeParameter: CharSequence?,
     textButton: CharSequence?
@@ -413,84 +715,89 @@ fun <T : Bus<T>> T.whatsAppCloudTextParameterTemplate(
 )
 
 fun <T : Bus<T>> T.whatsAppCloudTextParameterTemplate(
-    typeParameter: ParameterType,
-    textButton: CharSequence?
+    buttonTitle: CharSequence?
 ): TextParameter = TextParameter(
-    type = typeParameter,
-    text = translate(textButton).toString(),
+    type = ParameterType.TEXT,
+    text = translate(buttonTitle).toString(),
 )
 
 fun whatsAppCloudButtonTemplate(
-    index: String,
-    subType: String,
+    index: Int,
+    subType: ButtonSubType,
     parameters: List<PayloadParameter>
-): Component.Button = Component.Button(
+): WhatsappTemplateComponent.Button = WhatsappTemplateComponent.Button(
     type = ComponentType.BUTTON,
-    subType = ButtonSubType.valueOf(subType),
-    index = index,
+    subType = subType,
+    index = index.toString(),
     parameters = parameters
 )
 
 fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
-    index: String,
+    index: Int,
     textButton: String,
     payload: String?
-): Component.Button = whatsAppCloudButtonTemplate(
-    index, ButtonSubType.QUICK_REPLY.name, listOf(
-        whatsAppCloudPayloadParameterTemplate(textButton, payload, ParameterType.PAYLOAD.name)
+): WhatsappTemplateComponent.Button = whatsAppCloudButtonTemplate(
+    index, ButtonSubType.QUICK_REPLY, listOf(
+        whatsAppCloudPayloadParameterTemplate(textButton, payload, ParameterType.PAYLOAD)
     )
 )
 
 fun <T : Bus<T>> T.whatsAppCloudPostbackButton(
-    index: String,
+    index: Int,
     title: CharSequence,
     targetIntent: IntentAware,
     step: StoryStep<out StoryHandlerDefinition>? = null,
     parameters: Parameters = Parameters()
-): Component.Button = whatsAppCloudPostbackButton(
+): WhatsappTemplateComponent.Button = whatsAppCloudPostbackButton(
     index = index,
     textButton = translate(title).toString(),
-    targetIntent.let { i -> SendChoice.encodeChoiceId(this, i, step, parameters.toMap() + (index to index)) }
+    // Add an index parameter to ensure that all buttons in the list have unique ids
+    targetIntent.let { i -> SendChoice.encodeChoiceId(this, i, step, parameters.toMap() + (index.toString() to index.toString())) }
 )
 
 fun <T : Bus<T>> T.whatsAppCloudNLPPostbackButton(
-    index: String,
+    index: Int,
     title: CharSequence,
     textToSend: CharSequence = title,
-): Component.Button = whatsAppCloudPostbackButton(
+): WhatsappTemplateComponent.Button = whatsAppCloudPostbackButton(
     index = index,
     textButton = translate(title).toString(),
     payload = SendChoice.encodeNlpChoiceId(translate(textToSend).toString()),
 )
 
 fun <T : Bus<T>> T.whatsAppCloudUrlButton(
-    index: String,
+    index: Int,
     textButton: String,
-): Component.Button = whatsAppCloudButtonTemplate(
-    index, ButtonSubType.URL.name, listOf(
-        whatsAppCloudPayloadParameterTemplate(textButton, null, ParameterType.TEXT.name)
+): WhatsappTemplateComponent.Button = whatsAppCloudButtonTemplate(
+    index, ButtonSubType.URL, listOf(
+        whatsAppCloudPayloadParameterTemplate(textButton, null, ParameterType.TEXT)
     )
 )
 
 fun whatsAppCloudPayloadParameterTemplate(
     textButton: String,
     payload: String?,
-    typeParameter: String,
+    typeParameter: ParameterType,
 ): PayloadParameter = PayloadParameter(
-    type = ParameterType.valueOf(typeParameter),
+    type = typeParameter,
     payload = payload,
     text = textButton,
 )
 
 
+@Deprecated("renamed", ReplaceWith("whatsAppCloudTemplateImageHeader(imageId)"))
 fun whatsAppCloudHeaderTemplate(
     typeParameter: String,
     imageId: String
-): Component.Header = Component.Header(
+) = whatsAppCloudTemplateImageHeader(imageId)
+
+fun whatsAppCloudTemplateImageHeader(
+    imageId: String
+): WhatsappTemplateComponent.Header = WhatsappTemplateComponent.Header(
     type = ComponentType.HEADER,
     parameters = listOf(
         HeaderParameter.Image(
-            type = ParameterType.valueOf(typeParameter),
+            type = ParameterType.IMAGE,
             image = ImageId(
                 id = imageId
             )
@@ -498,9 +805,30 @@ fun whatsAppCloudHeaderTemplate(
     )
 )
 
-private fun String.checkLength(maxLength: Int): String {
-    if (maxLength > 0 && this.length > maxLength) {
-        logger.info { "text $this should not exceed $maxLength chars." }
+private inline fun <T> List<T>.checkCount(maxCount: Int, errorMessage: (Int) -> String): List<T> {
+    return if (this.size > maxCount) {
+        val msg = errorMessage(this.size) + " (max: $maxCount)"
+        if (errorOnInvalidMessages) {
+            throw IllegalArgumentException(msg)
+        } else {
+            logger.warn(msg)
+            this.take(maxCount)
+        }
+    } else {
+        this
     }
-    return this
+}
+
+private fun String.checkLength(maxLength: Int, textType: String = "text"): String {
+    return if (maxLength > 0 && this.length > maxLength) {
+        val msg = "$textType \"$this\" should not exceed $maxLength chars."
+        if (errorOnInvalidMessages) {
+            throw IllegalArgumentException(msg)
+        } else {
+            logger.warn(msg)
+            this.take(maxLength - 1) + "…"
+        }
+    } else {
+        this
+    }
 }

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotInteractive.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotInteractive.kt
@@ -111,7 +111,7 @@ data class WhatsAppCloudBotActionSection(
 data class WhatsAppBotRow(
     val id: String,
     val title: String,
-    val description: CharSequence? = null,
+    val description: String? = null,
 ) {
     fun toChoice() : Choice =
         SendChoice.decodeChoiceId(id)

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
@@ -24,39 +24,41 @@ enum class ButtonSubType { QUICK_REPLY, URL, PHONE_NUMBER }
 data class WhatsAppCloudBotTemplate(
     val name: String,
     val language: Language,
-    val components: List<WhatsappTemplateComponent>
+    val components: List<Component>
 )
 
 data class Language(@JsonProperty("code") val code: String)
 
-sealed class WhatsappTemplateComponent {
+// TODO (breaking) finish renaming Component to WhatsappTemplateComponent
+typealias WhatsappTemplateComponent = Component
+sealed class Component {
     abstract val type: ComponentType
 
     data class Body(
         override val type: ComponentType = ComponentType.BODY,
         val parameters: List<TextParameter>
-    ) : WhatsappTemplateComponent()
+    ) : Component()
 
     data class Header(
         override val type: ComponentType = ComponentType.HEADER,
         val parameters: List<HeaderParameter>
-    ) : WhatsappTemplateComponent()
+    ) : Component()
 
     data class Button(
         override val type: ComponentType = ComponentType.BUTTON,
         @JsonProperty("sub_type") val subType: ButtonSubType,
         val index: String,
         val parameters: List<PayloadParameter>
-    ) : WhatsappTemplateComponent()
+    ) : Component()
 
     data class Carousel(
         override val type: ComponentType = ComponentType.CAROUSEL,
         val cards: List<Card>
-    ) : WhatsappTemplateComponent()
+    ) : Component()
 
     data class Card(
         @JsonProperty("card_index") val cardIndex: Int,
-        val components: List<WhatsappTemplateComponent>
+        val components: List<Component>
     )
 }
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
@@ -24,39 +24,39 @@ enum class ButtonSubType { QUICK_REPLY, URL, PHONE_NUMBER }
 data class WhatsAppCloudBotTemplate(
     val name: String,
     val language: Language,
-    val components: List<Component>
+    val components: List<WhatsappTemplateComponent>
 )
 
 data class Language(@JsonProperty("code") val code: String)
 
-sealed class Component {
+sealed class WhatsappTemplateComponent {
     abstract val type: ComponentType
 
     data class Body(
         override val type: ComponentType = ComponentType.BODY,
         val parameters: List<TextParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Header(
         override val type: ComponentType = ComponentType.HEADER,
         val parameters: List<HeaderParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Button(
         override val type: ComponentType = ComponentType.BUTTON,
         @JsonProperty("sub_type") val subType: ButtonSubType,
         val index: String,
         val parameters: List<PayloadParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Carousel(
         override val type: ComponentType = ComponentType.CAROUSEL,
         val cards: List<Card>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Card(
         @JsonProperty("card_index") val cardIndex: Int,
-        val components: List<Component>
+        val components: List<WhatsappTemplateComponent>
     )
 }
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTextMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTextMessage.kt
@@ -26,16 +26,18 @@ data class WhatsAppCloudBotTextMessage (
         val text: TextContent,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val userId: String? = null,
+        val previewUrl: Boolean = false,
 ) : WhatsAppCloudBotMessage(WhatsAppCloudBotMessageType.text, userId) {
     override fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage =
             WhatsAppCloudSendBotTextMessage(
                     messagingProduct,
                     text,
                     recipientType,
-                    recipientId
+                    recipientId,
+                    previewUrl,
             )
 
-    override fun toGenericMessage(): GenericMessage? =
+    override fun toGenericMessage(): GenericMessage =
             GenericMessage(
                     texts = mapOf(GenericMessage.TEXT_PARAM to text.body),
             )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
@@ -30,7 +30,7 @@ import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSend
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotLocationMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotTextMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsappTemplateComponent
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.Component
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.HeaderParameter
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionButton
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionSection
@@ -211,8 +211,8 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
     ) {
         val updatedComponents = messageRequest.template.components.map { component ->
             when (component) {
-                is WhatsappTemplateComponent.Carousel -> updateCarouselPayloads(component)
-                is WhatsappTemplateComponent.Button -> updateTemplateButton(component)
+                is Component.Carousel -> updateCarouselPayloads(component)
+                is Component.Button -> updateTemplateButton(component)
                 else -> component
             }
         }
@@ -226,10 +226,10 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         sendUpdatedTemplateMessage(phoneNumberId, token, updatedMessageRequest)
     }
 
-    private fun updateCarouselPayloads(carousel: WhatsappTemplateComponent.Carousel): WhatsappTemplateComponent.Carousel {
+    private fun updateCarouselPayloads(carousel: Component.Carousel): Component.Carousel {
         val updatedCards = carousel.cards.map { card ->
             val updatedComponents = card.components.map { component ->
-                if (component is WhatsappTemplateComponent.Button) {
+                if (component is Component.Button) {
                     updateTemplateButton(component)
                 } else {
                     component
@@ -240,7 +240,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         return carousel.copy(cards = updatedCards)
     }
 
-    private fun updateTemplateButton(button: WhatsappTemplateComponent.Button): WhatsappTemplateComponent.Button =
+    private fun updateTemplateButton(button: Component.Button): Component.Button =
         button.copy(parameters = button.parameters.map { parameters ->
             parameters.payload?.takeIf { it.length >= 128 }?.let {
                 val uuidPayload = UUID.randomUUID().toString()
@@ -380,10 +380,10 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
     ) {
         messageRequest.template.components
             .asSequence()
-            .filterIsInstance<WhatsappTemplateComponent.Carousel>()
+            .filterIsInstance<Component.Carousel>()
             .flatMap { it.cards }
             .flatMap { it.components }
-            .filterIsInstance<WhatsappTemplateComponent.Header>()
+            .filterIsInstance<Component.Header>()
             .flatMap { it.parameters }
             .filterIsInstance<HeaderParameter.Image>()
             .filter { it.image.id != null }


### PR DESCRIPTION
#1605 and #1637 implemented payload shortening for template and reply button messages respectively.

This PR resolves #1852 by applying the same payload shortening logic to list messages. It also adds documentation in the form of a new readme and KDoc on the message factory methods.