### PR TITLE
[DERCBOT-1839] Fix broken Playground

### DIFF
--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/completion/completion_service.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/completion/completion_service.py
@@ -97,7 +97,7 @@ async def generate(
         answer=parsedLlmAnswer,
         observability_info=get_observability_info(
             observability_handler,
-            ObservabilityTrace.PLAYGROUND.value if observability_handler is not None else None,
+            ObservabilityTrace.PLAYGROUND.value,
         ),
     )
 

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/completion/completion_service.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/completion/completion_service.py
@@ -93,7 +93,13 @@ async def generate(
         time.time() - start_time,
         )
 
-    return PlaygroundResponse(answer=parsedLlmAnswer, observability_info=get_observability_info(observability_handler))
+    return PlaygroundResponse(
+        answer=parsedLlmAnswer,
+        observability_info=get_observability_info(
+            observability_handler,
+            ObservabilityTrace.PLAYGROUND.value if observability_handler is not None else None,
+        ),
+    )
 
 
 @openai_exception_handler(provider='OpenAI or AzureOpenAIService')

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -226,7 +226,7 @@ async def execute_rag_chain(
         },
         observability_info=get_observability_info(
             observability_handler,
-            ObservabilityTrace.RAG.value if observability_handler is not None else None,
+            ObservabilityTrace.RAG.value,
         ),
         debug=get_rag_debug_data(request, records_callback_handler, rag_duration)
         if debug


### PR DESCRIPTION
Ticket: [DERCBOT-1839](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1839)

  ### Details

  - Fixed Playground error when Langfuse is enabled.
  - The orchestrator was building the observability response without a trace name.
  - We now set the Playground trace name explicitly before returning the response.
