### PR TITLE
fixes #1860 whatsapp_connector: add message queue to connector

### DIFF
--- a/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/services/WhatsAppCloudApiService.kt
@@ -21,23 +21,17 @@ import ai.tock.bot.connector.whatsapp.cloud.WhatsAppCloudApiClient
 import ai.tock.bot.connector.whatsapp.cloud.database.model.PayloadWhatsAppCloud
 import ai.tock.bot.connector.whatsapp.cloud.database.repository.PayloadWhatsAppCloudDAO
 import ai.tock.bot.connector.whatsapp.cloud.database.repository.PayloadWhatsAppCloudMongoDAO
-import ai.tock.bot.connector.whatsapp.cloud.model.send.SendSuccessfulResponse
-import ai.tock.bot.connector.whatsapp.cloud.model.send.manageTemplate.ResponseCreateTemplate
 import ai.tock.bot.connector.whatsapp.cloud.model.send.manageTemplate.WhatsAppCloudTemplate
 import ai.tock.bot.connector.whatsapp.cloud.model.send.media.FileType
-import ai.tock.bot.connector.whatsapp.cloud.model.send.media.Media
 import ai.tock.bot.connector.whatsapp.cloud.model.send.media.MediaResponse
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotTemplateMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotInteractiveMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotImageMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotLocationMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotTextMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.Component
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.HeaderParameter
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.PayloadParameter
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionButton
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotHeaderType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionSection
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractiveHeader
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotMediaImage
 import ai.tock.bot.engine.BotRepository
@@ -59,44 +53,55 @@ import org.litote.kmongo.toId
 import retrofit2.Response
 import java.time.Instant
 import java.util.*
-import java.util.concurrent.Callable
-import java.util.concurrent.Executors
 
-class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
+internal class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
 
     private val logger = KotlinLogging.logger {}
     private val payloadWhatsApp: PayloadWhatsAppCloudDAO = PayloadWhatsAppCloudMongoDAO
     private val executor: Executor = injector.provide()
-    private val executorService = Executors.newCachedThreadPool()
+    private val client = OkHttpClient.Builder().apply(TockProxyAuthenticator::install).build()
 
-    fun sendMessage(phoneNumberId: String, token: String, messageRequest: WhatsAppCloudSendBotMessage) {
+    /**
+     * Processes a message request in preparation for sending it to the WhatsApp cloud API
+     */
+    fun prepareMessage(
+        phoneNumberId: String,
+        token: String,
+        messageRequest: WhatsAppCloudSendBotMessage
+    ): WhatsAppCloudSendBotMessage? {
         try {
-            when (messageRequest) {
-                is WhatsAppCloudSendBotTextMessage,
+            return when (messageRequest) {
+                is WhatsAppCloudSendBotImageMessage -> prepareImageMessage(phoneNumberId, token, messageRequest)
 
-                is WhatsAppCloudSendBotLocationMessage -> handleSimpleMessage(phoneNumberId, token, messageRequest)
-
-                is WhatsAppCloudSendBotImageMessage -> handleImageMessage(phoneNumberId, token, messageRequest)
-
-                is WhatsAppCloudSendBotInteractiveMessage -> handleInteractiveMessage(
+                is WhatsAppCloudSendBotInteractiveMessage -> prepareInteractiveMessage(
                     phoneNumberId,
                     token,
                     messageRequest
                 )
 
-                is WhatsAppCloudSendBotTemplateMessage -> handleTemplateMessage(phoneNumberId, token, messageRequest)
+                is WhatsAppCloudSendBotTemplateMessage -> prepareTemplateMessage(phoneNumberId, token, messageRequest)
+
+                else -> messageRequest
             }
         } catch (e: Exception) {
             logger.error(e)
+            return null
         }
     }
 
-    private fun handleImageMessage(
+    private fun prepareImageMessage(
         phoneNumberId: String,
         token: String,
         messageRequest: WhatsAppCloudSendBotImageMessage
+    ): WhatsAppCloudSendBotMessage {
+        return replaceWithRealMessageImageId(messageRequest, phoneNumberId, token)
+    }
+
+    fun sendMessage(
+        phoneNumberId: String,
+        token: String,
+        messageRequest: WhatsAppCloudSendBotMessage
     ) {
-        replaceWithRealMessageImageId(messageRequest, phoneNumberId, token)
         send(messageRequest) {
             apiClient.graphApi.sendMessage(phoneNumberId, token, messageRequest).execute()
         }
@@ -104,7 +109,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
 
     fun downloadImgByBinary(token: String, imgId: String, mimeType: String): String {
 
-        val url = getMedia(imgId) {
+        val url = send(imgId) {
             apiClient.graphApi.retrieveMediaUrl(imgId, token).execute()
         }.url
 
@@ -114,133 +119,88 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         return base64Response
     }
 
-    private fun handleSimpleMessage(phoneNumberId: String, token: String, messageRequest: WhatsAppCloudSendBotMessage) {
-        send(messageRequest) {
-            apiClient.graphApi.sendMessage(phoneNumberId, token, messageRequest).execute()
-        }
-    }
-
-    private fun handleInteractiveMessage2(
+    private fun prepareInteractiveMessage(
         phoneNumberId: String,
         token: String,
         messageRequest: WhatsAppCloudSendBotInteractiveMessage
-    ) {
-        messageRequest.interactive.action?.let { action ->
-            if (!action.buttons.isNullOrEmpty()) {
-                val updateButtons = action.buttons.map { button ->
-                    updateButton(button)
-                }
-
-                if(messageRequest.interactive.header!=null){
-                    val updateHeader = WhatsAppCloudBotInteractiveHeader(
-                        type = WhatsAppCloudBotHeaderType.image,
-                        image = WhatsAppCloudBotMediaImage(
-                            id = getRealIdImg(messageRequest, phoneNumberId, token)
-
+    ): WhatsAppCloudSendBotMessage? {
+        val action = messageRequest.interactive.action ?: return null
+        val updatedButtons = action.buttons.takeIf { !it.isNullOrEmpty() }?.map { btn ->
+            btn.copy(reply = btn.reply.copy(id = shortenPayload(btn.reply.id)))
+        }
+        val updatedSections = action.sections.takeIf { !it.isNullOrEmpty() }?.map { section ->
+            section.copy(rows = section.rows?.map { it.copy(id = shortenPayload(it.id)) })
+        }
+        val updatedHeader = messageRequest.interactive.header?.let { header ->
+            if (header.image != null) {
+                header.copy(
+                    image = WhatsAppCloudBotMediaImage(
+                        id = getRealIdImg(
+                            phoneNumberId,
+                            token,
+                            header.image.id
                         )
                     )
-                    sendUpdatedInteractiveMessage(phoneNumberId, token, messageRequest, updateButtons, updateHeader)
-                }else{
-                    sendUpdatedInteractiveMessage(phoneNumberId, token, messageRequest, updateButtons)
-                }
-
+                )
             } else {
-                send(messageRequest) {
-                    apiClient.graphApi.sendMessage(
-                        phoneNumberId,
-                        token,
-                        messageRequest
-                    ).execute()
-                }
+                header
             }
         }
-    }
-
-
-    private fun handleInteractiveMessage(
-        phoneNumberId: String,
-        token: String,
-        messageRequest: WhatsAppCloudSendBotInteractiveMessage
-    ) {
-        val action = messageRequest.interactive.action ?: return sendMessage(phoneNumberId, token, messageRequest)
-        val updatedButtons = action.buttons.takeIf { !it.isNullOrEmpty() }?.map { updateButton(it) }
-        val updatedHeader = messageRequest.interactive.header?.let {
-            WhatsAppCloudBotInteractiveHeader(
-                type = WhatsAppCloudBotHeaderType.image,
-                image = WhatsAppCloudBotMediaImage(id = getRealIdImg(messageRequest, phoneNumberId, token))
-            )
-        }
-        if (updatedButtons != null) {
-            sendUpdatedInteractiveMessage(phoneNumberId, token, messageRequest, updatedButtons, updatedHeader)
+        return if (updatedButtons != null || updatedSections != null) {
+            sendUpdatedInteractiveMessage(messageRequest, updatedButtons, updatedSections, updatedHeader)
         } else {
-            send(messageRequest) {
-                apiClient.graphApi.sendMessage(
-                    phoneNumberId,
-                    token,
-                    messageRequest
-                ).execute()
-            }
+            messageRequest
         }
     }
 
     private fun getRealIdImg(
-        messageRequest: WhatsAppCloudSendBotInteractiveMessage,
         phoneNumberId: String,
-        token: String
+        token: String,
+        headerImageId: String
     ): String {
-
-        val headerImageId = messageRequest.interactive.header?.image?.id
-
-        val client = OkHttpClient.Builder().apply(TockProxyAuthenticator::install).build()
-
-        val res = sendMedia(client, phoneNumberId, token, headerImageId.toString(), FileType.PNG.type)
+        val res = sendMedia(this.client, phoneNumberId, token, headerImageId, FileType.PNG.type)
 
         return res.id
     }
 
-    private fun updateButton(button: WhatsAppCloudBotActionButton): WhatsAppCloudBotActionButton =
-        if (button.reply.id.length >= 256) {
+    private fun shortenPayload(payload: String): String {
+        if (payload.length >= 256) {
             val uuidPayload = UUID.randomUUID().toString()
             executor.executeBlocking {
                 payloadWhatsApp.save(
                     PayloadWhatsAppCloud(
                         uuidPayload,
-                        button.reply.id,
+                        payload,
                         Date.from(Instant.now()),
                     )
                 )
             }
-            val copyReply = button.reply.copy(title = button.reply.title, id = uuidPayload)
-            button.copy(reply = copyReply)
+            return uuidPayload
         } else {
-            button
-        }
-
-    private fun sendUpdatedInteractiveMessage(
-        phoneNumberId: String,
-        token: String,
-        messageRequest: WhatsAppCloudSendBotInteractiveMessage,
-        updatedButtons: List<WhatsAppCloudBotActionButton>,
-        updateHeader: WhatsAppCloudBotInteractiveHeader? = null
-    ) {
-        val updateAction = messageRequest.interactive.action?.copy(buttons = updatedButtons)
-        val updateMessageRequest = messageRequest.copy(
-            interactive = messageRequest.interactive.copy(header = updateHeader, action = updateAction)
-        )
-        send(updateMessageRequest) {
-            apiClient.graphApi.sendMessage(
-                phoneNumberId,
-                token,
-                updateMessageRequest
-            ).execute()
+            return payload
         }
     }
 
-    private fun handleTemplateMessage(
+    private fun sendUpdatedInteractiveMessage(
+        messageRequest: WhatsAppCloudSendBotInteractiveMessage,
+        updatedButtons: List<WhatsAppCloudBotActionButton>?,
+        updatedSections: List<WhatsAppCloudBotActionSection>?,
+        updateHeader: WhatsAppCloudBotInteractiveHeader? = null
+    ): WhatsAppCloudSendBotInteractiveMessage {
+        val updateAction = messageRequest.interactive.action?.copy(
+            buttons = updatedButtons,
+            sections = updatedSections,
+        )
+        return messageRequest.copy(
+            interactive = messageRequest.interactive.copy(header = updateHeader, action = updateAction)
+        )
+    }
+
+    private fun prepareTemplateMessage(
         phoneNumberId: String,
         token: String,
         messageRequest: WhatsAppCloudSendBotTemplateMessage
-    ) {
+    ): WhatsAppCloudSendBotMessage {
         val updatedComponents = messageRequest.template.components.map { component ->
             when (component) {
                 is Component.Carousel -> updateCarouselPayloads(component)
@@ -255,11 +215,8 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
             )
         )
 
-        sendUpdatedTemplateMessage(phoneNumberId, token, updatedMessageRequest)
-    }
-
-    fun updatePayloadParameter(payloadParameter: PayloadParameter, newPayload: String?): PayloadParameter {
-        return payloadParameter.copy(type = payloadParameter.type, payload = newPayload, text = payloadParameter.text)
+        replaceWithRealImageId(updatedMessageRequest, phoneNumberId, token)
+        return updatedMessageRequest
     }
 
     private fun updateCarouselPayloads(carousel: Component.Carousel): Component.Carousel {
@@ -286,18 +243,6 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
                 parameters.copy(payload = uuidPayload)
             } ?: parameters
         })
-
-    private fun sendUpdatedTemplateMessage(
-        phoneNumberId: String,
-        token: String,
-        messageRequest: WhatsAppCloudSendBotTemplateMessage,
-    ) {
-
-        replaceWithRealImageId(messageRequest, phoneNumberId, token)
-        send(messageRequest) {
-            apiClient.graphApi.sendMessage(phoneNumberId, token, messageRequest).execute()
-        }
-    }
 
     private fun sendMedia(
         client: OkHttpClient,
@@ -333,7 +278,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
     }
 
     fun sendBuildTemplate(whatsAppBusinessAccountId: String, token: String, messageTemplate: WhatsAppCloudTemplate) {
-        sendTemplate(messageTemplate) {
+        send(messageTemplate) {
             apiClient.graphApi.createMessageTemplate(
                 whatsAppBusinessAccountId,
                 token,
@@ -342,54 +287,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         }
     }
 
-    private fun <T : Any> sendTemplate(
-        request: T,
-        call: (T) -> Response<ResponseCreateTemplate>
-    ): ResponseCreateTemplate {
-        val requestTimerData =
-            BotRepository.requestTimer.start("whatsapp_send_${request.javaClass.simpleName.lowercase()}")
-        try {
-            val response = call(request)
-            if (!response.isSuccessful) {
-                throw ConnectorException("Failed to send message: ${response.errorBody()?.string()}")
-            }
-            return response.body() ?: throw ConnectorException("Null response body")
-
-        } catch (e: Throwable) {
-            BotRepository.requestTimer.throwable(e, requestTimerData)
-            if (e is ConnectorException) {
-                throw e
-            } else {
-                throwError(e.message ?: "")
-            }
-        } finally {
-            BotRepository.requestTimer.end(requestTimerData)
-        }
-    }
-
-    private fun <T : Any> send(request: T, call: (T) -> Response<SendSuccessfulResponse>): SendSuccessfulResponse {
-        val requestTimerData =
-            BotRepository.requestTimer.start("whatsapp_send_${request.javaClass.simpleName.lowercase()}")
-        try {
-            val response = call(request)
-            if (!response.isSuccessful) {
-                throw ConnectorException("Failed to send message: ${response.errorBody()?.string()}")
-            }
-            return response.body() ?: throw ConnectorException("Null response body")
-
-        } catch (e: Throwable) {
-            BotRepository.requestTimer.throwable(e, requestTimerData)
-            if (e is ConnectorException) {
-                throw e
-            } else {
-                throwError(e.message ?: "")
-            }
-        } finally {
-            BotRepository.requestTimer.end(requestTimerData)
-        }
-    }
-
-    private fun <T : Any> getMedia(request: T, call: (T) -> Response<Media>): Media {
+    private fun <T : Any, R : Any> send(request: T, call: (T) -> Response<R>): R {
         val requestTimerData =
             BotRepository.requestTimer.start("whatsapp_send_${request.javaClass.simpleName.lowercase()}")
         try {
@@ -441,11 +339,9 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         messageRequest: WhatsAppCloudSendBotImageMessage,
         phoneNumberId: String,
         token: String
-    ) {
-        val client = OkHttpClient.Builder().apply(TockProxyAuthenticator::install).build()
-
-        var res = sendMedia(
-            client,
+    ): WhatsAppCloudSendBotMessage {
+        val res = sendMedia(
+            this.client,
             phoneNumberId,
             token,
             messageRequest.image.id,
@@ -455,6 +351,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         val image = messageRequest.image
         val newImageId = res.id
         image.id = newImageId
+        return messageRequest
     }
 
 
@@ -463,7 +360,6 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         phoneNumberId: String,
         token: String
     ) {
-        val client = OkHttpClient.Builder().apply(TockProxyAuthenticator::install).build()
         messageRequest.template.components
             .asSequence()
             .filterIsInstance<Component.Carousel>()
@@ -474,15 +370,15 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
             .filterIsInstance<HeaderParameter.Image>()
             .filter { it.image.id != null }
             .map {
-                it to executorService.submit(Callable {
+                it to executor.executeBlockingTask<MediaResponse> {
                     sendMedia(
-                        client,
+                        this.client,
                         phoneNumberId,
                         token,
                         it.image.id!!,
                         FileType.PNG.type
                     )
-                })
+                }
             }
             //exit from sequence
             .toList()
@@ -501,8 +397,7 @@ class WhatsAppCloudApiService(private val apiClient: WhatsAppCloudApiClient) {
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) error("Failed to download file: $fileUrl - ${response.message}")
             val mediaType = fileType.toMediaTypeOrNull()
-            return response.body?.byteStream()?.readBytes()?.toRequestBody(mediaType)
-                ?: error("no response message for: $fileUrl")
+            return response.body.byteStream().readBytes().toRequestBody(mediaType)
         }
 
     }

--- a/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
@@ -116,7 +116,7 @@ class ConnectorQueue(private val executor: Executor, private val clock: Clock = 
         action: ScheduledAction<T>,
         queue: ConcurrentLinkedQueue<ScheduledAction<*>>,
     ) {
-        val timeToWait = Duration.between(Instant.now(), action.timestamp)
+        val timeToWait = Duration.between(Instant.now(clock), action.timestamp)
         executor.executeBlocking(timeToWait) {
             try {
                 action.joinAndSend()

--- a/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
@@ -17,21 +17,27 @@
 package ai.tock.bot.connector
 
 import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.Executor
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
+import java.time.Clock
 import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 
 /**
  * A Queue to ensure the calls from the same user id are sent sequentially.
  */
-class ConnectorQueue(private val executor: Executor) {
+class ConnectorQueue(private val executor: Executor, private val clock: Clock = Clock.systemUTC()) {
 
-    private data class ActionWithTimestamp(val action: Action, val timestamp: Long)
+    private class ScheduledAction<T>(private val processedAction: CompletableFuture<T?>, private val send: (action: T) -> Unit, val timestamp: Instant) {
+        fun joinAndSend() = processedAction.join()?.let(send)
+    }
 
-    private val messagesByRecipientMap: Cache<String, ConcurrentLinkedQueue<ActionWithTimestamp>> =
+    private val messagesByRecipientMap: Cache<String, ConcurrentLinkedQueue<ScheduledAction<*>>> =
         CacheBuilder.newBuilder()
             .expireAfterAccess(1, TimeUnit.MINUTES)
             .build()
@@ -46,43 +52,83 @@ class ConnectorQueue(private val executor: Executor) {
      * @param send the send function
      */
     fun add(action: Action, delayInMs: Long, send: (action: Action) -> Unit) {
-        val actionWrapper = ActionWithTimestamp(action, System.currentTimeMillis() + delayInMs)
+        val actionWrapper = ScheduledAction(
+            CompletableFuture.completedFuture(action),
+            send,
+            Instant.now(clock) + Duration.ofMillis(delayInMs),
+        )
 
+        add0(action.recipientId, actionWrapper)
+    }
+
+    /**
+     * Adds an action to send to a queue by recipient, with a specific [prepare] step
+     * beforehand.
+     *
+     * [prepare] is run asynchronously as soon as this method is called.
+     * [send] is run once the following preconditions are met:
+     * - [prepare] returned a result. If [prepare] returns `null`, [send] is not called.
+     * - [delayInMs] has passed
+     * - the previous message has been sent
+     *
+     * This method is thread safe.
+     *
+     * @param action the action to send
+     * @param delayInMs the optional delay
+     * @param send the send function
+     */
+    fun <T> add(
+        action: Action,
+        delayInMs: Long,
+        prepare: (action: Action) -> T?,
+        send: (action: T) -> Unit
+    ) {
+        val actionWrapper = ScheduledAction(
+            executor.executeBlockingTask { prepare(action) },
+            send,
+            Instant.now(clock) + Duration.ofMillis(delayInMs),
+        )
+
+        add0(action.recipientId, actionWrapper)
+    }
+
+    private fun <T> add0(
+        recipient: PlayerId,
+        actionWrapper: ScheduledAction<T>,
+    ) {
         val queue = messagesByRecipientMap
-            .get(action.recipientId.id) { ConcurrentLinkedQueue() }
+            .get(recipient.id) { ConcurrentLinkedQueue() }
             .apply {
                 synchronized(this) {
                     peek().also { existingAction ->
                         offer(actionWrapper)
                         if (existingAction != null) {
+                            // sendNextAction is already looping through messages
                             return
                         }
                     }
                 }
             }
-        executor.executeBlocking(Duration.ofMillis(delayInMs)) {
-            sendActionFromConnector(actionWrapper, queue, send)
-        }
+        sendNextAction(actionWrapper, queue)
     }
 
-    private fun sendActionFromConnector(
-        action: ActionWithTimestamp,
-        queue: ConcurrentLinkedQueue<ActionWithTimestamp>,
-        send: (action: Action) -> Unit
+    private fun <T> sendNextAction(
+        action: ScheduledAction<T>,
+        queue: ConcurrentLinkedQueue<ScheduledAction<*>>,
     ) {
-        try {
-            val timeToWait = action.timestamp - System.currentTimeMillis()
-            if (timeToWait > 0) {
-                Thread.sleep(timeToWait)
-            }
-            send(action.action)
-        } finally {
-            synchronized(queue) {
-                // remove the current one
-                queue.poll()
-                queue.peek()
-            }?.also { a ->
-                sendActionFromConnector(a, queue, send)
+        val timeToWait = Duration.between(Instant.now(), action.timestamp)
+        executor.executeBlocking(timeToWait) {
+            try {
+                action.joinAndSend()
+            } finally {
+                synchronized(queue) {
+                    // remove the current one
+                    queue.poll()
+                    // schedule the next one
+                    queue.peek()
+                }?.also { a ->
+                    sendNextAction(a, queue)
+                }
             }
         }
     }

--- a/shared/src/main/kotlin/vertx/VertXs.kt
+++ b/shared/src/main/kotlin/vertx/VertXs.kt
@@ -39,6 +39,7 @@ import mu.KotlinLogging
 import mu.withLoggingContext
 import java.time.Duration
 import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
 
 private val logger = KotlinLogging.logger {}
 
@@ -127,18 +128,23 @@ fun Route.blocking(handler: (RoutingContext) -> Unit): Route =
 
 internal fun vertxExecutor(): Executor {
     return object : Executor {
-
         override fun executeBlocking(delay: Duration, runnable: () -> Unit) {
+            executeBlockingTask(delay, runnable)
+        }
+
+        override fun <T> executeBlockingTask(delay: Duration, task: () -> T): CompletableFuture<T> {
+            val future = newIncompleteFuture<T>()
             if (delay.isZero) {
-                executeBlocking(runnable)
+                future.completeAsync(task)
             } else {
                 val loggingContext = MDCContext().contextMap
                 vertx.setTimer(delay.toMillis()) {
                     invokeWithLoggingContext(loggingContext) {
-                        executeBlocking(runnable)
+                        executeBlocking(task) { future.complete(it) }
                     }
                 }
             }
+            return future
         }
 
         override fun executeBlocking(runnable: () -> Unit) {

--- a/shared/src/main/kotlin/vertx/VertXs.kt
+++ b/shared/src/main/kotlin/vertx/VertXs.kt
@@ -126,6 +126,8 @@ fun Route.blocking(handler: (RoutingContext) -> Unit): Route =
         false
     )
 
+private val VERTX_MIN_DELAY = Duration.ofMillis(1)
+
 internal fun vertxExecutor(): Executor {
     return object : Executor {
         override fun executeBlocking(delay: Duration, runnable: () -> Unit) {
@@ -134,7 +136,7 @@ internal fun vertxExecutor(): Executor {
 
         override fun <T> executeBlockingTask(delay: Duration, task: () -> T): CompletableFuture<T> {
             val future = newIncompleteFuture<T>()
-            if (delay.isZero) {
+            if (delay < VERTX_MIN_DELAY) {
                 future.completeAsync(task)
             } else {
                 val loggingContext = MDCContext().contextMap


### PR DESCRIPTION
Fixes #1860 by using the `ConnectorQueue` mechanism.

> [!NOTE]
> Since WhatsApp messages have preparation operations that can take several seconds, this PR adds a way to run these operations as soon as possible, delaying only the sending operation.

This PR is based on the `WhatsAppCloudApiService` changes from #1852 