### PR TITLE
Fix CORS problem on WebConnector (Options method not allowed)

### DIFF
--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -148,9 +148,11 @@ class WebConnector internal constructor(
                 // browsers do not send or save cookies unless credentials are allowed
                 .allowCredentials(webSecurityHandler is WebSecurityCookiesHandler)
 
+            // Apply CORS Handler for all paths and all methods (OPTIONS handled automatically)
+            router.route("$path*").handler(corsHandler)
+
             if (sseEnabled) {
                 router.route("$path/sse")
-                    .handler(corsHandler)
                     .handler(webSecurityHandler)
                     .handler { context ->
                         try {
@@ -189,7 +191,6 @@ class WebConnector internal constructor(
 
             // Main connector endpoint
             router.post(path)
-                .handler(corsHandler)
                 .handler(webSecurityHandler)
                 .handler { context ->
                     // Override the user on the request body


### PR DESCRIPTION
- Apply CorsHandler globally on $path* so that all sub-routes and HTTP methods (including automatic preflight OPTIONS) are covered.
- Remove redundant CorsHandler from child routes (/sse, /sse/direct) since the global handler already applies.