### PR TITLE
[DERCBOT-1791] Expose full footnote metadata and title fallback flag

### DIFF
--- a/bot/connector-mattermost/src/main/kotlin/MattermostMessageConverter.kt
+++ b/bot/connector-mattermost/src/main/kotlin/MattermostMessageConverter.kt
@@ -64,6 +64,7 @@ internal object MattermostMessageConverter {
                                 footnote.url,
                                 footnote.content,
                                 footnote.score,
+                                footnote.metadata,
                             )
                         },
                 )

--- a/bot/connector-mattermost/src/main/kotlin/model/Footnote.kt
+++ b/bot/connector-mattermost/src/main/kotlin/model/Footnote.kt
@@ -42,10 +42,6 @@ data class Footnote(
      */
     val score: Float?,
     /**
-     * Whether the title is a fallback value
-     */
-    val isTitleFallback: Boolean? = null,
-    /**
      * Document metadata associated to the footnote
      */
     val metadata: Map<String, Any?>? = null,

--- a/bot/connector-rest-client/src/main/kotlin/model/ClientFootnote.kt
+++ b/bot/connector-rest-client/src/main/kotlin/model/ClientFootnote.kt
@@ -25,6 +25,5 @@ data class ClientFootnote(
     val url: String?,
     val content: String?,
     val score: Float?,
-    val isTitleFallback: Boolean? = null,
     val metadata: Map<String, Any?>? = null,
 )

--- a/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/Footnote.kt
+++ b/bot/connector-web-model/src/main/kotlin/ai/tock/bot/connector/web/send/Footnote.kt
@@ -42,10 +42,6 @@ data class Footnote(
      */
     val score: Float?,
     /**
-     * Whether the title is a fallback value
-     */
-    val isTitleFallback: Boolean? = null,
-    /**
      * Document metadata associated to the footnote
      */
     val metadata: Map<String, Any?>? = null,

--- a/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
+++ b/bot/connector-web/src/main/kotlin/WebMessageProcessor.kt
@@ -45,7 +45,6 @@ internal class WebMessageProcessor(private val processMarkdown: Boolean) {
                                 footnote.url,
                                 footnote.content?.let { postProcess(it) },
                                 footnote.score,
-                                footnote.isTitleFallback,
                                 footnote.metadata,
                             )
                         },

--- a/bot/engine/src/main/kotlin/engine/action/Footnote.kt
+++ b/bot/engine/src/main/kotlin/engine/action/Footnote.kt
@@ -42,10 +42,6 @@ data class Footnote(
      */
     val score: Float?,
     /**
-     * Whether the title is a fallback value
-     */
-    val isTitleFallback: Boolean? = null,
-    /**
      * Document metadata associated to the footnote
      */
     val metadata: Map<String, Any?>? = null,

--- a/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
+++ b/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
@@ -92,7 +92,6 @@ object RAGAnswerHandler : AbstractProactiveAnswerHandler {
                                     it.url,
                                     if (action.metadata.sourceWithContent) it.content else null,
                                     it.score,
-                                    it.isTitleFallback,
                                     it.metadata,
                                 )
                             }.toMutableList(),

--- a/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/responses/Models.kt
+++ b/gen-ai/orchestrator-client/src/main/kotlin/ai/tock/genai/orchestratorclient/responses/Models.kt
@@ -27,7 +27,6 @@ data class Footnote(
     val url: String? = null,
     val content: String? = null,
     val score: Float? = null,
-    val isTitleFallback: Boolean? = null,
     val metadata: Map<String, Any?>? = null,
 )
 

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/models/rag/rag_models.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/models/rag/rag_models.py
@@ -53,9 +53,6 @@ class Footnote(Source):
     """A footnote model, used to associate document sources with the RAG answer"""
 
     identifier: str = Field(description='Footnote identifier', examples=['1'])
-    is_title_fallback: Optional[bool] = Field(
-        description='Whether the title is a fallback value.', default=None
-    )
     metadata: Optional[dict[str, Any]] = Field(
         description='Document metadata associated to the footnote.', default=None
     )

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -201,7 +201,6 @@ async def execute_rag_chain(
                         url=doc.metadata['source'],
                         content=get_source_content(doc),
                         score=doc.metadata.get('retriever_score', None),
-                        is_title_fallback=doc.metadata.get('is_title_fallback', None),
                         metadata=doc.metadata.copy(),
                     ),
                     response['documents'],


### PR DESCRIPTION
Ticket : [DERCBOT-1791](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1791)

### Goal 
Let the front-end reliably hide footnotes with fallback titles without relying on hardcoded strings, while still exposing full document metadata for future filtering needs.

### Details
- Added isTitleFallback to RAG footnotes and propagated it from the orchestrator to the bot engine and web connector (camelCase on the client side via snake_case mapping).
- Exposed full metadata on footnotes so the front-end can filter using any ingested field (including is_title_fallback).
- Aligned the server-side mapping to read is_title_fallback from document metadata and include it in the footnote payload.

Note :
- We keep the existing response structure and only add optional fields (backward compatible).
- metadata keeps original keys from ingestion (often snake_case), while isTitleFallback is a typed convenience field.