### PR TITLE
1897 fix/typo frontend

### DIFF
--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -27,7 +27,7 @@ import {
   PromptDefinitionFormatter
 } from '../../../shared/model/ai-settings';
 
-export const QuestionCondensingDefaultPrompt: string = `Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be nderstood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is.`;
+export const QuestionCondensingDefaultPrompt: string = `Given a chat history and the latest user question which might reference context in the chat history, formulate a standalone question which can be understood without the chat history. Do NOT answer the question, just reformulate it if needed and otherwise return it as is.`;
 
 export const QuestionAnsweringDefaultPrompt: string = `# TOCK (The Open Conversation Kit) chatbot
 

--- a/bot/admin/web/src/environments/environment.ts
+++ b/bot/admin/web/src/environments/environment.ts
@@ -25,5 +25,5 @@ export const environment = {
   ssologin: false,
   default_user: 'techadmin@app.com',
   default_password: 'password',
-  serverUrl: 'http://localhost:7999/rest'
+  serverUrl: 'http://localhost:80/rest'
 };

--- a/bot/admin/web/src/environments/environment.ts
+++ b/bot/admin/web/src/environments/environment.ts
@@ -25,5 +25,5 @@ export const environment = {
   ssologin: false,
   default_user: 'techadmin@app.com',
   default_password: 'password',
-  serverUrl: 'http://localhost:80/rest'
+  serverUrl: 'http://localhost:7999/rest'
 };


### PR DESCRIPTION
This pull request includes a minor correction to a typo in the `QuestionCondensingDefaultPrompt` string definition in the `engines-configurations.ts` file. The word "nderstood" was corrected to "understood" to ensure clarity in the prompt text.