### PR TITLE
resolves #1864 whatsapp_connector: deprecate legacy connector and clean up successor

### DIFF
--- a/bot/connector-whatsapp-cloud/README.md
+++ b/bot/connector-whatsapp-cloud/README.md
@@ -1,6 +1,7 @@
-> **This connector is still in alpha phase of development**
+> **This connector is in active development**
 > 
-> Breaking changes may occur.
+> Breaking changes may occur in the Bot API. Refer to [this issue](https://github.com/theopenconversationkit/tock/issues/1863)
+> for an outline of the changes to expect.
 
 ## Prerequisites
 
@@ -13,7 +14,6 @@
     * (Optional) **Meta Application id**: The id of the Meta application, only required for [template management](#template-management).
 
 * Then go to the *Configuration* -> *Bot Configurations* menu in Tock Studio, and create a new configuration with these parameters.
-  Set the `Mode` field to "subscribe".
 
 ## Bot API
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WebhookActionConverter.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WebhookActionConverter.kt
@@ -19,7 +19,12 @@ package ai.tock.bot.connector.whatsapp.cloud
 import ai.tock.bot.connector.whatsapp.cloud.UserHashedIdCache.createHashedId
 import ai.tock.bot.connector.whatsapp.cloud.database.repository.PayloadWhatsAppCloudDAO
 import ai.tock.bot.connector.whatsapp.cloud.database.repository.PayloadWhatsAppCloudMongoDAO
-import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.*
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudButtonMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudImageMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudInteractiveMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudLocationMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.WhatsAppCloudTextMessage
 import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.engine.action.SendAttachment
 import ai.tock.bot.engine.action.SendChoice
@@ -38,8 +43,7 @@ internal object WebhookActionConverter {
     fun toEvent(
         message: WhatsAppCloudMessage,
         applicationId: String,
-        whatsAppCloudApiService: WhatsAppCloudApiService,
-        token: String
+        whatsAppCloudApiService: WhatsAppCloudApiService
     ): Event? {
         val senderId = createHashedId(message.from)
         return when (message) {
@@ -51,7 +55,7 @@ internal object WebhookActionConverter {
             )
 
             is WhatsAppCloudImageMessage -> {
-                val binaryImg = whatsAppCloudApiService.downloadImgByBinary(token, message.image.id, message.image.mimeType)
+                val binaryImg = whatsAppCloudApiService.downloadImgByBinary(message.image.id, message.image.mimeType)
                 SendAttachment(
                     PlayerId(senderId),
                     applicationId,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudProvider.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudProvider.kt
@@ -31,7 +31,6 @@ internal object WhatsAppConnectorCloudProvider : ConnectorProvider {
     internal const val META_APPLICATION_ID = "metaApplicationId"
     internal const val TOKEN = "token"
     private const val VERIFY_TOKEN = "verifyToken"
-    private const val MODE = "mode"
 
     override val connectorType: ConnectorType get() = whatsAppCloudConnectorType
 
@@ -43,12 +42,9 @@ internal object WhatsAppConnectorCloudProvider : ConnectorProvider {
                 whatsAppBusinessAccountId = parameters.getValue(WHATSAPP_BUSINESS_ACCOUNT_ID),
                 metaApplicationId = parameters[META_APPLICATION_ID],
                 path = path,
-                token = parameters.getValue(TOKEN),
                 verifyToken = parameters[VERIFY_TOKEN],
-                mode = parameters.getValue(MODE),
+                requestFilter = createRequestFilter(connectorConfiguration),
                 client = createCloudApiClient(this),
-                requestFilter = createRequestFilter(connectorConfiguration)
-
             )
         }
     }
@@ -75,11 +71,6 @@ internal object WhatsAppConnectorCloudProvider : ConnectorProvider {
                 ConnectorTypeConfigurationField(
                     "Call Token",
                     TOKEN,
-                    true
-                ),
-                ConnectorTypeConfigurationField(
-                    "Mode",
-                    MODE,
                     true
                 ),
                 ConnectorTypeConfigurationField(

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudBotMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudBotMessage.kt
@@ -20,9 +20,13 @@ import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.connector.whatsapp.cloud.UserHashedIdCache
 import ai.tock.bot.connector.whatsapp.cloud.WhatsAppCloudConnectorMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.*
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotImageMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractiveMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotLocationMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotTemplateMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotTextMessage
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudConnectorType
-import ai.tock.bot.definition.Intent
 import ai.tock.bot.engine.action.SendChoice
 import ai.tock.bot.engine.action.SendChoice.Companion.TITLE_PARAMETER
 import ai.tock.bot.engine.message.Choice
@@ -52,13 +56,13 @@ abstract class WhatsAppCloudBotMessage (val type: WhatsAppCloudBotMessageType, @
     @get:JsonIgnore
     override val connectorType: ConnectorType = whatsAppCloudConnectorType
 
-    @get:JsonProperty("messaging_product")
-    abstract val messagingProduct: String
-
     @get:JsonProperty("recipient_type")
     abstract val recipientType: WhatsAppCloudBotRecipientType
 
-    internal abstract fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage
+    /**
+     * Processes a bot message in preparation for sending it to the WhatsApp cloud API
+     */
+    internal abstract fun prepareMessage(apiService: WhatsAppCloudApiService, recipientId: String): WhatsAppCloudSendBotMessage
 
     @get:JsonIgnore
     val to: String get() = userId?.let { UserHashedIdCache.getRealId(it) } ?: "unknown"

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotImageMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotImageMessage.kt
@@ -16,11 +16,14 @@
 
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message
 
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotImage
-
 data class WhatsAppCloudSendBotImageMessage(
-    override val messagingProduct: String,
-    val image: WhatsAppCloudBotImage,
+    val image: Image,
     override val recipientType: WhatsAppCloudBotRecipientType,
     override val to: String,
-) : WhatsAppCloudSendBotMessage(WhatsAppCloudBotMessageType.image)
+) : WhatsAppCloudSendBotMessage(WhatsAppCloudBotMessageType.image) {
+    data class Image(
+        val id: String?,
+        val link: String?,
+        val caption: String?
+    )
+}

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotInteractiveMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotInteractiveMessage.kt
@@ -19,7 +19,6 @@ package ai.tock.bot.connector.whatsapp.cloud.model.send.message
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractive
 
 data class WhatsAppCloudSendBotInteractiveMessage(
-        override val messagingProduct: String,
         val interactive: WhatsAppCloudBotInteractive,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val to: String,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotLocationMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotLocationMessage.kt
@@ -19,7 +19,6 @@ package ai.tock.bot.connector.whatsapp.cloud.model.send.message
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotLocation
 
 data class WhatsAppCloudSendBotLocationMessage(
-        override val messagingProduct: String,
         val location: WhatsAppCloudBotLocation,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val to: String,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotMessage.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 
@@ -32,11 +33,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
         JsonSubTypes.Type(value = WhatsAppCloudSendBotTemplateMessage::class, name = "template"),
         JsonSubTypes.Type(value = WhatsAppCloudSendBotImageMessage::class, name = "image"),
     )
-
+@JsonPropertyOrder("messaging_product")
 abstract class WhatsAppCloudSendBotMessage(val type: WhatsAppCloudBotMessageType) {
 
-    @get:JsonProperty("messaging_product")
-    abstract val messagingProduct:String
+    @Suppress("unused")
+    @JsonProperty("messaging_product")
+    val messagingProduct = "whatsapp"
 
     abstract val to: String?
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotTemplateMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotTemplateMessage.kt
@@ -19,7 +19,6 @@ package ai.tock.bot.connector.whatsapp.cloud.model.send.message
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotTemplate
 
 data class WhatsAppCloudSendBotTemplateMessage(
-        override val messagingProduct: String,
         val template: WhatsAppCloudBotTemplate,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val to: String,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotTextMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/WhatsAppCloudSendBotTextMessage.kt
@@ -20,7 +20,6 @@ import ai.tock.bot.connector.whatsapp.cloud.model.common.TextContent
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class WhatsAppCloudSendBotTextMessage (
-        override val messagingProduct: String,
         val text: TextContent,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val to: String,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotImage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotImage.kt
@@ -16,8 +16,41 @@
 
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message.content
 
-data class WhatsAppCloudBotImage(
-        var id: String,
-        val link: String?,
-        val caption: String?
-)
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotImageMessage
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
+import ai.tock.bot.engine.action.SendAttachment
+import ai.tock.bot.engine.message.Attachment
+import java.util.Base64
+
+sealed interface WhatsAppCloudBotImage {
+    val caption: String?
+    fun prepare(apiService: WhatsAppCloudApiService): WhatsAppCloudSendBotImageMessage.Image
+    fun toGenericAttachment(): Attachment
+
+    data class LinkedImage(val url: String, override val caption: String?, val uploadToWhatsapp: Boolean) : WhatsAppCloudBotImage {
+        override fun prepare(apiService: WhatsAppCloudApiService): WhatsAppCloudSendBotImageMessage.Image {
+            return WhatsAppCloudSendBotImageMessage.Image(
+                id = if (uploadToWhatsapp) apiService.getUploadedImageId(url) else null,
+                link = url.takeUnless { uploadToWhatsapp },
+                caption = caption,
+            )
+        }
+
+        override fun toGenericAttachment() = Attachment(url, SendAttachment.AttachmentType.image)
+    }
+
+    class UploadedImage(val id: String, val bytes: ByteArray, val mimeType: String, override val caption: String?) : WhatsAppCloudBotImage {
+        override fun prepare(apiService: WhatsAppCloudApiService): WhatsAppCloudSendBotImageMessage.Image {
+            return WhatsAppCloudSendBotImageMessage.Image(
+                id = apiService.getUploadedImageId(id, bytes, mimeType),
+                link = null,
+                caption = caption,
+            )
+        }
+
+        override fun toGenericAttachment(): Attachment {
+            val base64String = Base64.getEncoder().encodeToString(bytes)
+            return Attachment(url = "data:$mimeType;base64,$base64String", SendAttachment.AttachmentType.image)
+        }
+    }
+}

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotImageMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotImageMessage.kt
@@ -16,21 +16,23 @@
 
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message.content
 
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.*
-import ai.tock.bot.engine.config.UploadedFilesService.attachmentType
-import ai.tock.bot.engine.message.Attachment
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotRecipientType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotImageMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.engine.message.GenericMessage
 
 data class WhatsAppCloudBotImageMessage (
-        override val messagingProduct: String,
         val image: WhatsAppCloudBotImage,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val userId: String? = null,
+        val uploadToWhatsapp: Boolean = true,
 ) : WhatsAppCloudBotMessage(WhatsAppCloudBotMessageType.image, userId) {
-    override fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage =
+    override fun prepareMessage(apiService: WhatsAppCloudApiService, recipientId: String): WhatsAppCloudSendBotMessage =
             WhatsAppCloudSendBotImageMessage(
-                    messagingProduct,
-                    image,
+                    image.prepare(apiService),
                     recipientType,
                     recipientId
             )
@@ -38,6 +40,6 @@ data class WhatsAppCloudBotImageMessage (
     override fun toGenericMessage(): GenericMessage =
             GenericMessage(
                     texts = mapOf(GenericMessage.TEXT_PARAM to "image"),
-                    attachments = listOf(Attachment(image.id, attachmentType(image.id)))
+                    attachments = listOf(image.toGenericAttachment())
             )
 }

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotInteractive.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotInteractive.kt
@@ -29,7 +29,7 @@ data class WhatsAppCloudBotInteractive(
     val header: WhatsAppCloudBotInteractiveHeader? = null,
     val body: WhatsAppCloudBotBody? = null, // optional for product type
     val footer: WhatsAppCloudBotFooter? = null,
-    val action: WhatsAppCloudBotAction? = null,
+    val action: WhatsAppCloudBotAction,
 )
 
 data class WhatsAppCloudBotInteractiveHeader(

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotLocationMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotLocationMessage.kt
@@ -17,21 +17,20 @@
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message.content
 
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotRecipientType
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotLocationMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.engine.message.GenericMessage
 
 data class WhatsAppCloudBotLocationMessage(
-        override val messagingProduct: String,
         val location: WhatsAppCloudBotLocation,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val userId: String? = null,
 ) : WhatsAppCloudBotMessage(WhatsAppCloudBotMessageType.location, userId) {
-    override fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage =
+    override fun prepareMessage(apiService: WhatsAppCloudApiService, recipientId: String): WhatsAppCloudSendBotMessage =
             WhatsAppCloudSendBotLocationMessage(
-                    messagingProduct,
                     location,
                     recipientType,
                     recipientId

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplate.kt
@@ -24,41 +24,39 @@ enum class ButtonSubType { QUICK_REPLY, URL, PHONE_NUMBER }
 data class WhatsAppCloudBotTemplate(
     val name: String,
     val language: Language,
-    val components: List<Component>
+    val components: List<WhatsappTemplateComponent>
 )
 
 data class Language(@JsonProperty("code") val code: String)
 
-// TODO (breaking) finish renaming Component to WhatsappTemplateComponent
-typealias WhatsappTemplateComponent = Component
-sealed class Component {
+sealed class WhatsappTemplateComponent {
     abstract val type: ComponentType
 
     data class Body(
         override val type: ComponentType = ComponentType.BODY,
         val parameters: List<TextParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Header(
         override val type: ComponentType = ComponentType.HEADER,
         val parameters: List<HeaderParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Button(
         override val type: ComponentType = ComponentType.BUTTON,
         @JsonProperty("sub_type") val subType: ButtonSubType,
         val index: String,
         val parameters: List<PayloadParameter>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Carousel(
         override val type: ComponentType = ComponentType.CAROUSEL,
         val cards: List<Card>
-    ) : Component()
+    ) : WhatsappTemplateComponent()
 
     data class Card(
         @JsonProperty("card_index") val cardIndex: Int,
-        val components: List<Component>
+        val components: List<WhatsappTemplateComponent>
     )
 }
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplateMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTemplateMessage.kt
@@ -17,28 +17,31 @@
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message.content
 
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotRecipientType
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotTemplateMessage
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.engine.message.GenericMessage
 
 data class WhatsAppCloudBotTemplateMessage(
-        override val messagingProduct: String,
-        val template: WhatsAppCloudBotTemplate,
-        override val recipientType: WhatsAppCloudBotRecipientType,
-        override val userId: String? = null,
+    val template: WhatsAppCloudBotTemplate,
+    override val recipientType: WhatsAppCloudBotRecipientType,
+    override val userId: String? = null,
 ) : WhatsAppCloudBotMessage(WhatsAppCloudBotMessageType.template, userId) {
-    override fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage =
-            WhatsAppCloudSendBotTemplateMessage(
-                    messagingProduct,
-                    template,
-                    recipientType,
-                    recipientId
-            )
+    override fun prepareMessage(apiService: WhatsAppCloudApiService, recipientId: String): WhatsAppCloudSendBotMessage {
+        val updatedComponents = template.components
+        apiService.replaceWithRealImageId(updatedComponents, recipientId)
 
-    override fun toGenericMessage(): GenericMessage? =
-            GenericMessage(
-                    texts = mapOf(GenericMessage.TEXT_PARAM to "template"),
-            )
+        return WhatsAppCloudSendBotTemplateMessage(
+            template.copy(components = updatedComponents),
+            recipientType,
+            recipientId
+        )
+    }
+
+    override fun toGenericMessage(): GenericMessage =
+        GenericMessage(
+            texts = mapOf(GenericMessage.TEXT_PARAM to "template"),
+        )
 }

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTextMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/send/message/content/WhatsAppCloudBotTextMessage.kt
@@ -17,20 +17,22 @@
 package ai.tock.bot.connector.whatsapp.cloud.model.send.message.content
 
 import ai.tock.bot.connector.whatsapp.cloud.model.common.TextContent
-import ai.tock.bot.connector.whatsapp.cloud.model.send.message.*
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotMessageType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotRecipientType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotMessage
 import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotTextMessage
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.engine.message.GenericMessage
 
 data class WhatsAppCloudBotTextMessage (
-        override val messagingProduct: String,
         val text: TextContent,
         override val recipientType: WhatsAppCloudBotRecipientType,
         override val userId: String? = null,
         val previewUrl: Boolean = false,
 ) : WhatsAppCloudBotMessage(WhatsAppCloudBotMessageType.text, userId) {
-    override fun toSendBotMessage(recipientId: String): WhatsAppCloudSendBotMessage =
+    override fun prepareMessage(apiService: WhatsAppCloudApiService, recipientId: String): WhatsAppCloudSendBotMessage =
             WhatsAppCloudSendBotTextMessage(
-                    messagingProduct,
                     text,
                     recipientType,
                     recipientId,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/WhatsAppCloudMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/WhatsAppCloudMessage.kt
@@ -16,7 +16,9 @@
 
 package ai.tock.bot.connector.whatsapp.cloud.model.webhook.message
 
-import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.*
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.ContextContent
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.ErrorItem
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.Referral
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 
@@ -34,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
         JsonSubTypes.Type(value = WhatsAppCloudImageMessage::class, name = "image"),
         JsonSubTypes.Type(value = WhatsAppCloudInteractiveMessage::class, name = "interactive"),
         JsonSubTypes.Type(value = WhatsAppCloudOrderMessage::class, name = "order"),
-        JsonSubTypes.Type(value = WhatsAppCloudStrickerMessage::class, name = "sticker"),
+        JsonSubTypes.Type(value = WhatsAppCloudStickerMessage::class, name = "sticker"),
         JsonSubTypes.Type(value = WhatsAppCloudSystemMessage::class, name = "system"),
         JsonSubTypes.Type(value = WhatsAppCloudVideoMessage::class, name = "video"),
         JsonSubTypes.Type(value = WhatsAppCloudLocationMessage::class, name = "location")

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/WhatsAppCloudStickerMessage.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/WhatsAppCloudStickerMessage.kt
@@ -16,9 +16,12 @@
 
 package ai.tock.bot.connector.whatsapp.cloud.model.webhook.message
 
-import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.*
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.ContextContent
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.ErrorItem
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.Referral
+import ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content.StickerContent
 
-data class WhatsAppCloudStrickerMessage(
+data class WhatsAppCloudStickerMessage(
         val text: StickerContent,
         override val id: String,
         override val from: String,

--- a/bot/connector-whatsapp-cloud/src/test/kotlin/services/SendActionConverterTest.kt
+++ b/bot/connector-whatsapp-cloud/src/test/kotlin/services/SendActionConverterTest.kt
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test
 
 class SendActionConverterTest {
     @Test
-    fun `message conversion is correct for `() {
+    fun `message conversion is correct for reply button`() {
         mockkObject(UserHashedIdCache)
         val userId = "4567876543"
         every { UserHashedIdCache.getRealId(userId) } returns userId

--- a/bot/connector-whatsapp-cloud/src/test/kotlin/services/SendActionConverterTest.kt
+++ b/bot/connector-whatsapp-cloud/src/test/kotlin/services/SendActionConverterTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2017/2021 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import ai.tock.bot.connector.whatsapp.cloud.UserHashedIdCache
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudBotRecipientType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.WhatsAppCloudSendBotInteractiveMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotAction
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionButton
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotActionButtonReply
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotBody
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotHeaderType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractive
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractiveHeader
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractiveMessage
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotInteractiveType
+import ai.tock.bot.connector.whatsapp.cloud.model.send.message.content.WhatsAppCloudBotMediaImage
+import ai.tock.bot.connector.whatsapp.cloud.services.SendActionConverter
+import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
+import ai.tock.bot.engine.action.SendSentence
+import ai.tock.bot.engine.user.PlayerId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class SendActionConverterTest {
+    @Test
+    fun `message conversion is correct for `() {
+        mockkObject(UserHashedIdCache)
+        val userId = "4567876543"
+        every { UserHashedIdCache.getRealId(userId) } returns userId
+        val whatsAppCloudApiService = mockk<WhatsAppCloudApiService> {
+            every { getUploadedImageId("fish.png") } answers {
+                "test-image-id"
+            }
+            every { shortenPayload("button1") } answers {
+                "button1id"
+            }
+            every { shortenPayload("button2") } answers {
+                "button2id"
+            }
+        }
+
+        val result = SendActionConverter.toBotMessage(
+            whatsAppCloudApiService, SendSentence(
+                PlayerId("test-user"), "test", PlayerId(userId), text = null, messages = mutableListOf(
+                    WhatsAppCloudBotInteractiveMessage(
+                        recipientType = WhatsAppCloudBotRecipientType.individual,
+                        interactive = WhatsAppCloudBotInteractive(
+                            type = WhatsAppCloudBotInteractiveType.button,
+                            header = WhatsAppCloudBotInteractiveHeader(
+                                WhatsAppCloudBotHeaderType.image,
+                                image = WhatsAppCloudBotMediaImage("fish.png")
+                            ),
+                            body = WhatsAppCloudBotBody("test body"),
+                            action = WhatsAppCloudBotAction(
+                                buttons = listOf(
+                                    WhatsAppCloudBotActionButton(
+                                        reply = WhatsAppCloudBotActionButtonReply(
+                                            "Button 1",
+                                            "button1"
+                                        )
+                                    ),
+                                    WhatsAppCloudBotActionButton(
+                                        reply = WhatsAppCloudBotActionButtonReply(
+                                            "Button 2",
+                                            "button2"
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        assertEquals(WhatsAppCloudSendBotInteractiveMessage(
+            interactive = WhatsAppCloudBotInteractive(
+                type = WhatsAppCloudBotInteractiveType.button,
+                header = WhatsAppCloudBotInteractiveHeader(
+                    WhatsAppCloudBotHeaderType.image,
+                    image = WhatsAppCloudBotMediaImage("test-image-id")
+                ),
+                body = WhatsAppCloudBotBody("test body"),
+                action = WhatsAppCloudBotAction(
+                    buttons = listOf(
+                        WhatsAppCloudBotActionButton(
+                            reply = WhatsAppCloudBotActionButtonReply(
+                                "Button 1",
+                                "button1id"
+                            )
+                        ),
+                        WhatsAppCloudBotActionButton(
+                            reply = WhatsAppCloudBotActionButtonReply(
+                                "Button 2",
+                                "button2id"
+                            )
+                        )
+                    )
+                )
+            ),
+            recipientType = WhatsAppCloudBotRecipientType.individual,
+            to = userId,
+        ), result)
+    }
+}

--- a/bot/connector-whatsapp/README.md
+++ b/bot/connector-whatsapp/README.md
@@ -1,0 +1,3 @@
+> [!WARNING]
+> This module is deprecated due to WhatsApp [sunsetting their On-Premises API](https://developers.facebook.com/docs/whatsapp/on-premises/sunset).
+> Consider migrating to the [WhatsApp Cloud API equivalent](../connector-whatsapp-cloud).

--- a/bot/connector-whatsapp/src/main/kotlin/WhatsAppBuilder.kt
+++ b/bot/connector-whatsapp/src/main/kotlin/WhatsAppBuilder.kt
@@ -62,11 +62,19 @@ private const val WHATS_APP_MAX_SECTIONS = 10
 /**
  * The WhatsApp connector type.
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudConnectorType", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudConnectorType")
+)
 val whatsAppConnectorType = ConnectorType(WHATS_APP_CONNECTOR_TYPE_ID)
 
 /**
  * Sends an WhatsApp message only if the [ConnectorType] of the current [BotBus] is [whatsAppConnectorType].
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("sendToWhatsAppCloud", "ai.tock.bot.connector.whatsapp.cloud.sendToWhatsAppCloud"),
+)
 fun <T : Bus<T>> T.sendToWhatsApp(
     messageProvider: T.() -> WhatsAppBotMessage,
     delay: Long = defaultDelay(currentAnswerIndex)
@@ -81,6 +89,10 @@ fun <T : Bus<T>> T.sendToWhatsApp(
 /**
  * Sends an WhatsApp message as last bot answer, only if the [ConnectorType] of the current [BotBus] is [whatsAppConnectorType].
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("endForWhatsAppCloud", "ai.tock.bot.connector.whatsapp.cloud.endForWhatsAppCloud"),
+)
 fun <T : Bus<T>> T.endForWhatsApp(
     messageProvider: T.() -> WhatsAppBotMessage,
     delay: Long = defaultDelay(currentAnswerIndex)
@@ -96,6 +108,10 @@ fun <T : Bus<T>> T.endForWhatsApp(
  * Adds a WhatsApp [ConnectorMessage] if the current connector is WhatsApp.
  * You need to call [BotBus.send] or [BotBus.end] later to send this message.
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("withWhatsAppCloud", "ai.tock.bot.connector.whatsapp.cloud.withWhatsAppCloud"),
+)
 fun <T : Bus<T>> T.withWhatsApp(messageProvider: () -> WhatsAppBotMessage): T {
     return withMessage(whatsAppConnectorType, messageProvider)
 }
@@ -106,6 +122,10 @@ fun <T : Bus<T>> T.withWhatsApp(messageProvider: () -> WhatsAppBotMessage): T {
  * @param text the text sent
  * @param previewUrl is preview mode is used?
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudText", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudText"),
+)
 fun BotBus.whatsAppText(
     text: CharSequence,
     previewUrl: Boolean = false
@@ -121,6 +141,10 @@ fun BotBus.whatsAppText(
 /**
  * Creates a [WhatsAppBotImageMessage].
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudImage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudImage"),
+)
 fun BotBus.whatsAppImage(
     byteImages: ByteArray,
     contentType: String = "image/png",
@@ -140,6 +164,10 @@ fun BotBus.whatsAppImage(
 /**
  * Creates a [WhatsAppBotInteractiveMessage]
  */
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudTemplateMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudTemplateMessage"),
+)
 fun BotBus.whatsAppInteractiveMessage(
     nameSpace: String,
     templateName: String,
@@ -152,11 +180,19 @@ fun BotBus.whatsAppInteractiveMessage(
         userId = userId.id
     )
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudReplyButtonMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudReplyButtonMessage"),
+)
 fun I18nTranslator.replyButtonMessage(
     text: CharSequence,
     vararg replies: QuickReply
 ) : WhatsAppBotMessageInteractiveMessage = replyButtonMessage(text, replies.toList())
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudReplyButtonMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudReplyButtonMessage"),
+)
 fun I18nTranslator.replyButtonMessage(
     text: CharSequence,
     replies: List<QuickReply>
@@ -178,12 +214,20 @@ fun I18nTranslator.replyButtonMessage(
     )
 )
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudListMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudListMessage"),
+)
 fun I18nTranslator.completeListMessage(
     text: CharSequence,
     button: CharSequence,
     vararg sections: WhatsAppBotActionSection
 ) : WhatsAppBotMessageInteractiveMessage = completeListMessage(text, button, sections.toList())
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudListMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudListMessage"),
+)
 fun I18nTranslator.completeListMessage(
     text: CharSequence,
     button: CharSequence,
@@ -221,6 +265,10 @@ fun I18nTranslator.completeListMessage(
     }
 }
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudListMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudListMessage"),
+)
 fun I18nTranslator.listMessage(
     text: CharSequence,
     button: CharSequence,
@@ -228,6 +276,10 @@ fun I18nTranslator.listMessage(
 ) : WhatsAppBotMessageInteractiveMessage =
         listMessage(text, button, replies.toList())
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudListMessage", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudListMessage"),
+)
 fun I18nTranslator.listMessage(
     text: CharSequence,
     button: CharSequence,
@@ -243,6 +295,10 @@ fun I18nTranslator.listMessage(
         })
     )
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudNlpQuickReply", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudNlpQuickReply"),
+)
 fun I18nTranslator.nlpQuickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
@@ -253,6 +309,10 @@ fun I18nTranslator.nlpQuickReply(
         translate(subTitle).toString(),
 )
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudQuickReply", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudQuickReply"),
+)
 fun <T: Bus<T>> T.quickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
@@ -261,6 +321,10 @@ fun <T: Bus<T>> T.quickReply(
 ): QuickReply =
     quickReply(title, subTitle, targetIntent, stepName, parameters.toMap())
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudQuickReply", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudQuickReply"),
+)
 fun <T: Bus<T>> T.quickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
@@ -269,6 +333,10 @@ fun <T: Bus<T>> T.quickReply(
     vararg parameters: Pair<String, String>
 ) : QuickReply = quickReply(title, subTitle, targetIntent.wrappedIntent(), step?.name, parameters.toMap())
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudQuickReply", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudQuickReply"),
+)
 fun <T: Bus<T>> T.quickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,
@@ -280,6 +348,10 @@ fun <T: Bus<T>> T.quickReply(
         SendChoice.encodeChoiceId(intent, s, params, null, null, sourceAppId = null)
     }
 
+@Deprecated(
+    "On-Premises API is being sunset by Meta, consider migrating to the WhatsApp Cloud API connector",
+    ReplaceWith("whatsAppCloudQuickReply", "ai.tock.bot.connector.whatsapp.cloud.whatsAppCloudQuickReply"),
+)
 private fun I18nTranslator.quickReply(
     title: CharSequence,
     subTitle: CharSequence? = null,

--- a/bot/engine/src/main/kotlin/engine/event/Event.kt
+++ b/bot/engine/src/main/kotlin/engine/event/Event.kt
@@ -29,7 +29,7 @@ import org.litote.kmongo.newId
  */
 abstract class Event(
     /**
-     * The TOCK application id.
+     * The TOCK connector id.
      *
      * This ID should match the connector identifier in TOCK Studio.
      *

--- a/docs/docs/en/user/guides/canaux.md
+++ b/docs/docs/en/user/guides/canaux.md
@@ -22,62 +22,36 @@ This page actually lists:
 - The [_connectors_](canaux.md#connectors-provided-with-tock) provided with the Tock distribution:
 
 ![logo messenger](../../img/messenger.png "whatsapp"){style="width:50px;"}
-
 ![Logo slack](../../img/slack.png "Slack"){style="width: 75px;"}
-
 ![Logo Google assistant](../../img/googelassist.png "google assisstant"){style="width: 70px;"}
-
 ![logo google home](../../img/googlehome.png "google home "){style="width:50px;"}
-
 ![Logo Alexa](../../img/alexa2.png "alexa"){style="width: 75px;"}
-
 ![logo Rocket rachat](../../img/rocketrachat.png "rocket rachat"){style="width:50px;"}
-
 ![logo whatsapp](../../img/whatsapp.png "whatsapp"){style="width:50px;"}
-
 ![logo teams](../../img/teams.png "teams"){style="width:50px;"}
-
 ![logo BusinessChat Logo](../../img/message.png "BusinessChat Logo"){style="width:50px;"}
-
-
 ![logo twitter](../../img/twitter.png "twitter"){style="width:50px;"}
-
- 
 ![logo google chat ](../../img/ggchat.png "google chat"){style="width:50px;"}
-
 ![logo mattermost](../../img/mattermost.svg "Mattermost"){style="width:50px;"}
-
 ![logo web](../../img/web.png "web"){style="width:50px;"}
-
 ![logo test](../../img/test.jpeg "test"){style="width:50px;"}
 
 - The [kits using the _Web connector_](canaux.md#integrations-via-the-web-connector) to integrate other channels:
 
 ![logo React](../../img/React.png "React"){style="width:50px;"}
-
 ![logo flutter](../../img/flutter.png "allo media"){style="width:50px;"}
-
-
 ![logo Sharepoint](../../img/sharepoint.png "Sharepopint"){style="width:50px;"}
 
 - The [possible integrations for voice processing](canaux.md#voice-technologies):
 
 ![logo android](../../img/android.png "allo media"){style="width:50px;"}
-
 ![Logo Google assistant](../../img/googelassist.png "google assistant"){style="width: 70px;"}
-
 ![logo google home](../../img/googlehome.png "google home "){style="width:50px;"}
-
 ![logo teams](../../img/teams.png "teams"){style="width:50px;"}
-
 ![logo ios](../../img/ios.png "ios"){style="width:50px;"}
-
 ![logo BusinessChat Logo](../../img/message.png "BusinessChat Logo"){style="width:50px;"}
-
 ![Logo Alexa](../../img/alexa2.png "Alexa"){style="width: 75px;"}
-
- ![Logo voxygen](../../img/voxygen.png "Voxygen"){style="width: 100px;"}
-
+![Logo voxygen](../../img/voxygen.png "Voxygen"){style="width: 100px;"}
 ![Logo nuance](../../img/nuance.png "Nuance"){style="width: 75px;"}
 
 ## Connectors provided with Tock
@@ -167,10 +141,14 @@ To learn more about this connector, see its sources and its _README_ in the fold
 
 * **Channel** : [WhatsApp from Facebook](https://www.whatsapp.com/)
 * **Type** : text
-* **Status** : Tock connector used in production since 2019
+* **Status** :
+    * [*On-Premise API*](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp) : Tock connector
+      used in production since 2019, deprecated following the sunsetting of the API by Meta
+    * [*Cloud API*](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp-cloud) : Tock connector
+      used in production since 2024
 
 To learn more about this connector, see its sources and its _README_ in the folder
-[connector-whatsapp](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp) on GitHub.
+[connector-whatsapp-cloud](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp-cloud) on GitHub.
 
 ### Teams
 
@@ -201,7 +179,7 @@ To learn more about this connector, see its sources and its _README_ in the fold
 
 * **Channel** : [Twitter](https://twitter.com/) (private messages)
 * **Type** : text
-* **Status** : Tock connector used in production since 2019
+* **Status** : Tock connector previously used in production, no active support
 
 To learn more about this connector, see its sources and its _README_ in the folder
 [connector-twitter](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-twitter) on GitHub.

--- a/docs/docs/fr/user/guides/canaux.md
+++ b/docs/docs/fr/user/guides/canaux.md
@@ -22,60 +22,35 @@ Cette page liste en fait :
 - Les [_connecteurs_](#integrations-via-le-connecteur-web) fournis avec la distribution Tock :
 
 ![logo messenger](../../img/messenger.png "whatsapp"){style="width:50px;"}
-
 ![Logo slack](../../img/slack.png "Slack"){style="width: 75px;"}
-
 ![Logo Google assistant](../../img/googelassist.png "google assisstant"){style="width: 70px;"}
-
 ![logo google home](../../img/googlehome.png "google home "){style="width:50px;"}
-
 ![Logo Alexa](../../img/alexa2.png "alexa"){style="width: 75px;"}
-
 ![logo Rocket rachat](../../img/rocketrachat.png "rocket rachat"){style="width:50px;"}
-
 ![logo whatsapp](../../img/whatsapp.png "whatsapp"){style="width:50px;"}
-
 ![logo teams](../../img/teams.png "teams"){style="width:50px;"}
-
 ![logo BusinessChat Logo](../../img/message.png "BusinessChat Logo"){style="width:50px;"}
-
 ![logo twitter](../../img/twitter.png "twitter"){style="width:50px;"}
-
- 
 ![logo google chat ](../../img/ggchat.png "google chat"){style="width:50px;"}
-
 ![logo mattermost](../../img/mattermost.svg "Mattermost"){style="width:50px;"}
-
 ![logo web](../../img/web.png "web"){style="width:50px;"}
-
 ![logo test](../../img/test.jpeg "test"){style="width:50px;"}
 
 - Les [kits utilisant le _connecteur Web_](#integrations-via-le-connecteur-web) pour intégrer d'autres canaux :  
 
 ![logo React](../../img/React.png "React"){style="width:50px;"}
-
 ![logo flutter](../../img/flutter.png "allo media"){style="width:50px;"}
-
-
 ![logo Sharepoint](../../img/sharepoint.png "Sharepopint"){style="width:50px;"}
 
 - Les [intégrations possibles pour le traitement de la voix](canaux.md#technologies-vocales) :  
 ![logo android](../../img/android.png "allo media"){style="width:50px;"}
-
 ![Logo Google assistant](../../img/googelassist.png "google assistant"){style="width: 70px;"}
-
 ![logo google home](../../img/googlehome.png "google home "){style="width:50px;"}
-
 ![logo teams](../../img/teams.png "teams"){style="width:50px;"}
-
 ![logo ios](../../img/ios.png "ios"){style="width:50px;"}
-
 ![logo BusinessChat Logo](../../img/message.png "BusinessChat Logo"){style="width:50px;"}
-
 ![Logo Alexa](../../img/alexa2.png "Alexa"){style="width: 75px;"}
-
- ![Logo voxygen](../../img/voxygen.png "Voxygen"){style="width: 100px;"}
-
+![Logo voxygen](../../img/voxygen.png "Voxygen"){style="width: 100px;"}
 ![Logo nuance](../../img/nuance.png "Nuance"){style="width: 75px;"}
 
 ## Connecteurs fournis avec Tock
@@ -162,12 +137,15 @@ Pour en savoir plus sur ce connecteur, voir ses sources et son _README_ dans le 
 
 ![logo whatsapp](../../img/whatsapp.png "whatsapp"){style="width:100px;"}
 
-* **Canal** : [WhatsApp from Facebook](https://www.whatsapp.com/)
+* **Canal** : [WhatsApp from Meta](https://www.whatsapp.com/)
 * **Type** : texte
-* **Status** : connecteur Tock utilisé en production depuis 2019
+* **Status** :
+  * [*On-Premise API*](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp) : connecteur Tock
+    utilisé en production depuis 2019, déprécié suite à la fin du support par Meta
+  * [*Cloud API*](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp-cloud) : connecteur Tock utilisé en production depuis 2024
 
 Pour en savoir plus sur ce connecteur, voir ses sources et son _README_ dans le dossier 
-[connector-whatsapp](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp) sur GitHub.
+[connector-whatsapp](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-whatsapp-cloud) sur GitHub.
 
 ### Teams
 
@@ -198,7 +176,7 @@ Pour en savoir plus sur ce connecteur, voir ses sources et son _README_ dans le 
 
 * **Canal** : [Twitter](https://twitter.com/) (messages privés)
 * **Type** : texte
-* **Status** : connecteur Tock utilisé en production depuis 2019
+* **Status** : connecteur Tock précédemment utilisé en production, pas de support actif
 
 Pour en savoir plus sur ce connecteur, voir ses sources et son _README_ dans le dossier 
 [connector-twitter](https://github.com/theopenconversationkit/tock/tree/master/bot/connector-twitter) sur GitHub.

--- a/shared/src/main/kotlin/Executor.kt
+++ b/shared/src/main/kotlin/Executor.kt
@@ -24,14 +24,14 @@ import java.util.concurrent.Executor
 /**
  * Manage async tasks.
  */
-interface Executor {
+interface Executor : Executor {
 
     /**
      * Schedules a blocking task for execution on another thread.
      *
      * This method returns immediately, without waiting for the task to finish.
      *
-     * @delay delay the delay before run
+     * @param delay the time from now to delay execution
      * @param runnable the task to run
      */
     fun executeBlocking(delay: Duration, runnable: () -> Unit)
@@ -43,7 +43,7 @@ interface Executor {
      *
      * The returned future will schedule any followup async task on this executor.
      *
-     * @delay delay the delay before run
+     * @param delay the time from now to delay execution
      * @param task the task to run
      * @return a [CompletableFuture] that is asynchronously completed with the given [task]
      */
@@ -91,13 +91,15 @@ interface Executor {
      */
     fun setPeriodic(initialDelay: Duration, delay: Duration, runnable: () -> Unit): Long
 
+    override fun execute(command: Runnable) {
+        executeBlocking { command.run() }
+    }
+
     /**
      * Returns an incomplete [CompletableFuture] which uses this executor for async methods that do not specify
      * another executor
      */
-    fun <T> newIncompleteFuture(): CompletableFuture<T> = ExecutableFuture {
-        command -> executeBlocking { command.run() }
-    }
+    fun <T> newIncompleteFuture(): CompletableFuture<T> = ExecutableFuture(this)
 
     open class ExecutableFuture<T>(private val executor: Executor) : CompletableFuture<T>() {
         override fun <U : Any?> newIncompleteFuture(): CompletableFuture<U> {


### PR DESCRIPTION
This PR formally deprecates the `whatsapp-connector` module, and promotes the `whatsapp-cloud-connector` module as an alternative. It also does a cleanup pass on the latter, to make it more maintainable going forward.

The following changes have been made:
1. updated the README of both modules, as well as the relevant documentation pages
2. properly encapsulated WhatsApp API calls in the cloud connector
3. added missing `endForWhatsAppCloud` utility method
4. Split `whatsAppCloudImage` into one variant for images downloaded from a URL and another for images loaded in memory as a byte array
5. finished renaming `Component` to `WhatsappTemplateComponent`
6. moved the message preparation logic to the message classes
7. deprecated all message building methods in the legacy whatsapp-cloud connector