### PR TITLE
resolves #1907 bot_engine: implement coroutine-based stories

### DIFF
--- a/bot/engine/src/main/kotlin/definition/AsyncStoryHandler.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncStoryHandler.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import ai.tock.bot.engine.BotBus
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+
+/**
+ * Receive a sentence or action, and send the answer asynchronously.
+ *
+ * Story handlers should usually not directly extend this class, but instead extend [AsyncStoryHandlerBase].
+ */
+@ExperimentalTockCoroutines
+interface AsyncStoryHandler : StoryHandler {
+
+    /**
+     * Receive a message from the bus.
+     *
+     * @param bus the bus used to get the message and send the answer
+     */
+    @Deprecated("Use coroutines to call this interface")
+    override fun handle(bus: BotBus)
+
+    suspend fun handleAsync(bus: BotBus)
+}

--- a/bot/engine/src/main/kotlin/definition/AsyncStoryHandlerBase.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncStoryHandlerBase.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import ai.tock.bot.definition.BotDefinition.Companion.defaultBreath
+import ai.tock.bot.engine.BotBus
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+import ai.tock.shared.defaultNamespace
+
+@ExperimentalTockCoroutines
+abstract class AsyncStoryHandlerBase<out T : AsyncStoryHandlerDefinition>(
+    mainIntentName: String? = null,
+    i18nNamespace: String = defaultNamespace,
+    breath: Long = defaultBreath,
+) : StoryHandlerBase<T>(mainIntentName, i18nNamespace, breath), AsyncStoryHandler {
+    final override suspend fun handleAsync(bus: BotBus) {
+        handle0(bus) {
+            it.handleAsync()
+        }
+    }
+}

--- a/bot/engine/src/main/kotlin/definition/AsyncStoryHandlerDefinition.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncStoryHandlerDefinition.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+import kotlinx.coroutines.runBlocking
+
+@ExperimentalTockCoroutines
+interface AsyncStoryHandlerDefinition : StoryHandlerDefinition {
+    @Deprecated("Use coroutines to call this interface")
+    override fun handle() {
+        runBlocking {
+            handleAsync()
+        }
+    }
+
+    suspend fun handleAsync()
+}

--- a/bot/engine/src/main/kotlin/definition/StoryHandlerBase.kt
+++ b/bot/engine/src/main/kotlin/definition/StoryHandlerBase.kt
@@ -108,6 +108,10 @@ abstract class StoryHandlerBase<out T : StoryHandlerDefinition>(
     }
 
     final override fun handle(bus: BotBus) {
+        handle0(bus) { it.handle() }
+    }
+
+    internal inline fun handle0(bus: BotBus, op: (T) -> Unit) {
         val storyDefinition = findStoryDefinition(bus)
         // if not supported user interface, use unknown
         if (storyDefinition?.unsupportedUserInterfaces?.contains(bus.userInterfaceType) == true) {
@@ -143,7 +147,7 @@ abstract class StoryHandlerBase<out T : StoryHandlerDefinition>(
                     }
                 }
                 if (!isEndCalled(bus)) {
-                    handler.handle()
+                    op(handler)
 
                     if (!bus.connectorData.skipAnswer &&
                         !bus.hasCurrentSwitchStoryProcess &&

--- a/bot/engine/src/main/kotlin/engine/Bot.kt
+++ b/bot/engine/src/main/kotlin/engine/Bot.kt
@@ -33,11 +33,12 @@ import ai.tock.bot.engine.dialog.Story
 import ai.tock.bot.engine.feature.DefaultFeatureType
 import ai.tock.bot.engine.nlp.NlpController
 import ai.tock.bot.engine.user.UserTimeline
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
 import ai.tock.shared.injector
 import com.github.salomonbrys.kodein.instance
 import java.util.Locale
+import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
-import kotlin.time.Duration
 
 /**
  *
@@ -81,6 +82,14 @@ internal class Bot(botDefinitionBase: BotDefinition, val configuration: BotAppli
      * Handle the user action.
      */
     fun handle(action: Action, userTimeline: UserTimeline, connector: ConnectorController, connectorData: ConnectorData) {
+        @OptIn(ExperimentalTockCoroutines::class)
+        runBlocking {
+            handleAction(action, userTimeline, connector, connectorData)
+        }
+    }
+
+    @ExperimentalTockCoroutines
+    suspend fun handleAction(action: Action, userTimeline: UserTimeline, connector: ConnectorController, connectorData: ConnectorData) {
         connector as TockConnectorController
 
         loadProfileIfNotSet(connectorData, action, userTimeline, connector)
@@ -108,7 +117,7 @@ internal class Bot(botDefinitionBase: BotDefinition, val configuration: BotAppli
 
         if (!userTimeline.userState.botDisabled) {
             dialog.state.currentIntent?.let { intent ->
-                connector.sendIntent(intent, action.applicationId, connectorData)
+                connector.sendIntent(intent, action.connectorId, connectorData)
             }
             connector.startTypingInAnswerTo(action, connectorData)
             val story = getStory(userTimeline, dialog, action)
@@ -122,7 +131,7 @@ internal class Bot(botDefinitionBase: BotDefinition, val configuration: BotAppli
 
             try {
                 currentBus.set(bus)
-                story.handle(bus)
+                story.handleAsync(bus)
                 if (shouldRespondBeforeDisabling) {
                     userTimeline.userState.botDisabled = true
                 }

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -27,8 +27,8 @@ import ai.tock.bot.engine.action.SendAttachment
 import ai.tock.bot.engine.action.SendAttachment.AttachmentType.audio
 import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.event.Event
-import ai.tock.bot.engine.event.TypingOnEvent
 import ai.tock.bot.engine.event.MetadataEvent
+import ai.tock.bot.engine.event.TypingOnEvent
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.UserLock
 import ai.tock.bot.engine.user.UserPreferences
@@ -36,6 +36,8 @@ import ai.tock.bot.engine.user.UserTimeline
 import ai.tock.bot.engine.user.UserTimelineDAO
 import ai.tock.shared.Executor
 import ai.tock.shared.booleanProperty
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+import ai.tock.shared.coroutines.launchCoroutine
 import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.intProperty
@@ -44,10 +46,10 @@ import ai.tock.shared.provide
 import ai.tock.stt.STT
 import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
-import mu.KotlinLogging
 import java.net.URL
-import java.time.Duration
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
 
 private val synchronousMode = booleanProperty("tock_timeline_persistence_synchronous_mode", true)
 private val asynchronousMode = booleanProperty("tock_timeline_persistence_asynchronous_mode", false)
@@ -101,6 +103,7 @@ internal class TockConnectorController constructor(
 
     fun getBaseUrl(): String = configuration.getBaseUrl()
 
+    @OptIn(ExperimentalTockCoroutines::class)
     override fun handle(event: Event, data: ConnectorData) {
         if (event.state.sourceConnectorType == null) {
             event.state.sourceConnectorType = connector.connectorType
@@ -113,7 +116,9 @@ internal class TockConnectorController constructor(
         try {
             if (!botDefinition.eventListener.listenEvent(this, data, event)) {
                 when (event) {
-                    is Action -> handleAction(event, 0, data)
+                    is Action -> executor.launchCoroutine {
+                        handleAction(event, 0, data)
+                    }
                     else -> callback.eventSkipped(event)
                 }
             } else {
@@ -143,7 +148,8 @@ internal class TockConnectorController constructor(
         return action
     }
 
-    private fun handleAction(action: Action, nbAttempts: Int, data: ConnectorData) {
+    @ExperimentalTockCoroutines
+    private suspend fun handleAction(action: Action, nbAttempts: Int, data: ConnectorData) {
         val callback = data.callback
         try {
             val playerId = action.playerId
@@ -165,7 +171,7 @@ internal class TockConnectorController constructor(
 
                     val transformedAction = tryToParseVoiceAudio(action, userTimeline)
 
-                    bot.handle(transformedAction, userTimeline, this, data)
+                    bot.handleAction(transformedAction, userTimeline, this, data)
 
                     if (synchronousMode && data.saveTimeline) {
                         userTimelineDAO.save(userTimeline, bot.botDefinition)
@@ -179,9 +185,8 @@ internal class TockConnectorController constructor(
                 }
             } else if (nbAttempts < maxLockedAttempts) {
                 logger.debug { "$playerId locked - wait" }
-                executor.executeBlocking(Duration.ofMillis(lockedAttemptsWaitInMs)) {
-                    handleAction(action, nbAttempts + 1, data)
-                }
+                delay(lockedAttemptsWaitInMs)
+                handleAction(action, nbAttempts + 1, data)
             } else {
                 logger.debug { "$playerId locked for $maxLockedAttempts times - skip $action" }
                 callback.eventSkipped(action)

--- a/shared/src/main/kotlin/coroutines/ExperimentalTockCoroutines.kt
+++ b/shared/src/main/kotlin/coroutines/ExperimentalTockCoroutines.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.shared.coroutines
+
+import kotlin.RequiresOptIn.Level.WARNING
+
+/**
+ * The experimental TOCK Coroutine API marker.
+ *
+ * Any usage of a declaration annotated with `@ExperimentalTockCoroutines` must be accepted either by
+ * annotating that usage with the [OptIn] annotation, e.g. `@OptIn(ExperimentalTockCoroutines::class)`,
+ * or by using the compiler argument `-opt-in=ai.tock.bot.engine.ExperimentalTockCoroutines`.
+ */
+@RequiresOptIn(level = WARNING)
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalTockCoroutines

--- a/shared/src/main/kotlin/coroutines/TockCoroutines.kt
+++ b/shared/src/main/kotlin/coroutines/TockCoroutines.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.shared.coroutines
+
+import ai.tock.shared.Executor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+
+@ExperimentalTockCoroutines
+fun Executor.launchCoroutine(block: suspend CoroutineScope.() -> Unit): Job {
+    return CoroutineScope(asCoroutineDispatcher()).launch(block = block)
+}


### PR DESCRIPTION
resolves #1907 by adding new subtypes of story handlers with `suspend` methods. These methods are called by the engine based on an instance check.