### PR TITLE
FIX : Namespace deletion update role

### DIFF
--- a/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
+++ b/nlp/admin/server/src/main/kotlin/AdminVerticle.kt
@@ -1080,7 +1080,7 @@ open class AdminVerticle : WebVerticle() {
 
         blockingDelete(
             "/namespace/:namespace",
-            technicalAdmin,
+            admin,
             simpleLogger("Delete Namespace", { it.path("namespace") })
         ) { context ->
             val ns = context.path("namespace").trim()


### PR DESCRIPTION
Role update to delete a namespace 

- Before : `technicalAdmin`
- After : `Admin`