### PR TITLE
fixes #1867: improve handling of delay in message queues

### DIFF
--- a/bot/connector-messenger/src/test/kotlin/MessengerConnectorTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/MessengerConnectorTest.kt
@@ -21,6 +21,7 @@ import ai.tock.bot.connector.messenger.MessengerConnector.Companion.connectorIdT
 import ai.tock.bot.connector.messenger.MessengerConnector.Companion.pageIdConnectorIdMap
 import ai.tock.bot.engine.ConnectorController
 import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.action.ActionMetadata
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.Executor
 import ai.tock.shared.SimpleExecutor
@@ -33,13 +34,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verifyOrder
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 internal class MessengerConnectorTest {
 
@@ -131,9 +132,11 @@ internal class MessengerConnectorTest {
         val userId = PlayerId("userId")
         val action1 = mockk<Action> {
             every { recipientId } returns userId
+            every { metadata } returns ActionMetadata(lastAnswer = false)
         }
         val action2 = mockk<Action> {
             every { recipientId } returns userId
+            every { metadata } returns ActionMetadata(lastAnswer = true)
         }
         val callback = MessengerConnectorCallback("appId")
 

--- a/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorQueue.kt
@@ -21,9 +21,9 @@ import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.Executor
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
-import java.time.Clock
 import java.time.Duration
-import java.time.Instant
+import java.time.InstantSource
+import java.util.Queue
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -31,13 +31,53 @@ import java.util.concurrent.TimeUnit
 /**
  * A Queue to ensure the calls from the same user id are sent sequentially.
  */
-class ConnectorQueue(private val executor: Executor, private val clock: Clock = Clock.systemUTC()) {
+class ConnectorQueue(private val executor: Executor, private val clock: InstantSource = InstantSource.system()) {
 
-    private class ScheduledAction<T>(private val processedAction: CompletableFuture<T?>, private val send: (action: T) -> Unit, val timestamp: Instant) {
+    private class ScheduledAction<T>(
+        private val baseAction: Action,
+        private val processedAction: CompletableFuture<T?>,
+        private val send: (action: T) -> Unit,
+        val delay: Duration,
+    ) {
+        val lastInAnswer get() = baseAction.metadata.lastAnswer
         fun joinAndSend() = processedAction.join()?.let(send)
+
+        override fun toString(): String {
+            return baseAction.toString()
+        }
     }
 
-    private val messagesByRecipientMap: Cache<String, ConcurrentLinkedQueue<ScheduledAction<*>>> =
+    private inner class UserQueue : Queue<ScheduledAction<*>> by ConcurrentLinkedQueue() {
+        private var answerInProgress = false
+        private var lastScheduledTime = clock.instant()
+        private var lastSentTime = clock.instant()
+
+        @Synchronized
+        fun getElapsedTime(): Duration = Duration.between(
+            if (answerInProgress) lastSentTime else lastScheduledTime,
+            clock.instant()
+        )
+
+        @Synchronized
+        fun <T> enqueueMessage(actionWrapper: ScheduledAction<T>): Boolean {
+            lastScheduledTime = clock.instant()
+            val existingAction = peek()
+            offer(actionWrapper)
+            return existingAction != null
+        }
+
+        @Synchronized
+        fun dequeueMessage(): ScheduledAction<*>? {
+            // remove the current one
+            val popped: ScheduledAction<*>? = poll()
+            lastSentTime = clock.instant()
+            answerInProgress = popped != null && !popped.lastInAnswer
+            // schedule the next one
+            return peek()
+        }
+    }
+
+    private val messagesByRecipientMap: Cache<String, UserQueue> =
         CacheBuilder.newBuilder()
             .expireAfterAccess(1, TimeUnit.MINUTES)
             .build()
@@ -53,9 +93,10 @@ class ConnectorQueue(private val executor: Executor, private val clock: Clock = 
      */
     fun add(action: Action, delayInMs: Long, send: (action: Action) -> Unit) {
         val actionWrapper = ScheduledAction(
+            action,
             CompletableFuture.completedFuture(action),
             send,
-            Instant.now(clock) + Duration.ofMillis(delayInMs),
+            Duration.ofMillis(delayInMs),
         )
 
         add0(action.recipientId, actionWrapper)
@@ -84,9 +125,10 @@ class ConnectorQueue(private val executor: Executor, private val clock: Clock = 
         send: (action: T) -> Unit
     ) {
         val actionWrapper = ScheduledAction(
+            action,
             executor.executeBlockingTask { prepare(action) },
             send,
-            Instant.now(clock) + Duration.ofMillis(delayInMs),
+            Duration.ofMillis(delayInMs),
         )
 
         add0(action.recipientId, actionWrapper)
@@ -97,16 +139,10 @@ class ConnectorQueue(private val executor: Executor, private val clock: Clock = 
         actionWrapper: ScheduledAction<T>,
     ) {
         val queue = messagesByRecipientMap
-            .get(recipient.id) { ConcurrentLinkedQueue() }
+            .get(recipient.id) { UserQueue() }
             .apply {
-                synchronized(this) {
-                    peek().also { existingAction ->
-                        offer(actionWrapper)
-                        if (existingAction != null) {
-                            // sendNextAction is already looping through messages
-                            return
-                        }
-                    }
+                if (enqueueMessage(actionWrapper)) {
+                    return
                 }
             }
         sendNextAction(actionWrapper, queue)
@@ -114,19 +150,14 @@ class ConnectorQueue(private val executor: Executor, private val clock: Clock = 
 
     private fun <T> sendNextAction(
         action: ScheduledAction<T>,
-        queue: ConcurrentLinkedQueue<ScheduledAction<*>>,
+        queue: UserQueue,
     ) {
-        val timeToWait = Duration.between(Instant.now(clock), action.timestamp)
+        val timeToWait = action.delay - queue.getElapsedTime()
         executor.executeBlocking(timeToWait) {
             try {
                 action.joinAndSend()
             } finally {
-                synchronized(queue) {
-                    // remove the current one
-                    queue.poll()
-                    // schedule the next one
-                    queue.peek()
-                }?.also { a ->
+                queue.dequeueMessage()?.also { a ->
                     sendNextAction(a, queue)
                 }
             }

--- a/shared/src/main/kotlin/Executor.kt
+++ b/shared/src/main/kotlin/Executor.kt
@@ -27,7 +27,9 @@ import java.util.concurrent.Executor
 interface Executor {
 
     /**
-     * Execute a task to another thread.
+     * Schedules a blocking task for execution on another thread.
+     *
+     * This method returns immediately, without waiting for the task to finish.
      *
      * @delay delay the delay before run
      * @param runnable the task to run
@@ -35,17 +37,22 @@ interface Executor {
     fun executeBlocking(delay: Duration, runnable: () -> Unit)
 
     /**
-     * Execute a task to another thread.
+     * Schedules a blocking task for execution on another thread.
+     *
+     * This method returns immediately, without waiting for the task to finish.
      *
      * The returned future will schedule any followup async task on this executor.
      *
      * @delay delay the delay before run
      * @param task the task to run
+     * @return a [CompletableFuture] that is asynchronously completed with the given [task]
      */
     fun <T> executeBlockingTask(delay: Duration = Duration.ZERO, task: () -> T): CompletableFuture<T>
 
     /**
-     * Execute a task to another thread.
+     * Schedules a blocking task for execution on another thread.
+     *
+     * This method returns immediately, without waiting for the task to finish.
      *
      * @param runnable the task to run
      */
@@ -55,6 +62,8 @@ interface Executor {
      * Execute a task to another thread.
      * If an exception is thrown by the blocking function, null is passed to the result function.
      *
+     * This method returns immediately, without waiting for the task to finish.
+     *
      * @param blocking the task to run
      * @param result the result handler
      *
@@ -62,15 +71,19 @@ interface Executor {
     fun <T> executeBlocking(blocking: Callable<T>, result: (T?) -> Unit)
 
     /**
-     * Execute a periodic task.
+     * Schedules a periodic task.
      *
-     * @param delay the delay between each other call
+     * This method returns immediately, without waiting for the task to execute.
+     *
+     * @param delay the delay before the first call, and between each following call
      * @param runnable the task to run
      */
     fun setPeriodic(delay: Duration, runnable: () -> Unit): Long = setPeriodic(delay, delay, runnable)
 
     /**
-     * Execute a periodic task.
+     * Schedules a periodic task.
+     *
+     * This method returns immediately, without waiting for the task to execute.
      *
      * @param initialDelay the delay before first call
      * @param delay the delay between each other call


### PR DESCRIPTION
fixes #1867 by adding "last scheduled" and "last sent" timestamps to each user's action queue, ensuring the right delay passes before sending a message.

## Rules

The per-user queue object follows the following rules:
- if the message being sent is the beginning of a new answer, it should wait for:
  1. any previous message being sent, and
  2. `delay` having passed *since the time the message was scheduled*
- if the message being sent follows another in the same answer, it should wait for:
  1. any previous message being sent, and
  2. `delay` having passed *since the time the previous message was sent*

Note that by default TOCK sets a delay for all messages but the first, meaning the second scenario is the one where the delay matters most.

## Limitations

In the case of multiple instances of a bot answering to requests concurrently, messages answering one request may overlap with messages answering another request, and therefore ignore the specified delay between messages.