### PR TITLE
resolves #1881 NLP: add healthcheck for Sagemaker classifiers

### DIFF
--- a/nlp/api/service/src/main/kotlin/NlpVerticle.kt
+++ b/nlp/api/service/src/main/kotlin/NlpVerticle.kt
@@ -16,6 +16,10 @@
 
 package ai.tock.nlp.api
 
+/**
+ *
+ */
+// Add this import at the top with the other imports
 import ai.tock.nlp.front.client.FrontClient
 import ai.tock.nlp.front.service.UnknownApplicationException
 import ai.tock.nlp.front.shared.codec.ApplicationDump
@@ -28,13 +32,8 @@ import ai.tock.nlp.front.shared.merge.ValuesMergeQuery
 import ai.tock.nlp.front.shared.monitoring.MarkAsUnknownQuery
 import ai.tock.nlp.front.shared.monitoring.ParseRequestLogCountQuery
 import ai.tock.nlp.front.shared.parser.ParseQuery
-import ai.tock.shared.Executor
-import ai.tock.shared.TOCK_FRONT_DATABASE
-import ai.tock.shared.TOCK_MODEL_DATABASE
-import ai.tock.shared.injector
-import ai.tock.shared.namespace
-import ai.tock.shared.pingMongoDatabase
-import ai.tock.shared.property
+import ai.tock.nlp.model.service.NlpClassifierService
+import ai.tock.shared.*
 import ai.tock.shared.security.auth.TockAuthProvider
 import ai.tock.shared.security.initEncryptor
 import ai.tock.shared.vertx.WebVerticle
@@ -44,11 +43,8 @@ import io.vertx.ext.web.RoutingContext
 import mu.KLogger
 import mu.KotlinLogging
 import org.litote.kmongo.Id
-import java.util.Locale
+import java.util.*
 
-/**
- *
- */
 class NlpVerticle : WebVerticle() {
 
     private val protectPath = verticleBooleanProperty("tock_nlp_protect_path", false)
@@ -58,6 +54,9 @@ class NlpVerticle : WebVerticle() {
     override val rootPath: String = property("tock_nlp_root", "/rest/nlp")
 
     private val executor: Executor by injector.instance()
+
+    // Add this line to access NlpClassifierService
+    private val nlpClassifierService = NlpClassifierService
 
     override val logger: KLogger = KotlinLogging.logger {}
 
@@ -232,7 +231,7 @@ class NlpVerticle : WebVerticle() {
             Pair("duckling_service", { FrontClient.healthcheck() }),
             Pair("tock_front_database", { pingMongoDatabase(TOCK_FRONT_DATABASE) }),
             Pair("tock_model_database", { pingMongoDatabase(TOCK_MODEL_DATABASE) })
-        )
+        ) + NlpClassifierService.healthcheck()
     )
 }
 

--- a/nlp/api/service/src/main/kotlin/NlpVerticle.kt
+++ b/nlp/api/service/src/main/kotlin/NlpVerticle.kt
@@ -33,7 +33,13 @@ import ai.tock.nlp.front.shared.monitoring.MarkAsUnknownQuery
 import ai.tock.nlp.front.shared.monitoring.ParseRequestLogCountQuery
 import ai.tock.nlp.front.shared.parser.ParseQuery
 import ai.tock.nlp.model.service.NlpClassifierService
-import ai.tock.shared.*
+import ai.tock.shared.Executor
+import ai.tock.shared.TOCK_FRONT_DATABASE
+import ai.tock.shared.TOCK_MODEL_DATABASE
+import ai.tock.shared.injector
+import ai.tock.shared.namespace
+import ai.tock.shared.pingMongoDatabase
+import ai.tock.shared.property
 import ai.tock.shared.security.auth.TockAuthProvider
 import ai.tock.shared.security.initEncryptor
 import ai.tock.shared.vertx.WebVerticle
@@ -43,7 +49,7 @@ import io.vertx.ext.web.RoutingContext
 import mu.KLogger
 import mu.KotlinLogging
 import org.litote.kmongo.Id
-import java.util.*
+import java.util.Locale
 
 class NlpVerticle : WebVerticle() {
 

--- a/nlp/core/service/src/main/kotlin/NlpCoreService.kt
+++ b/nlp/core/service/src/main/kotlin/NlpCoreService.kt
@@ -16,32 +16,18 @@
 
 package ai.tock.nlp.core.service
 
-import ai.tock.nlp.core.CallContext
-import ai.tock.nlp.core.Entity
-import ai.tock.nlp.core.EntityRecognition
-import ai.tock.nlp.core.EntityType
-import ai.tock.nlp.core.Intent
+import ai.tock.nlp.core.*
 import ai.tock.nlp.core.Intent.Companion.UNKNOWN_INTENT_NAME
-import ai.tock.nlp.core.IntentClassification
-import ai.tock.nlp.core.IntentSelector
-import ai.tock.nlp.core.NlpCore
-import ai.tock.nlp.core.NlpEngineType
-import ai.tock.nlp.core.ParsingResult
 import ai.tock.nlp.core.merge.ValueDescriptor
 import ai.tock.nlp.core.quality.TestContext
 import ai.tock.nlp.core.service.entity.EntityCore
 import ai.tock.nlp.core.service.entity.EntityCoreService
 import ai.tock.nlp.core.service.entity.EntityMerge
-import ai.tock.nlp.model.EntityCallContextForEntity
-import ai.tock.nlp.model.EntityCallContextForIntent
-import ai.tock.nlp.model.IntentContext
-import ai.tock.nlp.model.ModelHolder
-import ai.tock.nlp.model.ModelNotInitializedException
-import ai.tock.nlp.model.NlpClassifier
+import ai.tock.nlp.model.*
 import ai.tock.shared.checkMaxLengthAllowed
 import ai.tock.shared.error
-import ai.tock.shared.normalize
 import ai.tock.shared.injector
+import ai.tock.shared.normalize
 import com.github.salomonbrys.kodein.instance
 import mu.KotlinLogging
 

--- a/nlp/core/service/src/main/kotlin/NlpCoreService.kt
+++ b/nlp/core/service/src/main/kotlin/NlpCoreService.kt
@@ -16,14 +16,29 @@
 
 package ai.tock.nlp.core.service
 
-import ai.tock.nlp.core.*
+
+import ai.tock.nlp.core.CallContext
+import ai.tock.nlp.core.Entity
+import ai.tock.nlp.core.EntityRecognition
+import ai.tock.nlp.core.EntityType
+import ai.tock.nlp.core.Intent
 import ai.tock.nlp.core.Intent.Companion.UNKNOWN_INTENT_NAME
+import ai.tock.nlp.core.IntentClassification
+import ai.tock.nlp.core.IntentSelector
+import ai.tock.nlp.core.NlpCore
+import ai.tock.nlp.core.NlpEngineType
+import ai.tock.nlp.core.ParsingResult
 import ai.tock.nlp.core.merge.ValueDescriptor
 import ai.tock.nlp.core.quality.TestContext
 import ai.tock.nlp.core.service.entity.EntityCore
 import ai.tock.nlp.core.service.entity.EntityCoreService
 import ai.tock.nlp.core.service.entity.EntityMerge
-import ai.tock.nlp.model.*
+import ai.tock.nlp.model.EntityCallContextForEntity
+import ai.tock.nlp.model.EntityCallContextForIntent
+import ai.tock.nlp.model.IntentContext
+import ai.tock.nlp.model.ModelHolder
+import ai.tock.nlp.model.ModelNotInitializedException
+import ai.tock.nlp.model.NlpClassifier
 import ai.tock.shared.checkMaxLengthAllowed
 import ai.tock.shared.error
 import ai.tock.shared.injector

--- a/nlp/model/opennlp/src/main/kotlin/OpenNlpEngineProvider.kt
+++ b/nlp/model/opennlp/src/main/kotlin/OpenNlpEngineProvider.kt
@@ -17,15 +17,7 @@
 package ai.tock.nlp.opennlp
 
 import ai.tock.nlp.core.NlpEngineType
-import ai.tock.nlp.model.service.engine.EntityClassifier
-import ai.tock.nlp.model.service.engine.EntityModelHolder
-import ai.tock.nlp.model.service.engine.IntentClassifier
-import ai.tock.nlp.model.service.engine.IntentModelHolder
-import ai.tock.nlp.model.service.engine.NlpEngineModelBuilder
-import ai.tock.nlp.model.service.engine.NlpEngineModelIo
-import ai.tock.nlp.model.service.engine.NlpEngineProvider
-import ai.tock.nlp.model.service.engine.Tokenizer
-import ai.tock.nlp.model.service.engine.TokenizerModelHolder
+import ai.tock.nlp.model.service.engine.*
 
 /**
  *

--- a/nlp/model/opennlp/src/main/kotlin/OpenNlpEngineProvider.kt
+++ b/nlp/model/opennlp/src/main/kotlin/OpenNlpEngineProvider.kt
@@ -17,7 +17,15 @@
 package ai.tock.nlp.opennlp
 
 import ai.tock.nlp.core.NlpEngineType
-import ai.tock.nlp.model.service.engine.*
+import ai.tock.nlp.model.service.engine.EntityClassifier
+import ai.tock.nlp.model.service.engine.EntityModelHolder
+import ai.tock.nlp.model.service.engine.IntentClassifier
+import ai.tock.nlp.model.service.engine.IntentModelHolder
+import ai.tock.nlp.model.service.engine.NlpEngineModelBuilder
+import ai.tock.nlp.model.service.engine.NlpEngineModelIo
+import ai.tock.nlp.model.service.engine.NlpEngineProvider
+import ai.tock.nlp.model.service.engine.Tokenizer
+import ai.tock.nlp.model.service.engine.TokenizerModelHolder
 
 /**
  *

--- a/nlp/model/sagemaker/pom.xml
+++ b/nlp/model/sagemaker/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sagemaker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
         <dependency>

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
@@ -19,10 +19,14 @@ import ai.tock.shared.jackson.mapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient
+import software.amazon.awssdk.services.sagemaker.SageMakerClient
+import software.amazon.awssdk.services.sagemaker.model.DescribeEndpointRequest
 import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointRequest
 import java.nio.charset.Charset
 
 class SagemakerAwsClient(private val configuration: SagemakerAwsClientProperties) {
+
+    val name = configuration.name
 
     // for intentions and entities
     data class ParsedRequest(
@@ -54,6 +58,12 @@ class SagemakerAwsClient(private val configuration: SagemakerAwsClientProperties
 
     private val runtimeClient: SageMakerRuntimeClient = SageMakerRuntimeClient.builder()
         .region(configuration.region)
+        .credentialsProvider(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.create())
+        .build()
+
+    private val sagemakerClient: SageMakerClient = SageMakerClient.builder()
+        .region(configuration.region)
+        .credentialsProvider(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.create())
         .build()
 
     fun parseIntent(request: ParsedRequest) = invokeSageMakerIntentEndpoint(request.text)
@@ -83,5 +93,13 @@ class SagemakerAwsClient(private val configuration: SagemakerAwsClientProperties
         val response = runtimeClient.invokeEndpoint(endpointRequest)
         val entities = mapper.readValue<List<ParsedEntity>>(response.body().asInputStream())
         return ParsedEntitiesResponse(entities)
+    }
+
+    fun healthcheck(): Boolean {
+        val endpointRequest = DescribeEndpointRequest.builder()
+            .endpointName(configuration.endpointName)
+            .build()
+        val response = sagemakerClient.describeEndpoint(endpointRequest)
+       return response.endpointStatus() == software.amazon.awssdk.services.sagemaker.model.EndpointStatus.IN_SERVICE
     }
 }

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
@@ -17,10 +17,11 @@ package ai.tock.nlp.sagemaker
 
 import ai.tock.shared.jackson.mapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.core.SdkBytes
-import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient
 import software.amazon.awssdk.services.sagemaker.SageMakerClient
 import software.amazon.awssdk.services.sagemaker.model.DescribeEndpointRequest
+import software.amazon.awssdk.services.sagemakerruntime.SageMakerRuntimeClient
 import software.amazon.awssdk.services.sagemakerruntime.model.InvokeEndpointRequest
 import java.nio.charset.Charset
 
@@ -58,12 +59,12 @@ class SagemakerAwsClient(private val configuration: SagemakerAwsClientProperties
 
     private val runtimeClient: SageMakerRuntimeClient = SageMakerRuntimeClient.builder()
         .region(configuration.region)
-        .credentialsProvider(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build()
 
     private val sagemakerClient: SageMakerClient = SageMakerClient.builder()
         .region(configuration.region)
-        .credentialsProvider(software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build()
 
     fun parseIntent(request: ParsedRequest) = invokeSageMakerIntentEndpoint(request.text)

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClient.kt
@@ -59,12 +59,10 @@ class SagemakerAwsClient(private val configuration: SagemakerAwsClientProperties
 
     private val runtimeClient: SageMakerRuntimeClient = SageMakerRuntimeClient.builder()
         .region(configuration.region)
-        .credentialsProvider(DefaultCredentialsProvider.create())
         .build()
 
     private val sagemakerClient: SageMakerClient = SageMakerClient.builder()
         .region(configuration.region)
-        .credentialsProvider(DefaultCredentialsProvider.create())
         .build()
 
     fun parseIntent(request: ParsedRequest) = invokeSageMakerIntentEndpoint(request.text)

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClientProperties.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerAwsClientProperties.kt
@@ -21,6 +21,7 @@ import software.amazon.awssdk.regions.Region
 internal fun String.unescapeSagemakerName(): String = replace("___", ":")
 
 data class SagemakerAwsClientProperties(
+    val name: String,
     val region: Region,
     val endpointName: String,
     val contentType: String,

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerClientProvider.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerClientProvider.kt
@@ -22,4 +22,7 @@ internal object SagemakerClientProvider {
 
     fun getClient(conf: SagemakerAwsClientProperties): SagemakerAwsClient =
         clientMap.getOrPut(conf) { SagemakerAwsClient(conf) }
+
+    fun getAllClient(): MutableCollection<SagemakerAwsClient> =
+        clientMap.values
 }

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerClientType.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerClientType.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017/2024 e-voyageurs technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.tock.nlp.sagemaker
+
+/**
+ * Enum representing the different types of Sagemaker clients.
+ */
+enum class SagemakerClientType(val clientName: String) {
+    INTENT_CLASSIFICATION("intent-classification"),
+    ENTITY_CLASSIFICATION("entity-classification");
+
+    override fun toString(): String = clientName
+}

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerEngineProvider.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerEngineProvider.kt
@@ -16,17 +16,10 @@
 
 package ai.tock.nlp.sagemaker
 
+import NlpHealthcheckResult
 import ai.tock.nlp.core.NlpEngineType
 import ai.tock.nlp.model.TokenizerContext
-import ai.tock.nlp.model.service.engine.EntityClassifier
-import ai.tock.nlp.model.service.engine.EntityModelHolder
-import ai.tock.nlp.model.service.engine.IntentClassifier
-import ai.tock.nlp.model.service.engine.IntentModelHolder
-import ai.tock.nlp.model.service.engine.NlpEngineModelBuilder
-import ai.tock.nlp.model.service.engine.NlpEngineModelIo
-import ai.tock.nlp.model.service.engine.NlpEngineProvider
-import ai.tock.nlp.model.service.engine.Tokenizer
-import ai.tock.nlp.model.service.engine.TokenizerModelHolder
+import ai.tock.nlp.model.service.engine.*
 
 class SagemakerEngineProvider : NlpEngineProvider {
 
@@ -56,4 +49,13 @@ class SagemakerEngineProvider : NlpEngineProvider {
         // do not tokenize anything at this stage
         override fun tokenize(context: TokenizerContext, text: String): Array<String> = arrayOf(text)
     }
+
+    override fun healthcheck(): () -> NlpHealthcheckResult = {
+        val grouped = SagemakerClientProvider.getAllClient().groupBy { it.name }.withDefault { emptyList() }
+        NlpHealthcheckResult(
+            entityClassifier = grouped.getValue(SagemakerEntityClassifier.CLIENT_NAME).all { it.healthcheck() },
+            intentClassifier = grouped.getValue(SagemakerIntentClassifier.CLIENT_NAME).all { it.healthcheck() },
+        )
+    }
 }
+

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerEngineProvider.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerEngineProvider.kt
@@ -19,7 +19,15 @@ package ai.tock.nlp.sagemaker
 import NlpHealthcheckResult
 import ai.tock.nlp.core.NlpEngineType
 import ai.tock.nlp.model.TokenizerContext
-import ai.tock.nlp.model.service.engine.*
+import ai.tock.nlp.model.service.engine.EntityClassifier
+import ai.tock.nlp.model.service.engine.EntityModelHolder
+import ai.tock.nlp.model.service.engine.IntentClassifier
+import ai.tock.nlp.model.service.engine.IntentModelHolder
+import ai.tock.nlp.model.service.engine.NlpEngineModelBuilder
+import ai.tock.nlp.model.service.engine.NlpEngineModelIo
+import ai.tock.nlp.model.service.engine.NlpEngineProvider
+import ai.tock.nlp.model.service.engine.Tokenizer
+import ai.tock.nlp.model.service.engine.TokenizerModelHolder
 
 class SagemakerEngineProvider : NlpEngineProvider {
 
@@ -53,8 +61,8 @@ class SagemakerEngineProvider : NlpEngineProvider {
     override fun healthcheck(): () -> NlpHealthcheckResult = {
         val grouped = SagemakerClientProvider.getAllClient().groupBy { it.name }.withDefault { emptyList() }
         NlpHealthcheckResult(
-            entityClassifier = grouped.getValue(SagemakerEntityClassifier.CLIENT_NAME).all { it.healthcheck() },
-            intentClassifier = grouped.getValue(SagemakerIntentClassifier.CLIENT_NAME).all { it.healthcheck() },
+            entityClassifier = grouped.getValue(SagemakerEntityClassifier.CLIENT_TYPE.clientName).all { it.healthcheck() },
+            intentClassifier = grouped.getValue(SagemakerIntentClassifier.CLIENT_TYPE.clientName).all { it.healthcheck() },
         )
     }
 }

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerEntityClassifier.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerEntityClassifier.kt
@@ -29,7 +29,7 @@ import software.amazon.awssdk.regions.Region
 
 internal class SagemakerEntityClassifier(model: EntityModelHolder) : NlpEntityClassifier(model) {
     companion object {
-        val CLIENT_NAME = "entity-classification"
+        val CLIENT_TYPE = SagemakerClientType.ENTITY_CLASSIFICATION
     }
 
     override fun classifyEntities(
@@ -39,7 +39,7 @@ internal class SagemakerEntityClassifier(model: EntityModelHolder) : NlpEntityCl
     ): List<EntityRecognition> {
         SagemakerClientProvider.getClient(
             SagemakerAwsClientProperties(
-                CLIENT_NAME,
+                CLIENT_TYPE.clientName,
                 Region.of(property("tock_sagemaker_aws_region_name", "eu-west-3")),
                 property("tock_sagemaker_aws_entities_endpoint_name", "default"),
                 property("tock_sagemaker_aws_content_type", "application/json"),

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerEntityClassifier.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerEntityClassifier.kt
@@ -26,7 +26,11 @@ import ai.tock.nlp.model.service.engine.NlpEntityClassifier
 import ai.tock.shared.property
 import software.amazon.awssdk.regions.Region
 
+
 internal class SagemakerEntityClassifier(model: EntityModelHolder) : NlpEntityClassifier(model) {
+    companion object {
+        val CLIENT_NAME = "entity-classification"
+    }
 
     override fun classifyEntities(
         context: EntityCallContext,
@@ -35,6 +39,7 @@ internal class SagemakerEntityClassifier(model: EntityModelHolder) : NlpEntityCl
     ): List<EntityRecognition> {
         SagemakerClientProvider.getClient(
             SagemakerAwsClientProperties(
+                CLIENT_NAME,
                 Region.of(property("tock_sagemaker_aws_region_name", "eu-west-3")),
                 property("tock_sagemaker_aws_entities_endpoint_name", "default"),
                 property("tock_sagemaker_aws_content_type", "application/json"),

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerIntentClassifier.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerIntentClassifier.kt
@@ -15,19 +15,24 @@
  */
 package ai.tock.nlp.sagemaker
 
-import ai.tock.nlp.sagemaker.SagemakerAwsClient.ParsedRequest
 import ai.tock.nlp.core.Intent
 import ai.tock.nlp.core.IntentClassification
 import ai.tock.nlp.model.IntentContext
 import ai.tock.nlp.model.service.engine.IntentClassifier
+import ai.tock.nlp.sagemaker.SagemakerAwsClient.ParsedRequest
 import ai.tock.shared.property
 import software.amazon.awssdk.regions.Region
 
+
 internal class SagemakerIntentClassifier(private val conf: SagemakerModelConfiguration) : IntentClassifier {
+    companion object {
+        const val CLIENT_NAME = "intent-classification"
+    }
 
     override fun classifyIntent(context: IntentContext, text: String, tokens: Array<String>): IntentClassification {
         return SagemakerClientProvider.getClient(
             SagemakerAwsClientProperties(
+                CLIENT_NAME,
                 Region.of(property("tock_sagemaker_aws_region_name", "eu-west-3")),
                 property("tock_sagemaker_aws_intent_endpoint_name", "default"),
                 property("tock_sagemaker_aws_content_type", "application/json"),
@@ -36,7 +41,6 @@ internal class SagemakerIntentClassifier(private val conf: SagemakerModelConfigu
         ).parseIntent(ParsedRequest(text))
             .run {
                 object : IntentClassification {
-
                     var probability = 0.0
                     val iterator = intent_ranking.iterator()
 

--- a/nlp/model/sagemaker/src/main/kotlin/SagemakerIntentClassifier.kt
+++ b/nlp/model/sagemaker/src/main/kotlin/SagemakerIntentClassifier.kt
@@ -26,13 +26,13 @@ import software.amazon.awssdk.regions.Region
 
 internal class SagemakerIntentClassifier(private val conf: SagemakerModelConfiguration) : IntentClassifier {
     companion object {
-        const val CLIENT_NAME = "intent-classification"
+        val CLIENT_TYPE = SagemakerClientType.INTENT_CLASSIFICATION
     }
 
     override fun classifyIntent(context: IntentContext, text: String, tokens: Array<String>): IntentClassification {
         return SagemakerClientProvider.getClient(
             SagemakerAwsClientProperties(
-                CLIENT_NAME,
+                CLIENT_TYPE.clientName,
                 Region.of(property("tock_sagemaker_aws_region_name", "eu-west-3")),
                 property("tock_sagemaker_aws_intent_endpoint_name", "default"),
                 property("tock_sagemaker_aws_content_type", "application/json"),

--- a/nlp/model/service/src/main/kotlin/NlpClassifierService.kt
+++ b/nlp/model/service/src/main/kotlin/NlpClassifierService.kt
@@ -16,16 +16,32 @@
 
 package ai.tock.nlp.model.service
 
-import ai.tock.nlp.core.*
+import ai.tock.nlp.core.Application
+import ai.tock.nlp.core.EntityRecognition
+import ai.tock.nlp.core.EntityType
+import ai.tock.nlp.core.Intent
+import ai.tock.nlp.core.IntentClassification
+import ai.tock.nlp.core.NlpEngineType
 import ai.tock.nlp.core.configuration.NlpApplicationConfiguration
 import ai.tock.nlp.core.sample.SampleExpression
-import ai.tock.nlp.model.*
+import ai.tock.nlp.model.EntityBuildContext
+import ai.tock.nlp.model.EntityCallContext
+import ai.tock.nlp.model.EntityCallContextForSubEntities
+import ai.tock.nlp.model.EntityContextKey
+import ai.tock.nlp.model.IntentContext
 import ai.tock.nlp.model.IntentContext.IntentContextKey
-import ai.tock.nlp.model.service.engine.*
+import ai.tock.nlp.model.ModelHolder
+import ai.tock.nlp.model.NlpClassifier
+import ai.tock.nlp.model.TokenizerContext
+import ai.tock.nlp.model.service.engine.EntityClassifier
+import ai.tock.nlp.model.service.engine.EntityModelHolder
+import ai.tock.nlp.model.service.engine.IntentModelHolder
+import ai.tock.nlp.model.service.engine.NlpEngineRepository
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.getModelBuilder
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.getModelIo
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.getProvider
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.registeredNlpEngineTypes
+import ai.tock.nlp.model.service.engine.NlpModelRepository
 import ai.tock.nlp.model.service.engine.NlpModelRepository.saveEntityModel
 import ai.tock.nlp.model.service.engine.NlpModelRepository.saveIntentModel
 import ai.tock.nlp.model.service.storage.NlpApplicationConfigurationDAO

--- a/nlp/model/service/src/main/kotlin/NlpClassifierService.kt
+++ b/nlp/model/service/src/main/kotlin/NlpClassifierService.kt
@@ -16,30 +16,16 @@
 
 package ai.tock.nlp.model.service
 
-import ai.tock.nlp.core.Application
-import ai.tock.nlp.core.EntityRecognition
-import ai.tock.nlp.core.EntityType
-import ai.tock.nlp.core.Intent
-import ai.tock.nlp.core.IntentClassification
-import ai.tock.nlp.core.NlpEngineType
+import ai.tock.nlp.core.*
 import ai.tock.nlp.core.configuration.NlpApplicationConfiguration
 import ai.tock.nlp.core.sample.SampleExpression
-import ai.tock.nlp.model.EntityBuildContext
-import ai.tock.nlp.model.EntityCallContext
-import ai.tock.nlp.model.EntityCallContextForSubEntities
-import ai.tock.nlp.model.EntityContextKey
-import ai.tock.nlp.model.IntentContext
+import ai.tock.nlp.model.*
 import ai.tock.nlp.model.IntentContext.IntentContextKey
-import ai.tock.nlp.model.ModelHolder
-import ai.tock.nlp.model.NlpClassifier
-import ai.tock.nlp.model.TokenizerContext
-import ai.tock.nlp.model.service.engine.EntityClassifier
-import ai.tock.nlp.model.service.engine.EntityModelHolder
-import ai.tock.nlp.model.service.engine.IntentModelHolder
-import ai.tock.nlp.model.service.engine.NlpEngineRepository
+import ai.tock.nlp.model.service.engine.*
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.getModelBuilder
 import ai.tock.nlp.model.service.engine.NlpEngineRepository.getModelIo
-import ai.tock.nlp.model.service.engine.NlpModelRepository
+import ai.tock.nlp.model.service.engine.NlpEngineRepository.getProvider
+import ai.tock.nlp.model.service.engine.NlpEngineRepository.registeredNlpEngineTypes
 import ai.tock.nlp.model.service.engine.NlpModelRepository.saveEntityModel
 import ai.tock.nlp.model.service.engine.NlpModelRepository.saveIntentModel
 import ai.tock.nlp.model.service.storage.NlpApplicationConfigurationDAO
@@ -234,5 +220,15 @@ object NlpClassifierService : NlpClassifier {
         configuration: NlpApplicationConfiguration
     ) {
         nlpApplicationConfigurationDAO.saveNewConfiguration(applicationName, engineType, configuration)
+    }
+
+    fun healthcheck(): List<Pair<String, () -> Boolean>> {
+        return registeredNlpEngineTypes().flatMap {
+            val healthcheck = getProvider(it).healthcheck()
+            listOf(
+                "${it.name}-entity" to { healthcheck().entityClassifier },
+                "${it.name}-intent" to { healthcheck().intentClassifier },
+            )
+        }
     }
 }

--- a/nlp/model/service/src/main/kotlin/engine/NlpEngineProvider.kt
+++ b/nlp/model/service/src/main/kotlin/engine/NlpEngineProvider.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.nlp.model.service.engine
 
+import NlpHealthcheckResult
 import ai.tock.nlp.core.NlpEngineType
 
 /**
@@ -53,4 +54,10 @@ interface NlpEngineProvider {
      * Returns the tokenizer from this [TokenizerModelHolder].
      */
     fun getTokenizer(model: TokenizerModelHolder): Tokenizer
+
+    /**
+     * Check if the NLP engine is healthy.
+     * @return true if the engine is healthy, false otherwise
+     */
+    fun healthcheck(): () -> NlpHealthcheckResult = { NlpHealthcheckResult.ALL_OK }
 }

--- a/nlp/model/service/src/main/kotlin/engine/NlpEngineRepository.kt
+++ b/nlp/model/service/src/main/kotlin/engine/NlpEngineRepository.kt
@@ -17,7 +17,12 @@
 package ai.tock.nlp.model.service.engine
 
 import ai.tock.nlp.core.NlpEngineType
-import ai.tock.nlp.model.*
+import ai.tock.nlp.model.ClassifierContext
+import ai.tock.nlp.model.ClassifierContextKey
+import ai.tock.nlp.model.EntityCallContext
+import ai.tock.nlp.model.EntityContext
+import ai.tock.nlp.model.IntentContext
+import ai.tock.nlp.model.TokenizerContext
 import ai.tock.shared.ThreadSafe
 
 /**

--- a/nlp/model/service/src/main/kotlin/engine/NlpEngineRepository.kt
+++ b/nlp/model/service/src/main/kotlin/engine/NlpEngineRepository.kt
@@ -17,12 +17,7 @@
 package ai.tock.nlp.model.service.engine
 
 import ai.tock.nlp.core.NlpEngineType
-import ai.tock.nlp.model.ClassifierContext
-import ai.tock.nlp.model.ClassifierContextKey
-import ai.tock.nlp.model.EntityCallContext
-import ai.tock.nlp.model.EntityContext
-import ai.tock.nlp.model.IntentContext
-import ai.tock.nlp.model.TokenizerContext
+import ai.tock.nlp.model.*
 import ai.tock.shared.ThreadSafe
 
 /**
@@ -89,6 +84,7 @@ internal object NlpEngineRepository {
             }
         }
     }
+
 
     fun <T : ClassifierContextKey> getModelBuilder(context: ClassifierContext<T>): NlpEngineModelBuilder {
         return getProvider(context.engineType).modelBuilder

--- a/nlp/model/service/src/main/kotlin/engine/NlpHealthcheckResult.kt
+++ b/nlp/model/service/src/main/kotlin/engine/NlpHealthcheckResult.kt
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-package ai.tock.nlp.model.service.engine
-
-import ai.tock.shared.ThreadSafe
-
-/**
- *
- */
-@ThreadSafe
-abstract class NlpEntityClassifier(val model: EntityModelHolder) : EntityClassifier {
+data class NlpHealthcheckResult(val entityClassifier: Boolean, val intentClassifier: Boolean) {
+    companion object {
+        val ALL_OK = NlpHealthcheckResult(entityClassifier = true, intentClassifier = true)
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,11 @@
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
+                <artifactId>sagemaker</artifactId>
+                <version>${aws-sagemaker}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
                 <artifactId>sts</artifactId>
                 <version>${aws-sagemaker}</version>
             </dependency>


### PR DESCRIPTION
This issue addresses our need for a healthcheck functionality for Sagemaker intent and entity classifiers to ensure proper monitoring of the NLP services. The implementation will:

- Group clients by name and verify their health status
- Include the healtcheck result to the existing detailed healthcheck