### PR TITLE
[DERCBOT-1843] Disable all FAQs

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -1022,6 +1022,19 @@ open class BotAdminVerticle : AdminVerticle() {
             FaqAdminService.deleteFaqDefinition(context.organization, context.path("faqId"))
         }
 
+        blockingJsonPost(
+            "/faq/disable-all/:applicationId",
+            setOf(botUser),
+            simpleLogger("Disable all FAQs"),
+        ) { context, _: ApplicationScopedQuery ->
+            val applicationDefinition = front.getApplicationById(context.pathId("applicationId"))
+            if (context.organization == applicationDefinition?.namespace) {
+                FaqAdminService.disableAllFAQs(applicationDefinition)
+            } else {
+                unauthorized()
+            }
+        }
+
         blockingJsonPost("/faq/tags", setOf(botUser)) { context, applicationId: String ->
             val applicationDefinition = front.getApplicationById(applicationId.toId())
             if (context.organization == applicationDefinition?.namespace) {

--- a/bot/admin/server/src/main/kotlin/FaqAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/FaqAdminService.kt
@@ -307,6 +307,33 @@ object FaqAdminService {
         return features
     }
 
+    private fun prepareActivationFeatures(
+        existingStory: StoryDefinitionConfiguration,
+        enabled: Boolean,
+    ): List<StoryDefinitionConfigurationFeature> {
+        val features = mutableListOf<StoryDefinitionConfigurationFeature>()
+        features.addAll(existingStory.features)
+
+        val activationFeatures =
+            features.filter { feature ->
+                feature.switchToStoryId == null && feature.endWithStoryId == null
+            }
+
+        val botApplicationConfigurationId = activationFeatures.firstOrNull()?.botApplicationConfigurationId
+        features.removeAll(activationFeatures)
+        features.add(
+            0,
+            StoryDefinitionConfigurationFeature(
+                botApplicationConfigurationId = botApplicationConfigurationId,
+                enabled = enabled,
+                switchToStoryId = null,
+                endWithStoryId = null,
+            ),
+        )
+
+        return features
+    }
+
     /**
      * Create or update the story
      * @param existingStory : the optional existing story
@@ -498,6 +525,54 @@ object FaqAdminService {
         namespace: String,
     ): List<String> {
         return faqDefinitionDAO.getTags(botId, namespace)
+    }
+
+    fun disableAllFAQs(applicationDefinition: ApplicationDefinition): Int {
+        val enabledFaqs =
+            faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(
+                applicationDefinition.name,
+                applicationDefinition.namespace,
+            ).filter { it.enabled }
+
+        if (enabledFaqs.isEmpty()) {
+            return 0
+        }
+
+        val intentsById =
+            intentDAO.getIntentByIds(enabledFaqs.map { it.intentId }.toSet())
+                ?.associateBy { it._id }
+                .orEmpty()
+
+        val updateDate = Instant.now()
+
+        enabledFaqs.forEach { faq ->
+            faqDefinitionDAO.save(
+                faq.copy(
+                    enabled = false,
+                    updateDate = updateDate,
+                ),
+            )
+
+            intentsById[faq.intentId]?.let { intent ->
+                storyDefinitionDAO.getConfiguredStoryDefinitionByNamespaceAndBotIdAndIntent(
+                    applicationDefinition.namespace,
+                    applicationDefinition.name,
+                    intent.name,
+                )?.let { story ->
+                    storyDefinitionDAO.save(
+                        story.copy(
+                            features = prepareActivationFeatures(story, false),
+                        ),
+                    )
+                }
+            }
+        }
+
+        logger.info {
+            "Disabled ${enabledFaqs.size} FAQ(s) for application '${applicationDefinition.name}' in namespace '${applicationDefinition.namespace}'"
+        }
+
+        return enabledFaqs.size
     }
 
     /**

--- a/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/FaqAdminServiceTest.kt
@@ -24,6 +24,7 @@ import ai.tock.bot.admin.model.FaqDefinitionRequest
 import ai.tock.bot.admin.model.FaqSearchRequest
 import ai.tock.bot.admin.story.StoryDefinitionConfiguration
 import ai.tock.bot.admin.story.StoryDefinitionConfigurationDAO
+import ai.tock.bot.admin.story.StoryDefinitionConfigurationFeature
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.definition.IntentWithoutNamespace
 import ai.tock.nlp.admin.AdminService
@@ -963,6 +964,98 @@ class FaqAdminServiceTest : AbstractTest() {
             assertThrows<BadRequestException> {
                 faqAdminService.deleteFaqDefinition(namespace, faqId.toString())
             }
+        }
+    }
+
+    @Nested
+    inner class DisableAllFaq {
+        @Test
+        fun `GIVEN enabled and disabled faqs WHEN disabling all THEN only enabled faqs and their stories are disabled`() {
+            val secondIntent =
+                existingIntent.copy(
+                    _id = intentId2,
+                    name = "faqtitle2",
+                    label = "FAQ TITLE 2",
+                )
+            val secondFaq = faqDefinition.copy(_id = faqId2, intentId = intentId2, i18nId = i18nId2, enabled = true)
+            val alreadyDisabledFaq = faqDefinition.copy(_id = faqId3, intentId = intentId3, i18nId = i18nId3, enabled = false)
+
+            val firstStory =
+                newFaqTestStory(
+                    storyId = "faq-story-1",
+                    type = AnswerConfigurationType.message,
+                    intentName = existingIntent.name,
+                    botName = botId,
+                ).toStoryDefinitionConfiguration().copy(
+                    features =
+                        listOf(
+                            StoryDefinitionConfigurationFeature(null, true, null, null),
+                            StoryDefinitionConfigurationFeature(null, true, null, "satisfaction-story-1"),
+                        ),
+                )
+
+            val secondStory =
+                newFaqTestStory(
+                    storyId = "faq-story-2",
+                    type = AnswerConfigurationType.message,
+                    intentName = secondIntent.name,
+                    botName = botId,
+                ).toStoryDefinitionConfiguration().copy(
+                    features =
+                        listOf(
+                            StoryDefinitionConfigurationFeature(null, true, null, null),
+                            StoryDefinitionConfigurationFeature(null, true, null, "satisfaction-story-2"),
+                        ),
+                )
+
+            every {
+                faqDefinitionDAO.getFaqDefinitionByBotIdAndNamespace(
+                    eq(applicationDefinition.name),
+                    eq(applicationDefinition.namespace),
+                )
+            } returns listOf(faqDefinition, secondFaq, alreadyDisabledFaq)
+            every { intentDAO.getIntentByIds(eq(setOf(intentId, intentId2))) } returns listOf(existingIntent, secondIntent)
+            every {
+                storyDefinitionDAO.getConfiguredStoryDefinitionByNamespaceAndBotIdAndIntent(
+                    eq(namespace),
+                    eq(botId),
+                    eq(existingIntent.name),
+                )
+            } returns firstStory
+            every {
+                storyDefinitionDAO.getConfiguredStoryDefinitionByNamespaceAndBotIdAndIntent(
+                    eq(namespace),
+                    eq(botId),
+                    eq(secondIntent.name),
+                )
+            } returns secondStory
+
+            val savedFaqs = mutableListOf<FaqDefinition>()
+            val savedStories = mutableListOf<StoryDefinitionConfiguration>()
+            every { faqDefinitionDAO.save(capture(savedFaqs)) } just Runs
+            every { storyDefinitionDAO.save(capture(savedStories)) } returns Unit
+
+            val disabledCount = FaqAdminService.disableAllFAQs(applicationDefinition)
+
+            assertEquals(2, disabledCount)
+            assertEquals(2, savedFaqs.size)
+            assertTrue(savedFaqs.all { !it.enabled })
+            assertFalse(savedFaqs.any { it._id == alreadyDisabledFaq._id })
+
+            assertEquals(2, savedStories.size)
+            assertTrue(
+                savedStories.all { story ->
+                    story.features.first { it.switchToStoryId == null && it.endWithStoryId == null }.enabled == false
+                },
+            )
+            assertEquals(
+                "satisfaction-story-1",
+                savedStories.first { it.storyId == firstStory.storyId }.features.first { it.endWithStoryId != null }.endWithStoryId,
+            )
+            assertEquals(
+                "satisfaction-story-2",
+                savedStories.first { it.storyId == secondStory.storyId }.features.first { it.endWithStoryId != null }.endWithStoryId,
+            )
         }
     }
 

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.html
@@ -46,12 +46,12 @@
     <button
       [disabled]="loading.list || loading.edit || !faqs?.length"
       nbButton
-      status="danger"
-      outline
-      data-testid="disable-all-faqs"
+      ghost
+      shape="round"
+      nbTooltip="Disable all currently active FAQs"
       (click)="disableAllFaqs()"
     >
-      DISABLE ALL FAQS
+      <nb-icon icon="toggle-off"></nb-icon>
     </button>
 
     <button

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.html
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.html
@@ -44,6 +44,17 @@
     </button>
 
     <button
+      [disabled]="loading.list || loading.edit || !faqs?.length"
+      nbButton
+      status="danger"
+      outline
+      data-testid="disable-all-faqs"
+      (click)="disableAllFaqs()"
+    >
+      DISABLE ALL FAQS
+    </button>
+
+    <button
       nbButton
       status="primary"
       [disabled]="!configurations?.length"

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.spec.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.spec.ts
@@ -16,7 +16,6 @@
 
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
 import { NbToastrService } from '@nebular/theme';
 import { of } from 'rxjs';
 

--- a/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
+++ b/bot/admin/web/src/app/faq/faq-management/faq-management.component.ts
@@ -24,11 +24,13 @@ import { BotApplicationConfiguration } from '../../core/model/configuration';
 import { BotConfigurationService } from '../../core/bot-configuration.service';
 import { RestService } from '../../core-nlp/rest/rest.service';
 import { StateService } from '../../core-nlp/state.service';
+import { DialogService } from '../../core-nlp/dialog.service';
 import { PaginatedQuery } from '../../model/commons';
 import { FaqDefinition, FaqFilter, FaqSearchQuery, PaginatedFaqResult } from '../models';
 import { FaqManagementEditComponent } from './faq-management-edit/faq-management-edit.component';
 import { FaqManagementSettingsComponent } from './faq-management-settings/faq-management-settings.component';
 import { Pagination } from '../../shared/components';
+import { ChoiceDialogComponent } from '../../shared/components';
 import { I18nLabel } from '../../bot/model/i18n';
 import { Footnote } from '../../shared/model/dialog-data';
 
@@ -75,6 +77,7 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
     private botConfiguration: BotConfigurationService,
     private rest: RestService,
     public stateService: StateService,
+    private dialogService: DialogService,
     private toastrService: NbToastrService,
     private location: Location
   ) {
@@ -308,6 +311,58 @@ export class FaqManagementComponent implements OnInit, OnDestroy {
   enableFaq(faq: FaqDefinitionExtended) {
     faq.enabled = !faq.enabled;
     this.saveFaq(faq);
+  }
+
+  disableAllFaqs() {
+    const action = 'disable all';
+    const dialogRef = this.dialogService.openDialog(ChoiceDialogComponent, {
+      context: {
+        title: 'Disable all FAQs',
+        subtitle: 'Are you sure you want to disable all FAQs for this bot ?',
+        actions: [
+          { actionName: 'cancel', buttonStatus: 'basic', ghost: true },
+          { actionName: 'Disable all', buttonStatus: 'danger' }
+        ]
+      }
+    });
+
+    dialogRef.onClose.pipe(take(1)).subscribe((result) => {
+      if (result === action) {
+        this.loading.edit = true;
+        this.rest
+          .post<unknown, number>(
+            `/faq/disable-all/${this.stateService.currentApplication._id}`,
+            this.stateService.createApplicationScopedQuery()
+          )
+          .pipe(take(1))
+          .subscribe({
+            next: (disabledCount: number) => {
+              this.stateService.resetConfiguration();
+              this.closeSidePanel();
+
+              if (disabledCount > 0) {
+                this.toastrService.success(`${
+                  disabledCount === 1 ? '1 FAQ successfully disabled' : `${disabledCount} FAQs successfully disabled`
+                }`, 'Success', {
+                  duration: 5000,
+                  status: 'success'
+                });
+              } else {
+                this.toastrService.info(`All FAQs are already disabled`, 'Info', {
+                  duration: 5000,
+                  status: 'info'
+                });
+              }
+
+              this.loading.edit = false;
+              this.search();
+            },
+            error: () => {
+              this.loading.edit = false;
+            }
+          });
+      }
+    });
   }
 
   saveFaq(faq: FaqDefinitionExtended) {


### PR DESCRIPTION
Ticket: [DERCBOT-1843](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1843)

 ### Details

- Added a bulk DISABLE ALL FAQS action in the FAQ management screen.
- Added a dedicated backend endpoint to disable all FAQs for the current application.
- Kept the existing single-FAQ enable/disable behavior unchanged.
- When disabling all FAQs, the associated FAQ stories are also disabled to stay consistent with the current behavior.