### PR TITLE
[DERCBOT-1607] Fixed label for documentsRequired switch

### DIFF
--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.html
@@ -416,14 +416,13 @@
                 [controls]="documentsRequired"
                 [required]="false"
                 [boldLabel]="false"
-                information="Allow the LLM to respond even if no documents were retrieved. Allows to make small talk and answer more general questions."
+                information="Prohibits LLM from responding if no document could be retrieved. Prevents the bot from engaging in informal conversation and responding to more general questions."
               >
                 <nb-toggle
                   formControlName="documentsRequired"
                   class="nb-toggle-small mt-1"
                 >
-                  <span *ngIf="documentsRequired.value">Don't allow undocumented answers</span>
-                  <span *ngIf="!documentsRequired.value">Allow undocumented answers</span>
+                  Don't allow undocumented answers
                 </nb-toggle>
               </tock-form-control>
             </div>

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
@@ -393,7 +393,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
 
   setFormDefaultValues(): void {
     this.form.patchValue({
-      documentsRequired: true,
+      documentsRequired: false,
       debugEnabled: false,
       maxMessagesFromHistory: 5,
       maxDocumentsRetrieved: 4


### PR DESCRIPTION
In the Rag settings, the Required Documents switch have the fixed label “Don't allow undocumented answers” and is set to false by default. The tooltip text has been adjusted accordingly.