### PR TITLE
[Tock Studio] Add of observability public url input

### DIFF
--- a/bot/admin/web/src/app/configuration/observability-settings/models/observability-settings.ts
+++ b/bot/admin/web/src/app/configuration/observability-settings/models/observability-settings.ts
@@ -7,6 +7,7 @@ export interface ObservabilitySetting {
   publicKey?: String;
 
   url?: String;
+  publicUrl?: String;
 }
 
 export interface ObservabilitySettings {

--- a/bot/admin/web/src/app/configuration/observability-settings/models/providers-configuration.ts
+++ b/bot/admin/web/src/app/configuration/observability-settings/models/providers-configuration.ts
@@ -17,7 +17,8 @@ export const ProvidersConfigurations: ObservabilityProvidersConfiguration[] = [
     params: [
       { key: 'publicKey', label: 'Public key', type: 'obfuscated' },
       { key: 'secretKey', label: 'Secret key', type: 'obfuscated', confirmExport: true },
-      { key: 'url', label: 'Url', type: 'obfuscated' }
+      { key: 'url', label: 'Url', type: 'obfuscated' },
+      { key: 'publicUrl', label: 'Public url', type: 'obfuscated', required: false }
     ]
   }
 ];

--- a/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
+++ b/bot/admin/web/src/app/configuration/observability-settings/observability-settings.component.ts
@@ -150,7 +150,9 @@ export class ObservabilitySettingsComponent implements OnInit, OnDestroy {
       this.resetFormGroupControls();
 
       requiredConfiguration.params.forEach((param) => {
-        this.form.controls['setting'].addControl(param.key, new FormControl(param.defaultValue, Validators.required));
+        const isRequired = param.required || typeof param.required === 'undefined';
+
+        this.form.controls['setting'].addControl(param.key, new FormControl(param.defaultValue, isRequired ? Validators.required : {}));
       });
 
       this.form.controls['setting'].addControl('provider', new FormControl(provider));

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.html
@@ -4,7 +4,7 @@
       [label]="getFormControlLabel()"
       [name]="configurationParam.key"
       [controls]="getFormControl()"
-      [required]="true"
+      [required]="isRequired"
       [boldLabel]="false"
       [showError]="isSubmitted"
       [information]="configurationParam.information"

--- a/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
+++ b/bot/admin/web/src/app/shared/components/ai-settings-engine-config-param-input/ai-settings-engine-config-param-input.component.ts
@@ -18,6 +18,10 @@ export class AiSettingsEngineConfigParamInputComponent {
 
   inputVisible: boolean = false;
 
+  get isRequired(): boolean {
+    return this.configurationParam.required || typeof this.configurationParam.required === 'undefined';
+  }
+
   getFormControl(): FormControl {
     return this.form.get(this.parentGroup).get(this.configurationParam.key) as FormControl;
   }

--- a/bot/admin/web/src/app/shared/model/ai-settings.ts
+++ b/bot/admin/web/src/app/shared/model/ai-settings.ts
@@ -12,6 +12,7 @@ export interface ProvidersConfigurationParam {
   step?: number;
   rows?: number;
   confirmExport?: boolean;
+  required?: boolean;
 }
 
 export enum AiEngineProvider {


### PR DESCRIPTION
Works with https://github.com/theopenconversationkit/tock/pull/1856

In Gen AI > Observability, define an optional public access url to the observability tool