### PR TITLE
[Tock Studio] Warning on inbox faq sentences + link to sentences search view

### DIFF
--- a/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
+++ b/bot/admin/web/src/app/analytics/dialog/dialog.component.ts
@@ -34,7 +34,7 @@ export class DialogComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    setTimeout(() => this.initialize());
+    setTimeout(() => this.initialize(), 500);
   }
 
   initialize(): void {

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.html
@@ -217,6 +217,23 @@
         </tock-form-control>
 
         <nb-alert
+          *ngIf="utterances.controls.length && showInboxSentencesWarning"
+          accent="warning"
+          closable
+          (close)="onCloseInboxSentencesWarning()"
+        >
+          <div class="font-size-small">
+            Only “validated” and “in model” sentences are listed here. To see the “inbox” sentences associated with this faq,
+            <a
+              href="javascript:void(0)"
+              (click)="sendToInbox()"
+            >
+              click here.
+            </a>
+          </div>
+        </nb-alert>
+
+        <nb-alert
           status="danger"
           *ngIf="existingUterranceInOtherintent"
           class="closable mt-2"

--- a/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management-edit/faq-management-edit.component.ts
@@ -27,6 +27,7 @@ import { KeyValue } from '@angular/common';
 import { ExtractFormControlTyping, GenericObject } from '../../../shared/utils/typescript.utils';
 import { BotConfigurationService } from '../../../core/bot-configuration.service';
 import { Footnote } from '../../../shared/model/dialog-data';
+import { Router } from '@angular/router';
 
 export enum FaqTabs {
   INFO = 'info',
@@ -100,6 +101,8 @@ export class FaqManagementEditComponent implements OnChanges {
     { label: 'Markdown', value: MarkupFormats.MARKDOWN }
   ];
 
+  showInboxSentencesWarning: boolean = true;
+
   @Input() loading: boolean;
   @Input() faq?: FaqDefinitionExtended;
   @Input() tagsCache?: string[];
@@ -120,7 +123,8 @@ export class FaqManagementEditComponent implements OnChanges {
     private state: StateService,
     public botSharedService: BotSharedService,
     private botService: BotService,
-    private botConfiguration: BotConfigurationService
+    private botConfiguration: BotConfigurationService,
+    private router: Router
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -1075,6 +1079,19 @@ export class FaqManagementEditComponent implements OnChanges {
 
   expandSidePanel() {
     this.onExpandSidePanel.emit(true);
+  }
+
+  onCloseInboxSentencesWarning() {
+    this.showInboxSentencesWarning = false;
+  }
+
+  sendToInbox() {
+    this.router.navigate(['/language-understanding/search'], {
+      state: {
+        intentId: this.faq.intentId,
+        status: SentenceStatus.inbox
+      }
+    });
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/model-quality/test-entity-errors/test-entity-errors.component.ts
+++ b/bot/admin/web/src/app/model-quality/test-entity-errors/test-entity-errors.component.ts
@@ -84,7 +84,7 @@ export class TestEntityErrorsComponent implements OnInit, OnDestroy {
 
   change(error: EntityTestError) {
     this.qualityService.deleteEntityError(error).subscribe((e) => {
-      this.router.navigate(['/language-understanding/search'], { state: { searchIntent: '^' + escapeRegex(error.sentence.text) + '$' } });
+      this.router.navigate(['/language-understanding/search'], { state: { searchSentence: '^' + escapeRegex(error.sentence.text) + '$' } });
     });
   }
 

--- a/bot/admin/web/src/app/model-quality/test-intent-errors/test-intent-errors.component.ts
+++ b/bot/admin/web/src/app/model-quality/test-intent-errors/test-intent-errors.component.ts
@@ -78,7 +78,7 @@ export class TestIntentErrorsComponent implements OnInit, OnDestroy {
 
   change(error: IntentTestError) {
     this.qualityService.deleteIntentError(error).subscribe((e) => {
-      this.router.navigate(['/language-understanding/search'], { state: { searchIntent: '^' + escapeRegex(error.sentence.text) + '$' } });
+      this.router.navigate(['/language-understanding/search'], { state: { searchSentence: '^' + escapeRegex(error.sentence.text) + '$' } });
     });
   }
 


### PR DESCRIPTION
- Added a closable warning to the “Question” tab of the faq editing view to inform the user that only “validated” and “in model” sentences are listed.
- The warning includes a link to the “Language understanding > Search sentences” view. If followed, the link opens the view with the advanced search field “Intent” filled in with the faq's intent and the “Inbox” option checked, and launches the search.

![image](https://github.com/user-attachments/assets/1405837f-0835-4b11-8215-fee5b709395e)
