### PR TITLE
[DERCBOT-1323] Allow deletion of empty namespaces

### DIFF
--- a/nlp/admin/server/src/main/kotlin/AdminService.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminService.kt
@@ -315,4 +315,15 @@ object AdminService {
             i == 0 || Duration.between(stats[i - 1].date, s.date) >= Duration.ofMinutes(1)
         }
     }
+
+    fun deleteNamespaceIfEmpty(namespace: String) {
+        // Check that no application is linked to namespace
+        if (FrontClient.getApplications().any { it.namespace == namespace }) {
+            throw IllegalStateException("Namespace '$namespace' still contains applications.")
+        }
+        // Delete all user/namespace associations
+        FrontClient.getUsers(namespace).forEach { userNamespace ->
+            FrontClient.deleteNamespace(userNamespace.login, namespace)
+        }
+    }
 }

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -42,6 +42,7 @@ import ai.tock.nlp.core.NlpEngineType
 import ai.tock.nlp.core.PredefinedValue
 import ai.tock.nlp.core.configuration.NlpApplicationConfiguration
 import ai.tock.nlp.front.client.FrontClient
+import ai.tock.nlp.front.service.storage.UserNamespaceDAO
 import ai.tock.nlp.front.shared.build.ModelBuildTrigger
 import ai.tock.nlp.front.shared.codec.ApplicationDump
 import ai.tock.nlp.front.shared.codec.ApplicationImportConfiguration
@@ -1074,6 +1075,22 @@ open class AdminVerticle : WebVerticle() {
                 }
             } else {
                 unauthorized()
+            }
+        }
+
+        blockingDelete(
+            "/namespace/:namespace",
+            technicalAdmin,
+            simpleLogger("Delete Namespace", { it.path("namespace") })
+        ) { context ->
+            val ns = context.path("namespace").trim()
+
+            if (front.getApplications().any { it.namespace == ns }) {
+                badRequest("Le namespace '$ns' contient encore des applications associées.")
+            } else {
+                front.getUsers(ns).forEach { userNamespace ->
+                    front.deleteNamespace(userNamespace.login, ns)
+                }
             }
         }
 

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -1085,7 +1085,11 @@ open class AdminVerticle : WebVerticle() {
         ) { context ->
             val ns = context.path("namespace").trim()
             try {
-                AdminService.deleteNamespaceIfEmpty(ns)
+                if (front.isNamespaceOwner(context.userLogin, ns)) {
+                    AdminService.deleteNamespaceIfEmpty(ns)
+                } else {
+                    unauthorized()
+                }
             } catch (e: IllegalStateException) {
                 badRequest(e.message ?: "Error while deleting namespace.")
             }

--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -1084,13 +1084,10 @@ open class AdminVerticle : WebVerticle() {
             simpleLogger("Delete Namespace", { it.path("namespace") })
         ) { context ->
             val ns = context.path("namespace").trim()
-
-            if (front.getApplications().any { it.namespace == ns }) {
-                badRequest("Le namespace '$ns' contient encore des applications associées.")
-            } else {
-                front.getUsers(ns).forEach { userNamespace ->
-                    front.deleteNamespace(userNamespace.login, ns)
-                }
+            try {
+                AdminService.deleteNamespaceIfEmpty(ns)
+            } catch (e: IllegalStateException) {
+                badRequest(e.message ?: "Error while deleting namespace.")
             }
         }
 


### PR DESCRIPTION
**Ticket** : [DERCBOT-1423](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1423)  

This PR introduces a new feature allowing the deletion of a namespace **only if** no applications are associated with it.  

### Changes:  
- Added `deleteNamespaceIfEmpty` method in the service to enforce this constraint.  
- Created the corresponding `DELETE` endpoint in the `AdminVerticle`.  
- Ensured that all user-namespace associations are also removed upon successful deletion.  
