### PR TITLE
[DERCBOT-1503] Google Chat Connector : Updates, Footnotes, Output Formatting

### DIFF
--- a/bot/connector-google-chat/README.md
+++ b/bot/connector-google-chat/README.md
@@ -1,25 +1,47 @@
 ## Prerequisites
 
-* You need to create and publish a Google  Chat bot :  https://developers.google.com/hangouts/chat/how-tos/bots-publish
+1. **Create and publish a Google Chat bot**  
+   Follow the instructions here:  
+   https://developers.google.com/hangouts/chat/how-tos/bots-publish
 
-* You need to retrieve from Google API these elements:
+2. **IAM Google Cloud Permissions**  
+    - `chat.bots.get`
+    - `chat.bots.update`
 
-    * **Bot project number** : The Google identifier of your bot.  
-    * **Json Credential** : The json credential page generated when you added the service accunt with Project Owner role.
-    
-* Then go to the Configuration -> Bot Configurations menu in the Tock Bot administration interface,
- and create a new Hangout Chat configuration with these parameters : inquire either serviceCredentialPath if you added json credential to your integrated bot resources or serviceCredentialContent with json credential file content. 
- 
-## Bot API 
- 
-* TO BE IMPLEMENTED AND TESTED
- 
-## Integrated mode
+3. **Retrieve the following elements from the Google Cloud Console**:
+    - **Bot project number**  
+      Example: `37564789203`
+    - **JSON credentials**  
+      Downloaded when you create a service account with the `Project Owner` role.
 
-In order to connect your bot with a google chat bot application, you need to configure your bot url in Google API. It should match your local bot url with path specified in configuration 
+4. **Configurate Google Chat API for your project**:
+    - `HTTP endpoint URL`: Your ngrok URL + TOCK Relative REST path. (Example : https://area-simple-teal.ngrok-free.app/io/app/assistant/google_chat)
+    - `Authentification Audience`: Select 'Project Number'.
 
-* On your local machine, you can configure a secure ssl tunnel (for example [ngrok](https://ngrok.com/)) is required to test the bot in dev mode:
 
-```sh 
-    ngrok http 8080
-``` 
+## Tock Configuration
+
+1. Go to **Settings > Configuration > New Configuration** in the Tock admin interface.
+
+2. Create a new Google Chat configuration specifying the following options:
+    - `Connector type`: google_chat.
+    - `Application base URL`: Your ngrok URL (Example : https://area-simple-teal.ngrok-free.app).
+    - `Bot project number`: Bot project number (Example : 37564789203).
+    - `Service account credential json content`: raw JSON content pasted from the credential file.
+
+## Bot API
+
+To be implemented and tested.
+
+## Integrated Mode (Local Development)
+
+To connect your bot to a Google Chat bot application in local development:
+
+1. Set your bot's URL in the Google Cloud Console.  
+   This URL must match the path configured in the Tock configuration.
+
+2. Use a secure tunnel to expose your local bot endpoint.  
+   Example using [ngrok](https://ngrok.com/):
+
+   ```sh
+   ngrok http 8080

--- a/bot/connector-google-chat/README.md
+++ b/bot/connector-google-chat/README.md
@@ -18,7 +18,8 @@
     - `HTTP endpoint URL`: Your ngrok URL + TOCK Relative REST path. (Example : https://area-simple-teal.ngrok-free.app/io/app/assistant/google_chat)
     - `Authentification Audience`: Select 'Project Number'.
 
-
+⚠️ For now, dialogs will reset every 24 hours as stated in the variable dialogMaxValidityInSeconds of `UserTimelineMongoDAO.kt`
+   
 ## Tock Configuration
 
 1. Go to **Settings > Configuration > New Configuration** in the Tock admin interface.
@@ -28,6 +29,7 @@
     - `Application base URL`: Your ngrok URL (Example : https://area-simple-teal.ngrok-free.app).
     - `Bot project number`: Bot project number (Example : 37564789203).
     - `Service account credential json content`: raw JSON content pasted from the credential file.
+    - `Use condensed footnotes`: If activated, sources will be shown as [1] [2] [3]... True = 1, False = 0.
 
 ## Bot API
 

--- a/bot/connector-google-chat/pom.xml
+++ b/bot/connector-google-chat/pom.xml
@@ -104,6 +104,10 @@
             <version>${vertx}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bot/connector-google-chat/pom.xml
+++ b/bot/connector-google-chat/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-chat</artifactId>
-            <version>v1-rev132-1.25.0</version>
+            <version>v1-rev20250706-2.0.0</version>
         </dependency>
 
         <dependency>

--- a/bot/connector-google-chat/src/main/kotlin/FootnoteFormatter.kt
+++ b/bot/connector-google-chat/src/main/kotlin/FootnoteFormatter.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.connector.googlechat
+
+import ai.tock.bot.engine.action.Footnote
+
+
+/**
+ * Utility object that formats footnotes for Google Chat messages.
+ *
+ * Supports two formats:
+ * - Detailed: shows the full list of sources below the message.
+ * - Condensed: shows compact numbered links at the end of the message.
+ */
+object FootnoteFormatter {
+
+    fun format(text: CharSequence, footnotes: List<Footnote>, condensed: Boolean = false): String {
+        if (footnotes.isEmpty()) return text.toString()
+        return if (condensed) formatCondensed(text, footnotes) else formatDetailed(text, footnotes)
+    }
+
+    private fun formatDetailed(text: CharSequence, footnotes: List<Footnote>): String {
+        val unique = footnotes.distinctBy { (it.url ?: "") to it.title.toString().trim() }
+        val header = if (unique.size > 1) "Sources" else "Source"
+
+        val formatted = unique.joinToString("\n") { fn ->
+            val title = fn.title.toString().trim()
+            val url = fn.url?.trim()
+
+            when {
+                !url.isNullOrBlank() && title.isNotBlank() -> "<$url|$title>"
+                !url.isNullOrBlank() -> "<$url>"
+                else -> title
+            }
+        }
+
+        return "$text\n\n*$header :*\n$formatted"
+    }
+
+    private fun formatCondensed(text: CharSequence, footnotes: List<Footnote>): String {
+        val unique = footnotes.distinctBy { (it.url ?: "") to it.title.toString().trim() }
+        val links = unique.mapIndexed { idx, fn ->
+            val num = idx + 1
+            fn.url?.let { "[[$num]]($it)" } ?: "[$num]"
+        }.joinToString(" ")
+
+        val header = if (unique.size > 1) "Sources" else "Source"
+        return "$text\n\n*$header:* $links"
+    }
+}

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
@@ -44,7 +44,8 @@ class GoogleChatConnector(
     private val connectorId: String,
     private val path: String,
     private val chatService: HangoutsChat,
-    private val authorisationHandler: GoogleChatAuthorisationHandler
+    private val authorisationHandler: GoogleChatAuthorisationHandler,
+    private val useCondensedFootnotes: Boolean
 ) : ConnectorBase(GoogleChatConnectorProvider.connectorType) {
 
     private val logger = KotlinLogging.logger {}
@@ -86,7 +87,7 @@ class GoogleChatConnector(
     override fun send(event: Event, callback: ConnectorCallback, delayInMs: Long) {
         logger.debug { "event: $event" }
         if (event is Action) {
-            val message = GoogleChatMessageConverter.toMessageOut(event)
+            val message = GoogleChatMessageConverter.toMessageOut(event, useCondensedFootnotes)
             if (message != null) {
                 callback as GoogleChatConnectorCallback
                 executor.executeBlocking(Duration.ofMillis(delayInMs)) {

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
@@ -93,7 +93,9 @@ class GoogleChatConnector(
                     chatService.spaces().messages().create(
                         callback.spaceName,
                         message.toGoogleMessage().setThread(Thread().setName(callback.threadName))
-                    ).execute()
+                    )
+                        .setMessageReplyOption("REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD")
+                        .execute()
                 }
             }
         }

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
@@ -40,6 +40,7 @@ private const val CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot"
 private const val SERVICE_CREDENTIAL_PATH_PARAMETER = "serviceCredentialPath"
 private const val SERVICE_CREDENTIAL_CONTENT_PARAMETER = "serviceCredentialContent"
 private const val BOT_PROJECT_NUMBER_PARAMETER = "botProjectNumber"
+private const val CONDENSED_FOOTNOTES_PARAMETER = "useCondensedFootnotes"
 
 internal object GoogleChatConnectorProvider : ConnectorProvider {
 
@@ -58,6 +59,9 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
             val requestInitializer: HttpRequestInitializer =
                 HttpCredentialsAdapter(loadCredentials(credentialInputStream))
 
+            val useCondensedFootnotes =
+                connectorConfiguration.parameters[CONDENSED_FOOTNOTES_PARAMETER] == "1"
+
             val chatService = HangoutsChat.Builder(
                 GoogleNetHttpTransport.newTrustedTransport(),
                 JacksonFactory.getDefaultInstance(),
@@ -75,7 +79,8 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 connectorId,
                 path,
                 chatService,
-                authorisationHandler
+                authorisationHandler,
+                useCondensedFootnotes
             )
         }
     }
@@ -102,6 +107,11 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 ConnectorTypeConfigurationField(
                     "Service account credential json content",
                     SERVICE_CREDENTIAL_CONTENT_PARAMETER,
+                    false
+                ),
+                ConnectorTypeConfigurationField(
+                    "Use condensed footnotes (true = 1, false = 0)",
+                    CONDENSED_FOOTNOTES_PARAMETER,
                     false
                 )
             ),

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatMarkdown.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatMarkdown.kt
@@ -1,0 +1,147 @@
+package ai.tock.bot.connector.googlechat
+
+import org.commonmark.node.*
+import org.commonmark.parser.Parser
+
+/**
+ * Converts standard Markdown to Google Chat format.
+ *
+ * Supports:
+ * - Headings (converted to bold text)
+ * - Formatted text (bold, italic, inline code)
+ * - Lists (all converted to simple bullet points)
+ * - Links (simple text extraction)
+ * - Code blocks
+ * - Paragraphs and line breaks
+ */
+object GoogleChatMarkdown {
+
+    private val parser: Parser = Parser.builder().build()
+
+    fun toGoogleChat(markdown: String): String {
+        if (markdown.isBlank()) return ""
+
+        val document = parser.parse(markdown)
+        val converter = GoogleChatConverter()
+        document.accept(converter)
+
+        return converter.result()
+    }
+
+    /**
+     * Visitor that converts CommonMark AST to Google Chat format.
+     */
+    private class GoogleChatConverter : AbstractVisitor() {
+        private val output = StringBuilder()
+        private var isInListItem = false
+
+        fun result(): String = output.toString().trimEnd()
+
+        override fun visit(heading: Heading) {
+            output.append('*')
+            visitChildren(heading)
+            output.append('*')
+
+            // H1 has more spacing than other heading levels
+            if (heading.level == 1) {
+                output.append("\n\n")
+            } else {
+                output.append('\n')
+            }
+        }
+
+        override fun visit(paragraph: Paragraph) {
+            visitChildren(paragraph)
+
+            // In a list, only add a single line break
+            if (isInListItem) {
+                output.append('\n')
+            } else {
+                output.append("\n\n")
+            }
+        }
+
+        override fun visit(bulletList: BulletList) {
+            visitChildren(bulletList)
+            output.append('\n')
+        }
+
+        override fun visit(orderedList: OrderedList) {
+            visitChildren(orderedList)
+            output.append('\n')
+        }
+
+        override fun visit(listItem: ListItem) {
+            output.append("* ")
+
+            val wasInListItem = isInListItem
+            isInListItem = true
+            visitChildren(listItem)
+            isInListItem = wasInListItem
+        }
+
+        override fun visit(fencedCodeBlock: FencedCodeBlock) {
+            output.append("```")
+            output.append(fencedCodeBlock.literal.trimEnd())
+            output.append("```\n\n")
+        }
+
+        override fun visit(indentedCodeBlock: IndentedCodeBlock) {
+            output.append("```")
+            output.append(indentedCodeBlock.literal.trimEnd())
+            output.append("```\n\n")
+        }
+
+        override fun visit(strongEmphasis: StrongEmphasis) {
+            output.append('*')
+            visitChildren(strongEmphasis)
+            output.append('*')
+        }
+
+        override fun visit(emphasis: Emphasis) {
+            output.append('_')
+            visitChildren(emphasis)
+            output.append('_')
+        }
+
+        override fun visit(code: Code) {
+            output.append('`')
+            output.append(code.literal)
+            output.append('`')
+        }
+
+        override fun visit(link: Link) {
+            val linkText = extractLinkText(link)
+
+            output.append('<')
+                .append(link.destination)
+                .append('|')
+                .append(linkText.ifBlank { link.destination })
+                .append('>')
+        }
+
+        override fun visit(text: Text) {
+            output.append(text.literal)
+        }
+
+        override fun visit(softLineBreak: SoftLineBreak) {
+            output.append('\n')
+        }
+
+        override fun visit(hardLineBreak: HardLineBreak) {
+            output.append('\n')
+        }
+
+        private fun extractLinkText(link: Link): String {
+            val textBuilder = StringBuilder()
+
+            link.accept(object : AbstractVisitor() {
+                override fun visit(text: Text) {
+                    textBuilder.append(text.literal)
+                }
+            })
+
+            return textBuilder.toString()
+        }
+    }
+}


### PR DESCRIPTION
**Ticket**: [DERCBOT-1503](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1503)

---

### **Changes**

* Bot now answers in a thread when mentioned (`REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD`)
* Connector now supports footnotes in bot responses using the new `SendSentenceWithFootnotes` action type
* Added support for two footnote display modes: detailed (default) and condensed (exemple : [1] [2] [3])
* Added new `useCondensedFootnotes` connector config parameter (`"1"` to enable condensed mode)
* Introduced Markdown-to-Google-Chat parsing