### PR TITLE
[DERCBOT-1633] Prevent mongoDb error "Regular expression is invalid: …

### DIFF
--- a/nlp/admin/server/src/main/kotlin/model/SearchQuery.kt
+++ b/nlp/admin/server/src/main/kotlin/model/SearchQuery.kt
@@ -21,6 +21,7 @@ import ai.tock.nlp.front.shared.config.ClassifiedSentenceStatus
 import ai.tock.nlp.front.shared.config.IntentDefinition
 import ai.tock.nlp.front.shared.config.SentencesQuery
 import ai.tock.shared.allowDiacriticsInRegexp
+import ai.tock.shared.escapeForRegex
 import org.litote.kmongo.Id
 import java.time.ZonedDateTime
 
@@ -60,7 +61,9 @@ data class SearchQuery(
             language,
             start,
             size,
-            search?.let { allowDiacriticsInRegexp(it.trim()) },
+            search?.trim()
+                ?.let { escapeForRegex(it) }
+                ?.let { allowDiacriticsInRegexp(it) },
             intentId,
             status,
             entityType = entityType,

--- a/shared/src/main/kotlin/Strings.kt
+++ b/shared/src/main/kotlin/Strings.kt
@@ -96,3 +96,16 @@ fun allowDiacriticsInRegexp(s: String) : String = s.replace("e", "[eéèêë]", 
         .replace("n", "[nñ]", ignoreCase = true)
         .replace(" ", "['-_ ]")
         .replace("c", "[cç]", ignoreCase = true)
+
+/**
+ * Escapes all special characters in a string so that it can be safely used
+ * inside a regular expression as a literal match.
+ *
+ * This function replaces regex metacharacters (such as `. ^ $ | ? * + ( ) [ ] { } \`)
+ * with their escaped form (e.g., `?` → `\?`, `.` → `\.`).
+ *
+ * @param s the input string that may contain regex metacharacters
+ * @return a new string where all regex metacharacters are escaped
+ */
+fun escapeForRegex(s: String): String =
+    s.replace(Regex("([\\\\.^$|?*+()\\[\\]{}])")) { "\\${it.value}" }


### PR DESCRIPTION
…quantifier does not follow a repeatable item"

When I search for sentences (in inbox sentences):
- Then send me the corresponding certificate? Thank you very much for your help.
- *CROUS

I receive:
{
    "errors": [
        {
            "message": "Error searching sentences: Command failed with error 51091 (Location51091): 'Regular expression is invalid: quantifier does not follow a repeatable item' on server. The full response is {\"ok\": 0.0, \"errmsg\": \"Regular expression is invalid: quantifier does not follow a repeatable item\", \"code\": 51091, \"codeName\": \"Location51091\", \"$clusterTime\": {\"clusterTime\": {\"$timestamp\": {\"t\": 1758533783, \"i\": 1}}, \"signature\": {\"hash\": {\"$binary\": {\"base64\": \"fo9ErA3celmKrPPMKkcxilzbl44=\", \"subType\": \"00\"}}, \"keyId\": 7515631085061931010}}, \"operationTime\": {\"$timestamp\":{\"t\": 1758533783, \"i\": 1}}}"
        }
    ]
}

The problem comes from the character ‘?’ which is interpreted by MongoDB as a RegExp metacharacter.
Solution: I escaped these special characters (?, ., *, +, (, ), [{}}}, \{{{}], {}{, }) to avoid this issue.