### PR TITLE
[Tock Studio] LLM Playground View

### DIFF
--- a/bot/admin/web/src/app/bot-admin-app-routing.module.ts
+++ b/bot/admin/web/src/app/bot-admin-app-routing.module.ts
@@ -39,6 +39,10 @@ const routes: Routes = [
     path: 'rag',
     loadChildren: () => import('./rag/rag.module').then((m) => m.RagModule)
   },
+  {
+    path: 'playground',
+    loadChildren: () => import('./playground/playground.module').then((m) => m.PlaygroundModule)
+  },
   { path: '**', redirectTo: '/language-understanding/inbox' }
 ];
 

--- a/bot/admin/web/src/app/bot-admin-app.component.ts
+++ b/bot/admin/web/src/app/bot-admin-app.component.ts
@@ -248,6 +248,12 @@ export class BotAdminAppComponent implements AuthListener, OnInit, OnDestroy {
             title: 'Vector DB settings',
             icon: 'database',
             hidden: !this.state.hasRole(UserRole.admin)
+          },
+          {
+            link: '/playground',
+            title: 'Playground',
+            icon: 'joystick',
+            hidden: !this.state.hasRole(UserRole.admin)
           }
         ]
       },

--- a/bot/admin/web/src/app/bot/story/search-story/stories-upload/stories-upload.component.ts
+++ b/bot/admin/web/src/app/bot/story/search-story/stories-upload/stories-upload.component.ts
@@ -45,7 +45,7 @@ export class StoriesUploadComponent implements OnInit {
 
   private loadRagSettings() {
     this.loading = true;
-    const url = `/configuration/bots/${this.state.currentApplication.name}/rag`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/rag`;
     this.rest
       .get<RagSettings>(url, (settings: RagSettings) => settings)
       .subscribe((settings: RagSettings) => {
@@ -110,9 +110,9 @@ export class StoriesUploadComponent implements OnInit {
       context: {
         title: `Unknown story detected : ${story.name}`,
         subtitle: `
-        The batch of stories provided contains a story (${story.name}) whose intent is 'unknown' while Retrieval Augmented Generation (RAG) is active. 
-        When RAG is active, the 'unkown' story is replaced by the RAG. It is therefore not possible to import the indicated story and keep the RAG active. 
-        
+        The batch of stories provided contains a story (${story.name}) whose intent is 'unknown' while Retrieval Augmented Generation (RAG) is active.
+        When RAG is active, the 'unkown' story is replaced by the RAG. It is therefore not possible to import the indicated story and keep the RAG active.
+
         What do you want to do:
         - Deactivate the RAG and activate the 'unknown' story
         - Deactivate the 'unknown' story and keep the RAG active`,

--- a/bot/admin/web/src/app/configuration/compressor-settings/compressor-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/compressor-settings/compressor-settings.component.ts
@@ -93,7 +93,7 @@ export class CompressorSettingsComponent implements OnInit, OnDestroy {
   }
 
   private getCompressorSettingsLoader(): Observable<CompressorSettings> {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/document-compressor`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/document-compressor`;
     return this.rest.get<CompressorSettings>(url, (settings: CompressorSettings) => settings);
   }
 
@@ -178,7 +178,7 @@ export class CompressorSettingsComponent implements OnInit, OnDestroy {
 
       delete formValue['compressorProvider'];
 
-      const url = `/configuration/bots/${this.state.currentApplication.name}/document-compressor`;
+      const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/document-compressor`;
       this.rest.post(url, formValue, null, null, true).subscribe({
         next: (compressorSettings: CompressorSettings) => {
           this.settingsBackup = compressorSettings;
@@ -371,7 +371,7 @@ export class CompressorSettingsComponent implements OnInit, OnDestroy {
   }
 
   deleteSettings() {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/document-compressor`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/document-compressor`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;
       this.form.reset();

--- a/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
@@ -94,7 +94,7 @@ export class ObservabilitySettingsComponent implements OnInit, OnDestroy {
   }
 
   private getObservabilitySettingsLoader(): Observable<ObservabilitySettings> {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/observability`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/observability`;
     return this.rest.get<ObservabilitySettings>(url, (settings: ObservabilitySettings) => settings);
   }
 
@@ -178,7 +178,7 @@ export class ObservabilitySettingsComponent implements OnInit, OnDestroy {
 
       delete formValue['observabilityProvider'];
 
-      const url = `/configuration/bots/${this.state.currentApplication.name}/observability`;
+      const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/observability`;
       this.rest.post(url, formValue, null, null, true).subscribe({
         next: (observabilitySettings: ObservabilitySettings) => {
           this.settingsBackup = observabilitySettings;
@@ -372,7 +372,7 @@ export class ObservabilitySettingsComponent implements OnInit, OnDestroy {
   }
 
   deleteSettings() {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/observability`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/observability`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;
       this.form.reset();

--- a/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/sentence-generation-settings/sentence-generation-settings.component.ts
@@ -175,7 +175,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   }
 
   private getSentenceGenerationSettingsLoader(): Observable<SentenceGenerationSettings> {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/configuration`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/sentence-generation`;
     return this.rest.get<SentenceGenerationSettings>(url, (settings: SentenceGenerationSettings) => settings);
   }
 
@@ -225,7 +225,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
 
       delete formValue['llmProvider'];
 
-      const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/configuration`;
+      const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/sentence-generation`;
       this.rest.post(url, formValue, null, null, true).subscribe({
         next: (genAiSettings: SentenceGenerationSettings) => {
           this.settingsBackup = genAiSettings;
@@ -421,7 +421,7 @@ export class SentenceGenerationSettingsComponent implements OnInit, OnDestroy {
   }
 
   deleteSettings(): void {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/configuration`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/sentence-generation`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;
       this.form.reset();

--- a/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.ts
@@ -94,7 +94,7 @@ export class VectorDbSettingsComponent implements OnInit {
   }
 
   private getVectorDbSettingsLoader(): Observable<VectorDbSettings> {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/vector-store`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/vector-store`;
     return this.rest.get<VectorDbSettings>(url, (settings: VectorDbSettings) => settings);
   }
 
@@ -178,7 +178,7 @@ export class VectorDbSettingsComponent implements OnInit {
 
       delete formValue['vectorDbProvider'];
 
-      const url = `/configuration/bots/${this.state.currentApplication.name}/vector-store`;
+      const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/vector-store`;
       this.rest.post(url, formValue, null, null, true).subscribe({
         next: (vectorDbSettings: VectorDbSettings) => {
           this.settingsBackup = vectorDbSettings;
@@ -371,7 +371,7 @@ export class VectorDbSettingsComponent implements OnInit {
   }
 
   deleteSettings() {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/vector-store`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/vector-store`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;
       this.form.reset();

--- a/bot/admin/web/src/app/playground/playground-routing.module.ts
+++ b/bot/admin/web/src/app/playground/playground-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from '../core-nlp/auth/auth.guard';
+import { ApplicationResolver } from '../core-nlp/application.resolver';
+import { PlaygroundComponent } from './playground.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    canActivate: [AuthGuard],
+    component: PlaygroundComponent,
+    resolve: {
+      application: ApplicationResolver
+    }
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PlaygroundRoutingModule {}

--- a/bot/admin/web/src/app/playground/playground.component.html
+++ b/bot/admin/web/src/app/playground/playground.component.html
@@ -1,0 +1,306 @@
+<div class="d-flex flex-wrap align-items-center">
+  <h1 class="flex-grow-1">Gen AI playground</h1>
+
+  <section class="grid-actions">
+    <button
+      nbButton
+      ghost
+      shape="round"
+      nbTooltip="Import Rag settings dump"
+      (click)="importSettings()"
+    >
+      <nb-icon icon="upload"></nb-icon>
+    </button>
+  </section>
+</div>
+
+<tock-no-data-found
+  *ngIf="configurations?.length === 0"
+  title="No bot configuration detected"
+></tock-no-data-found>
+
+<form
+  [formGroup]="form"
+  *ngIf="configurations?.length > 0"
+>
+  <nb-card class="mb-3">
+    <nb-card-header class="p-0 border-bottom">
+      <nb-accordion
+        multi
+        class="shadow-none"
+      >
+        <nb-accordion-item
+          [expanded]="llmSettingsIsExpanded"
+          class="settings-card"
+        >
+          <nb-accordion-item-header>
+            LLM settings
+
+            <ng-container *ngIf="getCurrentProviderLabel()">
+              (
+              {{ getCurrentProviderLabel() }}
+              <ng-container *ngIf="questionAnsweringLlmSetting.value?.model">
+                | {{ questionAnsweringLlmSetting.value.model }}
+              </ng-container>
+              )
+            </ng-container>
+          </nb-accordion-item-header>
+
+          <nb-accordion-item-body>
+            <tock-form-control
+              name="questionAnsweringLlmProvider"
+              [controls]="questionAnsweringLlmProvider"
+              [required]="true"
+              [showError]="isSubmitted"
+              [hasMargin]="false"
+            >
+              <nb-radio-group
+                formControlName="questionAnsweringLlmProvider"
+                name="questionAnsweringLlmProvider"
+                class="d-flex"
+              >
+                <nb-radio
+                  *ngFor="let engine of enginesConfigurations[engineSettingKeyName.questionAnsweringLlmSetting]"
+                  [value]="engine.key"
+                >
+                  {{ engine.label }}
+                </nb-radio>
+              </nb-radio-group>
+            </tock-form-control>
+
+            <div
+              *ngIf="currentQuestionAnsweringConfig"
+              class="mt-3"
+            >
+              <div class="row">
+                <ng-container *ngFor="let param of currentQuestionAnsweringConfig.params">
+                  <div
+                    class="col-12 px-3"
+                    [ngClass]="{ 'col-lg-6': param.inputScale !== 'fullwidth' }"
+                  >
+                    <tock-ai-settings-engine-config-param-input
+                      [parentGroup]="engineSettingKeyName.questionAnsweringLlmSetting"
+                      [configurationParam]="param"
+                      [form]="form"
+                      [isSubmitted]="isSubmitted"
+                    ></tock-ai-settings-engine-config-param-input>
+                  </div>
+                </ng-container>
+              </div>
+            </div>
+          </nb-accordion-item-body>
+        </nb-accordion-item>
+      </nb-accordion>
+    </nb-card-header>
+
+    <nb-card-body class="d-flex justify-content-between align-items-start pr-3">
+      <nb-form-field class="w-100 align-items-start">
+        <textarea
+          #textareaPromptRef
+          id="prompt-textarea"
+          class="w-100"
+          rows="6"
+          nbInput
+          fullWidth
+          fieldSize="medium"
+          placeholder="Enter your prompt here..."
+          formControlName="prompt"
+          (keydown.enter)="preventDefault($event)"
+          (keyup.enter)="submit($event)"
+          autocomplete="off"
+          spellcheck="false"
+          tockAutofocusElement
+          class="scrollbar-narrow"
+          [readonly]="testQueryInProgress"
+        ></textarea>
+
+        <button
+          nbSuffix
+          nbButton
+          ghost
+          [nbContextMenu]="promptTemplateShortcuts"
+          nbContextMenuTag="prompt-template-shortcuts"
+        >
+          <nb-icon
+            icon="chevron-down-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+
+        <button
+          nbSuffix
+          nbButton
+          ghost
+          nbTooltip="Expand/reduce the input area"
+          [style.margin]="getPromptShortcutsMargin()"
+          (click)="expandTextareaPrompt()"
+        >
+          <nb-icon icon="arrows-angle-expand"></nb-icon>
+        </button>
+      </nb-form-field>
+
+      <div
+        class="ml-2"
+        style="width: min-content"
+      >
+        <button
+          nbButton
+          size="medium"
+          status="primary"
+          nbTooltip="Send query"
+          (click)="submit()"
+          [disabled]="testQueryInProgress || !form.valid || !prompt.value?.length"
+        >
+          <nb-icon icon="send"></nb-icon>
+        </button>
+
+        <button
+          *ngIf="messages.length !== 0"
+          nbTooltip="Clear history"
+          nbButton
+          status="warning"
+          size="medium"
+          class="mt-2"
+          (click)="clearHistory()"
+        >
+          <nb-icon icon="trash"></nb-icon>
+        </button>
+
+        <div
+          *ngIf="!testQueryInProgress && messagesHistory.length > 1"
+          class="border-top mt-2"
+        >
+          <button
+            type="button"
+            nbButton
+            ghost
+            size="medium"
+            nbTooltip="Go back in query history"
+            class="index-change-button"
+            (click)="messageHistoryMove(false)"
+            [disabled]="messagesHistoryCursor < 1"
+          >
+            <nb-icon
+              icon="chevron-up-outline"
+              pack="nebular-essentials"
+            ></nb-icon>
+          </button>
+
+          <button
+            type="button"
+            nbButton
+            ghost
+            size="medium"
+            nbTooltip="Move forward in query history"
+            class="index-change-button"
+            (click)="messageHistoryMove(true)"
+            [disabled]="messagesHistory.length < 2 || messagesHistoryCursor === messagesHistory.length - 1"
+          >
+            <nb-icon
+              icon="chevron-down-outline"
+              pack="nebular-essentials"
+            ></nb-icon>
+          </button>
+        </div>
+      </div>
+    </nb-card-body>
+
+    <nb-card-footer
+      class="overflow-visible px-2"
+      *ngIf="testQueryInProgress || messages.length"
+    >
+      <div #resultWrapper>
+        <tock-chat-ui
+          padding="0.2em 0.5em 0 0.2em"
+          [mayScroll]="false"
+          [queryInProgress]="testQueryInProgress"
+        >
+          <tock-chat-ui-message
+            *ngFor="let message of messages"
+            [message]="message.message.message"
+            [reply]="message.message.bot"
+            [avatar]="getUserAvatar(message.message.bot)"
+            switchFormattingPos="afterAvatar"
+          >
+            <ng-container *ngIf="message.observabilityInfo">
+              <br />
+              <button
+                nbButton
+                ghost
+                size="small"
+                nbTooltip="View observability details"
+                class="mb-2"
+                (click)="openObservabilityTrace(message)"
+              >
+                <nb-icon icon="display"></nb-icon>
+              </button>
+            </ng-container>
+          </tock-chat-ui-message>
+        </tock-chat-ui>
+      </div>
+    </nb-card-footer>
+  </nb-card>
+</form>
+
+<tock-scroll-top-button></tock-scroll-top-button>
+
+<ng-template #importModal>
+  <nb-card class="help-modal">
+    <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+      Import Rag settings dump
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Cancel"
+        (click)="closeImportModal()"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </nb-card-header>
+
+    <nb-card-body>
+      <form
+        [formGroup]="importForm"
+        (submit)="submitImportSettings()"
+      >
+        <tock-form-control
+          label="Rag settings dump file"
+          name="importFile"
+          [required]="true"
+          [controls]="fileSource"
+          [showError]="isImportSubmitted"
+        >
+          <tock-file-upload
+            id="importFile"
+            formControlName="fileSource"
+            [autofocus]="true"
+            [fullWidth]="true"
+            [multiple]="false"
+            [fileTypeAccepted]="['json']"
+          ></tock-file-upload>
+        </tock-form-control>
+      </form>
+    </nb-card-body>
+
+    <nb-card-footer class="card-footer-actions">
+      <button
+        nbButton
+        ghost
+        size="small"
+        (click)="closeImportModal()"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        nbButton
+        status="primary"
+        size="small"
+        (click)="submitImportSettings()"
+      >
+        Import
+      </button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>

--- a/bot/admin/web/src/app/playground/playground.component.scss
+++ b/bot/admin/web/src/app/playground/playground.component.scss
@@ -1,0 +1,11 @@
+.settings-card {
+  background-color: var(--background-basic-color-2) !important;
+}
+
+.overflow-visible {
+  overflow: visible;
+}
+
+#prompt-textarea {
+  min-height: 10em;
+}

--- a/bot/admin/web/src/app/playground/playground.component.spec.ts
+++ b/bot/admin/web/src/app/playground/playground.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PlaygroundComponent } from './playground.component';
+
+describe('PlaygroundComponent', () => {
+  let component: PlaygroundComponent;
+  let fixture: ComponentFixture<PlaygroundComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlaygroundComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(PlaygroundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/bot/admin/web/src/app/playground/playground.component.ts
+++ b/bot/admin/web/src/app/playground/playground.component.ts
@@ -1,0 +1,402 @@
+import { Component, ElementRef, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Location } from '@angular/common';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { NbDialogRef, NbDialogService, NbMenuService, NbToastrService } from '@nebular/theme';
+import { FileValidators } from '../shared/validators';
+import { getDialogMessageUserAvatar, readFileAsText } from '../shared/utils';
+import { AiEngineProvider, AiEngineSettingKeyName, EnginesConfiguration, PromptDefinitionFormatter } from '../shared/model/ai-settings';
+import { EnginesConfigurations, QuestionAnsweringDefaultPrompt } from '../rag/rag-settings/models/engines-configurations';
+import { BotApplicationConfiguration } from '../core/model/configuration';
+import { Observable, Subject, filter, forkJoin, takeUntil } from 'rxjs';
+import { BotConfigurationService } from '../core/bot-configuration.service';
+import { RagSettings } from '../rag/rag-settings/models';
+import { StateService } from '../core-nlp/state.service';
+import { RestService } from '../core-nlp/rest/rest.service';
+import { TestMessage } from '../test/model/test';
+import { Sentence } from '../shared/model/dialog-data';
+
+interface PlaygroundForm {
+  questionAnsweringLlmProvider: FormControl<AiEngineProvider>;
+  questionAnsweringLlmSetting: FormGroup<any>;
+  questionAnsweringPromptTemplate: FormControl<string>;
+
+  prompt: FormControl<string>;
+}
+
+@Component({
+  selector: 'tock-playground',
+  templateUrl: './playground.component.html',
+  styleUrl: './playground.component.scss'
+})
+export class PlaygroundComponent implements OnInit, OnDestroy {
+  destroy$: Subject<unknown> = new Subject();
+
+  loading: boolean = false;
+
+  @ViewChild('textareaPromptRef') textareaPromptRef: ElementRef;
+  @ViewChild('importModal') importModal: TemplateRef<any>;
+  @ViewChild('resultWrapper') private resultWrapper: ElementRef;
+
+  configurations: BotApplicationConfiguration[];
+
+  isSubmitted: boolean = false;
+
+  enginesConfigurations = EnginesConfigurations;
+
+  engineSettingKeyName = AiEngineSettingKeyName;
+
+  llmSettingsIsExpanded: boolean = false;
+
+  testQueryInProgress: boolean = false;
+
+  messages: { message: TestMessage; observabilityInfo?: any }[] = [];
+
+  messagesHistory: { prompt: string; message: TestMessage; observabilityInfo?: any }[] = [];
+
+  messagesHistoryCursor: number = 0;
+
+  question_answering_prompt: string;
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    public state: StateService,
+    private rest: RestService,
+    private location: Location,
+    private nbDialogService: NbDialogService,
+    private toastrService: NbToastrService,
+    private nbMenuService: NbMenuService
+  ) {
+    this.question_answering_prompt = (this.location.getState() as any)?.question_answering_prompt;
+  }
+
+  ngOnInit(): void {
+    this.questionAnsweringLlmProvider.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((engine: AiEngineProvider) => {
+      this.initFormSettings(AiEngineSettingKeyName.questionAnsweringLlmSetting, engine);
+    });
+
+    this.nbMenuService
+      .onItemClick()
+      .pipe(filter(({ tag }) => tag === 'prompt-template-shortcuts'))
+      .subscribe((args) => {
+        const type = (args.item as any).type;
+        this.loadPromptTemplate(type);
+      });
+
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((confs: BotApplicationConfiguration[]) => {
+      this.loading = true;
+      this.configurations = confs;
+
+      if (confs.length) {
+        forkJoin([this.getRagSettingsLoader()]).subscribe((res) => {
+          const settings = res[0];
+          if (settings?.id) {
+            setTimeout(() => {
+              this.initForm(settings);
+            });
+          } else {
+            this.form.reset();
+            this.llmSettingsIsExpanded = true;
+          }
+
+          if (this.question_answering_prompt) {
+            this.form.patchValue({ prompt: this.question_answering_prompt });
+          }
+
+          this.loading = false;
+        });
+      } else {
+        this.form.reset();
+
+        this.loading = false;
+      }
+    });
+  }
+
+  private getRagSettingsLoader(): Observable<RagSettings> {
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/rag`;
+    return this.rest.get<RagSettings>(url, (settings: RagSettings) => settings);
+  }
+
+  form = new FormGroup<PlaygroundForm>({
+    questionAnsweringLlmProvider: new FormControl(undefined, [Validators.required]),
+    questionAnsweringLlmSetting: new FormGroup({}),
+    questionAnsweringPromptTemplate: new FormControl(),
+    prompt: new FormControl('')
+  });
+
+  get questionAnsweringLlmProvider(): FormControl {
+    return this.form.get('questionAnsweringLlmProvider') as FormControl;
+  }
+  get questionAnsweringLlmSetting(): FormControl {
+    return this.form.get('questionAnsweringLlmSetting') as FormControl;
+  }
+  get prompt(): FormControl {
+    return this.form.get('prompt') as FormControl;
+  }
+  get questionAnsweringPromptTemplate(): FormControl {
+    return this.form.get('questionAnsweringPromptTemplate') as FormControl;
+  }
+
+  get currentQuestionAnsweringConfig(): EnginesConfiguration {
+    return EnginesConfigurations[AiEngineSettingKeyName.questionAnsweringLlmSetting].find(
+      (e) => e.key === this.questionAnsweringLlmProvider.value
+    );
+  }
+
+  getCurrentProviderLabel(): string {
+    return this.enginesConfigurations[this.engineSettingKeyName.questionAnsweringLlmSetting].find(
+      (conf) => conf.key === this.questionAnsweringLlmProvider.value
+    )?.label;
+  }
+
+  initFormSettings(group: AiEngineSettingKeyName, provider: AiEngineProvider): void {
+    let requiredConfiguration: EnginesConfiguration = EnginesConfigurations[group].find((c) => c.key === provider);
+
+    if (requiredConfiguration) {
+      // Purge existing controls that may contain values incompatible with a new control with the same name after engine change
+      this.resetFormGroupControls(group);
+
+      requiredConfiguration.params.forEach((param) => {
+        this.form.controls[group].addControl(param.key, new FormControl(param.defaultValue, Validators.required));
+      });
+
+      this.form.controls[group].addControl('provider', new FormControl(provider));
+    }
+  }
+
+  resetFormGroupControls(group: string): void {
+    const existingGroupKeys = Object.keys(this.form.controls[group].controls);
+    existingGroupKeys.forEach((key) => {
+      this.form.controls[group].removeControl(key);
+    });
+  }
+
+  initForm(settings: RagSettings): void {
+    this.initFormSettings(AiEngineSettingKeyName.questionAnsweringLlmSetting, settings.questionAnsweringLlmSetting?.provider);
+
+    this.form.patchValue({
+      questionAnsweringLlmProvider: settings.questionAnsweringLlmSetting?.provider
+    });
+    this.form.patchValue(settings);
+
+    this.form.patchValue({
+      questionAnsweringPromptTemplate: settings.questionAnsweringPrompt?.template
+    });
+
+    this.form.markAsPristine();
+
+    this.llmSettingsIsExpanded = !this.form.valid;
+  }
+
+  preventDefault(event: Event): void {
+    event.preventDefault();
+  }
+
+  submit(event?: Event): void {
+    if (event) {
+      this.preventDefault(event);
+    }
+
+    if (!this.form.valid) return;
+
+    let m = this.prompt.value;
+    if (!m || m.trim().length === 0) {
+      return;
+    }
+
+    this.talk(m.trim());
+  }
+
+  talk(message: string) {
+    this.testQueryInProgress = true;
+    this.messages = [];
+
+    const formValue = this.form.value;
+
+    const payload = {
+      llmSetting: {
+        ...formValue.questionAnsweringLlmSetting,
+        provider: formValue.questionAnsweringLlmProvider
+      },
+      prompt: {
+        formatter: PromptDefinitionFormatter.jinja2,
+        inputs: {},
+        template: message
+      }
+    };
+
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/completion/playground`;
+    return this.rest.post(url, payload).subscribe({
+      next: (res: { answer: string; observabilityInfo?: any }) => {
+        this.messages.push({
+          message: new TestMessage(true, new Sentence(0, [], res.answer)),
+          observabilityInfo: res.observabilityInfo
+        });
+
+        this.messagesHistory.push({
+          prompt: message,
+          message: new TestMessage(true, new Sentence(0, [], res.answer)),
+          observabilityInfo: res.observabilityInfo
+        });
+
+        this.messagesHistoryCursor = this.messagesHistory.length - 1;
+
+        delete this.testQueryInProgress;
+        this.resultWrapper.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'start' });
+      },
+      error: (error) => {
+        console.log(error);
+        this.toastrService.danger('An error occured', 'Error', {
+          duration: 5000,
+          status: 'danger'
+        });
+        delete this.testQueryInProgress;
+      }
+    });
+  }
+
+  messageHistoryMove(forward: boolean) {
+    let hEntry;
+
+    if (!forward) {
+      if (this.messagesHistoryCursor > 0) {
+        this.messagesHistoryCursor--;
+        hEntry = this.messagesHistory[this.messagesHistoryCursor];
+      }
+    } else {
+      if (this.messagesHistoryCursor < this.messagesHistory.length - 1) {
+        this.messagesHistoryCursor++;
+        hEntry = this.messagesHistory[this.messagesHistoryCursor];
+      }
+    }
+
+    if (hEntry) {
+      this.messages = [
+        {
+          message: hEntry.message,
+          observabilityInfo: hEntry.observabilityInfo
+        }
+      ];
+
+      this.form.patchValue({ prompt: hEntry.prompt });
+    }
+  }
+
+  getUserAvatar(isBot: boolean): string {
+    return getDialogMessageUserAvatar(isBot);
+  }
+
+  openObservabilityTrace(message) {
+    window.open(message.observabilityInfo.traceUrl, '_blank');
+  }
+
+  expandTextareaPrompt() {
+    const defaultHeight = 160;
+    const textarea = this.textareaPromptRef?.nativeElement;
+    if (textarea.offsetHeight <= defaultHeight) {
+      textarea.style.height = 'auto';
+      textarea.style.height = Math.max(textarea.scrollHeight + 5, defaultHeight) + 'px';
+    } else {
+      textarea.style.height = `${defaultHeight}px`;
+    }
+  }
+
+  getPromptShortcutsMargin() {
+    const textarea = this.textareaPromptRef?.nativeElement;
+    if (textarea && textarea.clientHeight < textarea.scrollHeight) return '0 1em 0 0';
+
+    return '0';
+  }
+
+  promptTemplateShortcuts = [
+    { title: 'Load current bot prompt', type: 'current' },
+    { title: 'Load default prompt', type: 'default' },
+    { title: 'Clear prompt', type: 'clear' }
+  ];
+
+  loadPromptTemplate(wich: 'current' | 'default' | 'clear') {
+    if (wich === 'current') {
+      this.form.patchValue({ prompt: this.questionAnsweringPromptTemplate.value });
+    }
+    if (wich === 'default') {
+      this.form.patchValue({ prompt: QuestionAnsweringDefaultPrompt });
+    }
+
+    if (wich === 'clear') {
+      this.form.patchValue({ prompt: '' });
+    }
+  }
+
+  clearHistory() {
+    this.messages = [];
+    this.messagesHistory = [];
+    this.messagesHistoryCursor = 0;
+  }
+
+  // IMPORT
+
+  importModalRef: NbDialogRef<any>;
+
+  importSettings(): void {
+    this.isImportSubmitted = false;
+    this.importForm.reset();
+    this.importModalRef = this.nbDialogService.open(this.importModal);
+  }
+
+  closeImportModal(): void {
+    this.importModalRef.close();
+  }
+
+  isImportSubmitted: boolean = false;
+
+  importForm: FormGroup = new FormGroup({
+    fileSource: new FormControl<File[]>([], {
+      nonNullable: true,
+      validators: [Validators.required, FileValidators.mimeTypeSupported(['application/json'])]
+    })
+  });
+
+  get fileSource(): FormControl {
+    return this.importForm.get('fileSource') as FormControl;
+  }
+
+  get canSaveImport(): boolean {
+    return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
+  }
+
+  submitImportSettings(): void {
+    this.isImportSubmitted = true;
+    if (this.canSaveImport) {
+      const file = this.fileSource.value[0];
+
+      readFileAsText(file).then((fileContent) => {
+        const settings = JSON.parse(fileContent.data);
+
+        const hasCompatibleProvider = Object.values(AiEngineSettingKeyName).some((ekn) => {
+          return settings[ekn]?.provider && Object.values(AiEngineProvider).includes(settings[ekn].provider);
+        });
+
+        if (!hasCompatibleProvider) {
+          this.toastrService.show(
+            `The file supplied does not reference a compatible provider. Please check the file.`,
+            'Rag settings import fails',
+            {
+              duration: 6000,
+              status: 'danger'
+            }
+          );
+          return;
+        }
+
+        this.initForm(settings);
+
+        this.closeImportModal();
+      });
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/playground/playground.module.ts
+++ b/bot/admin/web/src/app/playground/playground.module.ts
@@ -1,0 +1,38 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PlaygroundComponent } from './playground.component';
+import { PlaygroundRoutingModule } from './playground-routing.module';
+import { BotSharedModule } from '../shared/bot-shared.module';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import {
+  NbAccordionModule,
+  NbButtonModule,
+  NbCardModule,
+  NbContextMenuModule,
+  NbFormFieldModule,
+  NbIconModule,
+  NbInputModule,
+  NbRadioModule,
+  NbTooltipModule
+} from '@nebular/theme';
+
+@NgModule({
+  declarations: [PlaygroundComponent],
+  imports: [
+    CommonModule,
+    BotSharedModule,
+    FormsModule,
+    ReactiveFormsModule,
+    NbButtonModule,
+    NbTooltipModule,
+    NbCardModule,
+    NbIconModule,
+    NbAccordionModule,
+    NbRadioModule,
+    NbInputModule,
+    NbFormFieldModule,
+    NbContextMenuModule,
+    PlaygroundRoutingModule
+  ]
+})
+export class PlaygroundModule {}

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
@@ -183,7 +183,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
   }
 
   private getRagSettingsLoader(): Observable<RagSettings> {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/rag`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/rag`;
     return this.rest.get<RagSettings>(url, (settings: RagSettings) => settings);
   }
 
@@ -515,7 +515,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
       formValue.botId = this.state.currentApplication.name;
       formValue.noAnswerStoryId = this.noAnswerStoryId.value === 'null' ? null : this.noAnswerStoryId.value;
 
-      const url = `/configuration/bots/${this.state.currentApplication.name}/rag`;
+      const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/rag`;
       this.rest.post(url, formValue, null, null, true).subscribe({
         next: (ragSettings: RagSettings) => {
           if (!ragSettings.noAnswerStoryId) {
@@ -735,7 +735,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
   }
 
   deleteSettings(): void {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/rag`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/rag`;
     this.rest.delete<boolean>(url).subscribe(() => {
       delete this.settingsBackup;
       this.form.reset();

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.html
@@ -140,8 +140,21 @@
             nbTooltip="Show debug infos"
             (click)="showDebug(action)"
             class="mb-1"
+            *ngIf="$any(action).message?.data?.errorDetail"
           >
             <nb-icon icon="bug"></nb-icon>
+          </button>
+
+          <button
+            nbButton
+            ghost
+            size="small"
+            nbTooltip="Open query in playground"
+            (click)="goToPlayground(action)"
+            class="mb-1"
+            *ngIf="$any(action).message?.data?.question_answering_prompt"
+          >
+            <nb-icon icon="joystick"></nb-icon>
           </button>
         </div>
 

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-dialog-logger/chat-ui-dialog-logger.component.ts
@@ -196,6 +196,13 @@ export class ChatUiDialogLoggerComponent implements OnDestroy {
     });
   }
 
+  goToPlayground(action: ActionReport) {
+    const debugData = (action.message as Debug).data;
+    if (debugData.question_answering_prompt) {
+      this.router.navigate(['playground'], { state: { question_answering_prompt: debugData.question_answering_prompt } });
+    }
+  }
+
   messageClicked(action: ActionReport): void {
     this.onMessageClicked.emit(action);
   }

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.html
@@ -2,12 +2,34 @@
   *ngIf="!message.isDebug() && !isMessageEmpty()"
   class="wrapper"
 >
-  <div>
+  <div class="avatar-wrapper">
     <div
       class="avatar"
       [style.background-image]="avatarStyle"
       [class.mt-1]="sender || date"
     ></div>
+
+    <button
+      *ngIf="
+        switchFormattingPos === 'afterAvatar' && reply && (message.isSentence() || message.isSentenceWithFootnotes()) && $any(message).text
+      "
+      nbButton
+      size="small"
+      ghost
+      nbTooltip="Switch message formatting"
+      class="mt-1"
+      (click)="switchFormatting()"
+    >
+      <nb-icon
+        *ngIf="!formatting"
+        icon="body-text"
+      ></nb-icon>
+      <nb-icon
+        *ngIf="formatting"
+        icon="code-square"
+      ></nb-icon>
+    </button>
+
     <ng-content></ng-content>
   </div>
 
@@ -31,7 +53,13 @@
         </div>
 
         <button
-          *ngIf="sender && reply && (message.isSentence() || message.isSentenceWithFootnotes()) && $any(message).text"
+          *ngIf="
+            sender &&
+            switchFormattingPos === 'afterSender' &&
+            reply &&
+            (message.isSentence() || message.isSentenceWithFootnotes()) &&
+            $any(message).text
+          "
           nbButton
           size="small"
           ghost

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.scss
@@ -11,19 +11,23 @@
       flex: 1;
     }
 
-    .avatar {
-      border-radius: 50%;
-      flex-shrink: 0;
-      background: #c5cee0;
-      background-position: center;
-      background-size: cover;
-      background-repeat: no-repeat;
-      width: 2.5rem;
-      height: 2.5rem;
+    .avatar-wrapper {
       text-align: center;
-      line-height: 2.5rem;
-      font-size: 0.875rem;
-      color: white;
+
+      .avatar {
+        border-radius: 50%;
+        flex-shrink: 0;
+        background: #c5cee0;
+        background-position: center;
+        background-size: cover;
+        background-repeat: no-repeat;
+        width: 2.5rem;
+        height: 2.5rem;
+        text-align: center;
+        line-height: 2.5rem;
+        font-size: 0.875rem;
+        color: white;
+      }
     }
     .sender {
       font-size: 0.875rem;

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui-message/chat-ui-message.component.ts
@@ -16,6 +16,7 @@ export class ChatUiMessageComponent {
   @Input() sender?: string;
   @Input() date?: Date;
   @Input() applicationId?: string;
+  @Input() switchFormattingPos: 'afterSender' | 'afterAvatar' = 'afterSender';
 
   @Input()
   set avatar(value: string) {

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.html
@@ -9,9 +9,8 @@
   <div class="messages">
     <ng-content></ng-content>
 
-    <div
-      *ngIf="queryInProgress"
-      class="query-spinner my-2"
-    ></div>
+    <div *ngIf="queryInProgress">
+      <div class="query-spinner my-2 mx-auto"></div>
+    </div>
   </div>
 </div>

--- a/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
+++ b/bot/admin/web/src/app/shared/components/chat-ui/chat-ui.component.scss
@@ -7,7 +7,7 @@
   line-height: 1.25rem;
 
   .scrollable {
-    min-height: 6rem;
+    min-height: 2rem;
 
     overflow: auto;
     flex: 1;

--- a/bot/admin/web/src/app/shared/components/sentences-generation/sentences-generation.component.ts
+++ b/bot/admin/web/src/app/shared/components/sentences-generation/sentences-generation.component.ts
@@ -52,7 +52,7 @@ export class SentencesGenerationComponent implements OnInit {
   }
 
   checkLlmSettingsConfiguration(): void {
-    const url = `/configuration/bots/${this.state.currentApplication.name}/sentence-generation/info`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/sentence-generation/info`;
     this.restService
       .get(url, (settings) => settings)
       .subscribe((settings) => {
@@ -116,7 +116,7 @@ export class SentencesGenerationComponent implements OnInit {
   }
 
   generateSentences(body: CompletionRequest): Observable<CompletionResponse> {
-    const url = `/gen-ai/bot/${this.state.currentApplication.name}/sentence-generation`;
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/completion/sentence-generation`;
 
     return this.restService.post<CompletionRequest, CompletionResponse>(url, body);
   }

--- a/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/test-dialog/test-dialog.component.html
@@ -85,6 +85,7 @@
           [reply]="message.bot"
           [avatar]="getUserAvatar(message.bot)"
           (sendMessage)="onNewMessage($event)"
+          switchFormattingPos="afterAvatar"
         >
           <div
             *ngIf="message.locale"
@@ -114,6 +115,17 @@
     </div>
 
     <div class="d-flex justify-content-between align-items-center flex-wrap gap-1 mt-3">
+      <button
+        *ngIf="messages.length !== 0"
+        nbTooltip="Clear conversation"
+        nbButton
+        status="warning"
+        size="medium"
+        (click)="clear()"
+      >
+        <nb-icon icon="trash"></nb-icon>
+      </button>
+
       <div class="d-flex gap-1 flex-grow-1">
         <textarea
           #textareaAutocompleteDirectiveRef
@@ -139,22 +151,13 @@
         <button
           nbButton
           size="medium"
+          status="primary"
           (click)="submit()"
+          [disabled]="!userMessage.trim().length"
         >
-          GO
+          <nb-icon icon="send"></nb-icon>
         </button>
       </div>
-
-      <button
-        *ngIf="messages.length !== 0"
-        nbTooltip="Clear conversation"
-        nbButton
-        status="warning"
-        size="medium"
-        (click)="clear()"
-      >
-        <nb-icon icon="trash"></nb-icon>
-      </button>
     </div>
     <nb-autocomplete
       #userMessageAutocomplete

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -362,3 +362,33 @@ nb-menu {
     }
   }
 }
+
+.scrollbar-narrow::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.scrollbar-narrow::-webkit-scrollbar-thumb {
+  cursor: pointer;
+  border-radius: 0.15625rem;
+}
+
+.nb-theme-default .scrollbar-narrow::-webkit-scrollbar-thumb {
+  background: #e4e9f2;
+}
+.nb-theme-default .scrollbar-narrow::-webkit-scrollbar-track {
+  background: #f7f9fc;
+}
+.nb-theme-default .scrollbar-narrow::-webkit-scrollbar-corner {
+  background: #f7f9fc;
+}
+
+.nb-theme-dark .scrollbar-narrow::-webkit-scrollbar-thumb {
+  background: #101426;
+}
+.nb-theme-dark .scrollbar-narrow::-webkit-scrollbar-track {
+  background: #192038;
+}
+.nb-theme-dark .scrollbar-narrow::-webkit-scrollbar-corner {
+  background: #192038;
+}


### PR DESCRIPTION
This pull request introduces a new feature on the frontend: a playground view for testing the execution of LLM queries with user-generated prompts. The view provides users the flexibility to adjust connection settings for the LLM and initially loads with the current settings of the active bot.

Key features include:

- Prompt Testing: Users can input prompts freely and see how the LLM responds.
- Adjustable Settings: Users can modify the LLM connection settings as needed, but the view initially displays the bot's current settings.
- Test History: An history log is implemented, allowing users to navigate between previous test queries easily.
- Integration with Analytics/Dialogs: A direct link from the Analytics/dialogs view enables users to load archived dialog prompts into the playground for further testing or iteration.

This feature aims to enhance the testing and development workflow by giving users a robust tool to experiment with LLM prompts and settings, facilitating more effective and creative interactions with the model.

Works with https://github.com/theopenconversationkit/tock/pull/1834

![image](https://github.com/user-attachments/assets/49e3abce-1bc5-4928-b64e-5b6d977e61f7)
