### PR TITLE
fix #2027 [Bot Engine] add coroutine-based checked pushNotification implementation

### DIFF
--- a/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
+++ b/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
@@ -618,7 +618,7 @@ class MessengerConnector internal constructor(
         }
     }
 
-    override fun notify(
+    override suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
+++ b/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
@@ -627,7 +627,7 @@ class MessengerConnector internal constructor(
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {
-        controller.handle(
+        controller.handleUserEvent(
             SendChoice(
                 recipientId,
                 connectorId,

--- a/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
+++ b/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
@@ -193,7 +193,7 @@ class OpenAIConnector internal constructor(
         )
     }
 
-    override fun notify(
+    override suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
+++ b/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
@@ -77,7 +77,7 @@ class OpenAIConnector internal constructor(
     }
 
     override fun register(controller: ConnectorController) {
-        controller.registerServices(path) { router ->
+        controller.coRegisterServices(path) { router ->
             logger.debug("deploy Open API connector services for root path $path ")
 
             val corsHandler =
@@ -122,7 +122,7 @@ class OpenAIConnector internal constructor(
                     .end(writeJson(defaultModel))
             }
 
-            router.post("$path/chat/completions").handler { context ->
+            router.post("$path/chat/completions").coHandler { context ->
                 val body = context.body()?.asString()
                 if (body == null) {
                     logger.warn { "null body for chat completion" }
@@ -134,7 +134,7 @@ class OpenAIConnector internal constructor(
         }
     }
 
-    private fun handleRequest(
+    private suspend fun handleRequest(
         controller: ConnectorController,
         context: RoutingContext,
         body: String,
@@ -168,7 +168,7 @@ class OpenAIConnector internal constructor(
         }
     }
 
-    private fun handleEvent(
+    private suspend fun handleEvent(
         applicationId: String,
         locale: Locale,
         event: Event,
@@ -184,7 +184,7 @@ class OpenAIConnector internal constructor(
                 eventId = event.id.toString(),
                 streamedResponse = (event as? Action)?.metadata?.streamedResponse == true,
             )
-        controller.handle(
+        controller.handleUserEvent(
             event,
             ConnectorData(
                 callback = callback,

--- a/bot/connector-twitter/src/main/kotlin/TwitterConnector.kt
+++ b/bot/connector-twitter/src/main/kotlin/TwitterConnector.kt
@@ -254,7 +254,7 @@ internal class TwitterConnector internal constructor(
         }
     }
 
-    override fun notify(
+    override suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/connector-web-sse/src/main/kotlin/ai/tock/bot/connector/web/sse/SseEndpoint.kt
+++ b/bot/connector-web-sse/src/main/kotlin/ai/tock/bot/connector/web/sse/SseEndpoint.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.connector.web.sse
 
 import ai.tock.bot.connector.web.WebConnectorResponseContract
+import ai.tock.bot.connector.web.sse.channel.SseChannel
 import ai.tock.bot.connector.web.sse.channel.SseChannels
 import ai.tock.shared.injector
 import ai.tock.shared.jackson.mapper
@@ -32,6 +33,7 @@ import io.vertx.core.Future
 import io.vertx.core.http.HttpServerResponse
 import io.vertx.ext.web.Router
 import mu.KotlinLogging
+import java.util.concurrent.CompletableFuture
 
 class SseEndpoint internal constructor(
     private val responseSerializer: ObjectMapper,
@@ -87,12 +89,18 @@ class SseEndpoint internal constructor(
         userId: String,
     ) {
         initListeners()
+        val channelFuture = CompletableFuture<SseChannel>()
+        response.setupSSE { channelFuture.thenAccept(this::unregister) }
         val channel =
             register(appId = connectorId, userId) { msg ->
                 logger.debug { "send response from channel: $msg" }
-                response.sendSseMessage(responseSerializer.writeValueAsString(msg))
+                Future.fromCompletionStage(
+                    channelFuture.thenRun {
+                        response.sendSseMessage(responseSerializer.writeValueAsString(msg))
+                    },
+                )
             }
-        response.setupSSE { unregister(channel) }
         sendMissedEvents(channel)
+        channelFuture.complete(channel)
     }
 }

--- a/bot/connector-web-sse/src/main/kotlin/ai/tock/bot/connector/web/sse/SseEndpoint.kt
+++ b/bot/connector-web-sse/src/main/kotlin/ai/tock/bot/connector/web/sse/SseEndpoint.kt
@@ -94,11 +94,9 @@ class SseEndpoint internal constructor(
         val channel =
             register(appId = connectorId, userId) { msg ->
                 logger.debug { "send response from channel: $msg" }
-                Future.fromCompletionStage(
-                    channelFuture.thenRun {
-                        response.sendSseMessage(responseSerializer.writeValueAsString(msg))
-                    },
-                )
+                Future.fromCompletionStage(channelFuture).compose {
+                    response.sendSseMessage(responseSerializer.writeValueAsString(msg))
+                }
             }
         sendMissedEvents(channel)
         channelFuture.complete(channel)

--- a/bot/connector-web/pom.xml
+++ b/bot/connector-web/pom.xml
@@ -57,6 +57,10 @@
             <groupId>org.litote.kmongo</groupId>
             <artifactId>kmongo-async</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>ai.tock</groupId>

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -112,7 +112,7 @@ class WebConnector internal constructor(
     }
 
     override fun register(controller: ConnectorController) {
-        controller.registerServices(path) { router ->
+        controller.coRegisterServices(path) { router ->
             logger.debug("deploy web connector services for root path $path ")
 
             val corsHandler =
@@ -141,7 +141,7 @@ class WebConnector internal constructor(
 
             if (directSseEnabled) {
                 router.route("$path/sse/direct")
-                    .handler { context ->
+                    .coHandler { context ->
                         try {
                             val body =
                                 context.request().getHeader("message")
@@ -158,7 +158,7 @@ class WebConnector internal constructor(
             // Main connector endpoint
             router.post(path)
                 .handler(webSecurityHandler)
-                .handler { context ->
+                .coHandler { context ->
                     // Override the user on the request body
                     val tockUserId: String? = context.get<String>(TOCK_USER_ID)
                     val body =
@@ -180,7 +180,7 @@ class WebConnector internal constructor(
             proxyHandler = this::handleProxy,
         )
 
-    private fun handleRequest(
+    private suspend fun handleRequest(
         controller: ConnectorController,
         context: RoutingContext,
         body: String,
@@ -213,7 +213,7 @@ class WebConnector internal constructor(
         }
     }
 
-    private fun handleEvent(
+    private suspend fun handleEvent(
         applicationId: String,
         locale: Locale,
         event: Event,
@@ -235,7 +235,7 @@ class WebConnector internal constructor(
             // Uniquely identify each response, so they can be reconciled between SSE and POST
             callback.addMetadata(MetadataEvent.responseId(UUID.randomUUID(), applicationId))
         }
-        controller.handle(
+        controller.handleIncomingEvent(
             event,
             ConnectorData(
                 callback = callback,
@@ -244,7 +244,7 @@ class WebConnector internal constructor(
         )
     }
 
-    override fun notify(
+    override suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -204,7 +204,7 @@ class WebConnector internal constructor(
             val event = request.toEvent(applicationId)
             val requestInfos = WebRequestInfos(context.request())
             WebRequestInfosByEvent.put(event.id.toString(), requestInfos)
-            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos))
+            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos), errorListener = null)
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)
@@ -220,10 +220,12 @@ class WebConnector internal constructor(
         controller: ConnectorController,
         context: RoutingContext?,
         headersMetadata: Map<String, String>,
+        errorListener: ((Throwable) -> Unit)?,
     ) {
         val callback =
             WebConnectorCallback(
                 applicationId = applicationId,
+                errorListener = errorListener,
                 locale = locale,
                 context = context,
                 webMapper = webMapper,
@@ -235,7 +237,7 @@ class WebConnector internal constructor(
             // Uniquely identify each response, so they can be reconciled between SSE and POST
             callback.addMetadata(MetadataEvent.responseId(UUID.randomUUID(), applicationId))
         }
-        controller.handleIncomingEvent(
+        controller.handleUserEvent(
             event,
             ConnectorData(
                 callback = callback,
@@ -271,6 +273,7 @@ class WebConnector internal constructor(
             controller = controller,
             context = null,
             headersMetadata = emptyMap(),
+            errorListener = errorListener,
         )
     }
 

--- a/bot/connector-web/src/main/kotlin/WebConnectorCallback.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnectorCallback.kt
@@ -36,6 +36,7 @@ private val mergeStreamResponse: Boolean =
 
 internal class WebConnectorCallback(
     applicationId: String,
+    errorListener: ((Throwable) -> Unit)?,
     val locale: Locale,
     private val context: RoutingContext?,
     private val actions: MutableList<Action> = CopyOnWriteArrayList(),
@@ -44,7 +45,7 @@ internal class WebConnectorCallback(
     private val eventId: String,
     private val messageProcessor: WebMessageProcessor,
     internal val streamedResponse: Boolean,
-) : ConnectorCallbackBase(applicationId, webConnectorType) {
+) : ConnectorCallbackBase(applicationId, webConnectorType, errorListener) {
     fun addAction(action: Action) {
         actions.add(action)
     }

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -255,7 +255,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
         }
     }
 
-    override fun notify(
+    override suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -264,7 +264,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {
-        controller.handle(
+        controller.handleUserEvent(
             SendChoice(
                 recipientId,
                 connectorId,

--- a/bot/engine/pom.xml
+++ b/bot/engine/pom.xml
@@ -53,6 +53,10 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>ai.tock</groupId>

--- a/bot/engine/src/main/kotlin/connector/Connector.kt
+++ b/bot/engine/src/main/kotlin/connector/Connector.kt
@@ -121,7 +121,7 @@ interface Connector {
      * @param notificationType notification type if any
      * @param errorListener called when a message has not been delivered
      */
-    fun notify(
+    suspend fun notify(
         controller: ConnectorController,
         recipientId: PlayerId,
         intent: IntentAware,

--- a/bot/engine/src/main/kotlin/connector/ConnectorCallbackBase.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorCallbackBase.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.connector
 
 import ai.tock.bot.engine.BotRepository.requestTimer
 import ai.tock.bot.engine.event.Event
+import ai.tock.bot.engine.event.SkippedEventException
 import ai.tock.bot.engine.monitoring.RequestTimer
 import ai.tock.bot.engine.monitoring.RequestTimerData
 import mu.KotlinLogging
@@ -28,6 +29,7 @@ import mu.KotlinLogging
 open class ConnectorCallbackBase(
     override val applicationId: String,
     val connectorType: ConnectorType,
+    protected open val errorListener: ((Throwable) -> Unit)? = null,
 ) : ConnectorCallback {
     private val requestTimerData = requestTimer.start("${connectorType.id}_response")
     private var lockTimerData: RequestTimerData? = null
@@ -49,6 +51,7 @@ open class ConnectorCallbackBase(
         logger.warn { "event skipped: $event" }
         requestTimer.error("event skipped: $event", requestTimerData)
         requestTimer.end(requestTimerData)
+        errorListener?.invoke(SkippedEventException("event skipped: $event"))
     }
 
     override fun eventAnswered(event: Event) {
@@ -60,8 +63,9 @@ open class ConnectorCallbackBase(
         event: Event,
         throwable: Throwable,
     ) {
-        logger.error("error thown for $event", throwable)
+        logger.error("error thrown for $event", throwable)
         requestTimer.throwable(throwable, requestTimerData)
         requestTimer.end(requestTimerData)
+        errorListener?.invoke(throwable)
     }
 }

--- a/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
@@ -23,6 +23,7 @@ import ai.tock.bot.engine.action.ActionNotificationType
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.coroutines.ExperimentalTockCoroutines
 import ai.tock.translator.UserInterfaceType
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Creates a new coroutine-based story.
@@ -236,7 +237,7 @@ suspend fun BotDefinition.pushNotification(
     stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
     notificationType: ActionNotificationType? = null,
 ) {
-    var throwable: Throwable? = null
+    val throwable = AtomicReference<Throwable?>(null)
     BotRepository.notifyAsync(
         applicationId = connectorId,
         recipientId = recipientId,
@@ -247,9 +248,7 @@ suspend fun BotDefinition.pushNotification(
         notificationType = notificationType,
         namespace = namespace,
         botId = botId,
-        errorListener = { throwable = it },
+        errorListener = { throwable.set(it) },
     )
-    if (throwable != null) {
-        throw throwable
-    }
+    throwable.get()?.let { throw it }
 }

--- a/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
@@ -16,7 +16,11 @@
 
 package ai.tock.bot.definition
 
+import ai.tock.bot.connector.NotifyBotStateModifier
 import ai.tock.bot.engine.AsyncBus
+import ai.tock.bot.engine.BotRepository
+import ai.tock.bot.engine.action.ActionNotificationType
+import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.coroutines.ExperimentalTockCoroutines
 import ai.tock.translator.UserInterfaceType
 
@@ -210,3 +214,42 @@ inline fun <reified T : AsyncStoryHandling, reified S> storyDefWithSteps(
         stepsList = enumValues<S>().toList(),
         unsupportedUserInterface = unsupportedUserInterface,
     )
+
+/**
+ * Sends a notification to a connector.
+ * A [ai.tock.bot.engine.Bus] is created and the corresponding story is called.
+ *
+ * @param connectorId the configuration connector id
+ * @param recipientId the recipient identifier
+ * @param intent the notification intent
+ * @param step the optional step target
+ * @param parameters the optional parameters
+ * @param stateModifier allow the notification to bypass current user state
+ * @param notificationType the notification type if any
+ */
+suspend fun BotDefinition.pushNotification(
+    connectorId: String,
+    recipientId: PlayerId,
+    intent: IntentAware,
+    step: StoryStepDef? = null,
+    parameters: Parameters = Parameters.EMPTY,
+    stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
+    notificationType: ActionNotificationType? = null,
+) {
+    var throwable: Throwable? = null
+    BotRepository.notifyAsync(
+        applicationId = connectorId,
+        recipientId = recipientId,
+        intent = intent,
+        step = step,
+        parameters = parameters.toMap(),
+        stateModifier = stateModifier,
+        notificationType = notificationType,
+        namespace = namespace,
+        botId = botId,
+        errorListener = { throwable = it },
+    )
+    if (throwable != null) {
+        throw throwable
+    }
+}

--- a/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
+++ b/bot/engine/src/main/kotlin/definition/AsyncDefinitionBuilders.kt
@@ -16,14 +16,9 @@
 
 package ai.tock.bot.definition
 
-import ai.tock.bot.connector.NotifyBotStateModifier
 import ai.tock.bot.engine.AsyncBus
-import ai.tock.bot.engine.BotRepository
-import ai.tock.bot.engine.action.ActionNotificationType
-import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.coroutines.ExperimentalTockCoroutines
 import ai.tock.translator.UserInterfaceType
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Creates a new coroutine-based story.
@@ -215,40 +210,3 @@ inline fun <reified T : AsyncStoryHandling, reified S> storyDefWithSteps(
         stepsList = enumValues<S>().toList(),
         unsupportedUserInterface = unsupportedUserInterface,
     )
-
-/**
- * Sends a notification to a connector.
- * A [ai.tock.bot.engine.Bus] is created and the corresponding story is called.
- *
- * @param connectorId the configuration connector id
- * @param recipientId the recipient identifier
- * @param intent the notification intent
- * @param step the optional step target
- * @param parameters the optional parameters
- * @param stateModifier allow the notification to bypass current user state
- * @param notificationType the notification type if any
- */
-suspend fun BotDefinition.pushNotification(
-    connectorId: String,
-    recipientId: PlayerId,
-    intent: IntentAware,
-    step: StoryStepDef? = null,
-    parameters: Parameters = Parameters.EMPTY,
-    stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
-    notificationType: ActionNotificationType? = null,
-) {
-    val throwable = AtomicReference<Throwable?>(null)
-    BotRepository.notifyAsync(
-        applicationId = connectorId,
-        recipientId = recipientId,
-        intent = intent,
-        step = step,
-        parameters = parameters.toMap(),
-        stateModifier = stateModifier,
-        notificationType = notificationType,
-        namespace = namespace,
-        botId = botId,
-        errorListener = { throwable.set(it) },
-    )
-    throwable.get()?.let { throw it }
-}

--- a/bot/engine/src/main/kotlin/definition/DefinitionBuilders.kt
+++ b/bot/engine/src/main/kotlin/definition/DefinitionBuilders.kt
@@ -16,15 +16,11 @@
 
 package ai.tock.bot.definition
 
-import ai.tock.bot.connector.NotifyBotStateModifier
 import ai.tock.bot.definition.BotDefinition.Companion.findStoryDefinition
 import ai.tock.bot.definition.BotDefinitionBase.Companion.defaultKeywordStory
 import ai.tock.bot.definition.BotDefinitionBase.Companion.defaultUnknownStory
 import ai.tock.bot.engine.BotBus
-import ai.tock.bot.engine.BotRepository
 import ai.tock.bot.engine.action.Action
-import ai.tock.bot.engine.action.ActionNotificationType
-import ai.tock.bot.engine.user.PlayerId
 import ai.tock.translator.UserInterfaceType
 
 /**
@@ -542,43 +538,3 @@ inline fun <reified T> storyWithSteps(
         unsupportedUserInterface,
         handler,
     )
-
-/**
- * Sends a notification to a connector.
- * A [Bus] is created and the corresponding story is called.
- *
- * @param applicationId the configuration connector id
- * @param namespace the configuration namespace
- * @param botId the configuration botId
- * @param applicationId the configuration connector id
- * @param recipientId the recipient identifier
- * @param intent the notification intent
- * @param step the optional step target
- * @param parameters the optional parameters
- * @param stateModifier allow the notification to bypass current user state
- * @param notificationType the notification type if any
- * @param errorListener called when a message has not been delivered
- */
-fun notify(
-    applicationId: String,
-    namespace: String,
-    botId: String,
-    recipientId: PlayerId,
-    intent: IntentAware,
-    step: StoryStepDef? = null,
-    parameters: Parameters = Parameters.EMPTY,
-    stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
-    notificationType: ActionNotificationType? = null,
-    errorListener: (Throwable) -> Unit = {},
-) = BotRepository.notify(
-    applicationId = applicationId,
-    recipientId = recipientId,
-    intent = intent,
-    step = step,
-    parameters = parameters.toMap(),
-    stateModifier = stateModifier,
-    notificationType = notificationType,
-    namespace = namespace,
-    botId = botId,
-    errorListener = errorListener,
-)

--- a/bot/engine/src/main/kotlin/definition/PushNotifications.kt
+++ b/bot/engine/src/main/kotlin/definition/PushNotifications.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import ai.tock.bot.connector.ConnectorException
+import ai.tock.bot.connector.NotifyBotStateModifier
+import ai.tock.bot.engine.BotRepository
+import ai.tock.bot.engine.Bus
+import ai.tock.bot.engine.action.ActionNotificationType
+import ai.tock.bot.engine.event.SkippedEventException
+import ai.tock.bot.engine.user.PlayerId
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Sends a notification to a connector.
+ * A [Bus] is created and the corresponding story is called.
+ *
+ * @param applicationId the configuration connector id
+ * @param namespace the configuration namespace
+ * @param botId the configuration botId
+ * @param applicationId the configuration connector id
+ * @param recipientId the recipient identifier
+ * @param intent the notification intent
+ * @param step the optional step target
+ * @param parameters the optional parameters
+ * @param stateModifier allow the notification to bypass current user state
+ * @param notificationType the notification type if any
+ * @param errorListener called when a message has not been delivered
+ */
+fun notify(
+    applicationId: String,
+    namespace: String,
+    botId: String,
+    recipientId: PlayerId,
+    intent: IntentAware,
+    step: StoryStepDef? = null,
+    parameters: Parameters = Parameters.EMPTY,
+    stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
+    notificationType: ActionNotificationType? = null,
+    errorListener: (Throwable) -> Unit = {},
+) {
+    runBlocking {
+        BotRepository.notifyAsync(
+            namespace = namespace,
+            botId = botId,
+            applicationId = applicationId,
+            recipientId = recipientId,
+            intent = intent,
+            step = step,
+            parameters = parameters.toMap(),
+            stateModifier = stateModifier,
+            notificationType = notificationType,
+            errorListener = errorListener,
+        )
+    }
+}
+
+/**
+ * Sends a notification to a connector.
+ * A [ai.tock.bot.engine.Bus] is created and the corresponding story is called.
+ *
+ * @param connectorId the configuration connector id
+ * @param recipientId the recipient identifier
+ * @param intent the notification intent
+ * @param step the optional step target
+ * @param parameters the optional parameters
+ * @param stateModifier allow the notification to bypass current user state
+ * @param notificationType the notification type if any
+ * @throws SkippedEventException if a concurrent request prevents processing of the pushed event
+ * @throws ConnectorException
+ */
+@ExperimentalTockCoroutines
+suspend fun BotDefinition.pushNotification(
+    connectorId: String,
+    recipientId: PlayerId,
+    intent: IntentAware,
+    step: StoryStepDef? = null,
+    parameters: Parameters = Parameters.EMPTY,
+    stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
+    notificationType: ActionNotificationType? = null,
+) {
+    val throwable = AtomicReference<Throwable?>(null)
+    BotRepository.notifyAsync(
+        applicationId = connectorId,
+        recipientId = recipientId,
+        intent = intent,
+        step = step,
+        parameters = parameters.toMap(),
+        stateModifier = stateModifier,
+        notificationType = notificationType,
+        namespace = namespace,
+        botId = botId,
+        errorListener = throwable::set,
+    )
+    throwable.get()?.let { throw it }
+}

--- a/bot/engine/src/main/kotlin/definition/PushNotifications.kt
+++ b/bot/engine/src/main/kotlin/definition/PushNotifications.kt
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicReference
  * @param applicationId the configuration connector id
  * @param namespace the configuration namespace
  * @param botId the configuration botId
- * @param applicationId the configuration connector id
  * @param recipientId the recipient identifier
  * @param intent the notification intent
  * @param step the optional step target

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -194,7 +194,7 @@ object BotRepository {
      * @param errorListener called when a message has not been delivered
      */
     @Deprecated(
-        "use ai.tock.bot.definition.notify",
+        "use ai.tock.bot.definition.notify or pushNotification",
         replaceWith = ReplaceWith("notify", "ai.tock.bot.definition.notify"),
     )
     fun notify(

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -67,6 +67,7 @@ import ai.tock.shared.provide
 import ai.tock.shared.vertx.vertx
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import org.litote.kmongo.Id
@@ -99,6 +100,7 @@ object BotRepository {
     internal val nlpClient: NlpClient get() = injector.provide()
     private val nlpController: NlpController get() = injector.provide()
     private val executor: Executor get() = injector.provide()
+    private val userTimelineDAO: UserTimelineDAO get() = injector.provide()
     internal val botAnswerInterceptors: MutableList<BotAnswerInterceptor> = CopyOnWriteArrayList()
     private val connectorServices: MutableSet<ConnectorService> =
         CopyOnWriteArraySet(ServiceLoader.load(ConnectorService::class.java).toList())
@@ -207,6 +209,23 @@ object BotRepository {
         botId: String? = null,
         errorListener: (Throwable) -> Unit = {},
     ) {
+        runBlocking {
+            notifyAsync(namespace, botId, applicationId, recipientId, intent, step, parameters, stateModifier, notificationType, errorListener)
+        }
+    }
+
+    internal suspend fun notifyAsync(
+        namespace: String?,
+        botId: String?,
+        applicationId: String,
+        recipientId: PlayerId,
+        intent: IntentAware,
+        step: StoryStepDef?,
+        parameters: Map<String, String>,
+        stateModifier: NotifyBotStateModifier,
+        notificationType: ActionNotificationType?,
+        errorListener: (Throwable) -> Unit,
+    ) {
         val key =
             if (namespace == null || botId == null) {
                 logger.warn { "notify without specifying namespace or botId will be removed in next release" }
@@ -219,7 +238,7 @@ object BotRepository {
             .notifyAndCheckState(recipientId, intent, step, parameters, stateModifier, notificationType, errorListener)
     }
 
-    private fun ConnectorController.notifyAndCheckState(
+    private suspend fun ConnectorController.notifyAndCheckState(
         recipientId: PlayerId,
         intent: IntentAware,
         step: StoryStepDef?,
@@ -228,27 +247,24 @@ object BotRepository {
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit = {},
     ) {
-        runBlocking {
-            val userTimelineDAO: UserTimelineDAO = injector.provide()
-            val userTimeline = userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
-            val userState = userTimeline.userState
-            val currentState = userState.botDisabled
+        val userTimeline = userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
+        val userState = userTimeline.userState
+        val currentState = userState.botDisabled
 
-            if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION ||
-                stateModifier == NotifyBotStateModifier.REACTIVATE
-            ) {
-                userState.botDisabled = false
-                userTimelineDAO.save(userTimeline, botDefinition)
-            }
+        if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION ||
+            stateModifier == NotifyBotStateModifier.REACTIVATE
+        ) {
+            userState.botDisabled = false
+            userTimelineDAO.save(userTimeline, botDefinition)
+        }
 
-            notify(recipientId, intent, step, parameters, notificationType, errorListener)
+        notify(recipientId, intent, step, parameters, notificationType, errorListener)
 
-            if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION) {
-                val userTimelineAfterNotification =
-                    userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
-                userTimelineAfterNotification.userState.botDisabled = currentState
-                userTimelineDAO.save(userTimeline, botDefinition)
-            }
+        if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION) {
+            val userTimelineAfterNotification =
+                userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
+            userTimelineAfterNotification.userState.botDisabled = currentState
+            userTimelineDAO.save(userTimeline, botDefinition)
         }
     }
 
@@ -365,7 +381,7 @@ object BotRepository {
      * @param startupLock if not null, wait do listen until the lock is released
      */
     fun installBots(
-        routerHandlers: List<(Router) -> Any?>,
+        routerHandlers: List<CoroutineRouterSupport.(Router) -> Any?>,
         createApplicationIfNotExists: Boolean = true,
         startupLock: Lock? = null,
     ) {

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -264,7 +264,7 @@ object BotRepository {
             val userTimelineAfterNotification =
                 userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
             userTimelineAfterNotification.userState.botDisabled = currentState
-            userTimelineDAO.save(userTimeline, botDefinition)
+            userTimelineDAO.save(userTimelineAfterNotification, botDefinition)
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -258,13 +258,16 @@ object BotRepository {
             userTimelineDAO.save(userTimeline, botDefinition)
         }
 
-        notify(recipientId, intent, step, parameters, notificationType, errorListener)
+        try {
+            notify(recipientId, intent, step, parameters, notificationType, errorListener)
+        } finally {
+            if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION) {
+                val userTimelineAfterNotification =
+                    userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
+                userTimelineAfterNotification.userState.botDisabled = currentState
+                userTimelineDAO.save(userTimelineAfterNotification, botDefinition)
+            }
 
-        if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION) {
-            val userTimelineAfterNotification =
-                userTimelineDAO.loadWithoutDialogs(botDefinition.namespace, recipientId)
-            userTimelineAfterNotification.userState.botDisabled = currentState
-            userTimelineDAO.save(userTimelineAfterNotification, botDefinition)
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -267,7 +267,6 @@ object BotRepository {
                 userTimelineAfterNotification.userState.botDisabled = currentState
                 userTimelineDAO.save(userTimelineAfterNotification, botDefinition)
             }
-
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/BotVerticle.kt
+++ b/bot/engine/src/main/kotlin/engine/BotVerticle.kt
@@ -32,6 +32,8 @@ import io.vertx.core.Promise
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
+import io.vertx.kotlin.coroutines.coroutineRouter
 import mu.KLogger
 import mu.KotlinLogging
 import java.time.Instant
@@ -48,7 +50,7 @@ internal class BotVerticle(
 ) : WebVerticle() {
     inner class ServiceInstaller(
         val serviceId: String,
-        private val installer: (Router) -> Any?,
+        private val installer: CoroutineRouterSupport.(Router) -> Any?,
         private val routes: MutableList<Route> = CopyOnWriteArrayList(),
         @Volatile
         var installed: Boolean = false,
@@ -60,7 +62,9 @@ internal class BotVerticle(
                 try {
                     logger.debug("install $serviceId")
                     val registeredRoutes = router.routes
-                    installer.invoke(router)
+                    coroutineRouter {
+                        installer.invoke(this, router)
+                    }
                     routes.addAll(router.routes.subtract(registeredRoutes))
                 } catch (e: Exception) {
                     logger.error(e)
@@ -87,7 +91,7 @@ internal class BotVerticle(
 
     fun registerServices(
         serviceIdentifier: String,
-        installer: (Router) -> Any?,
+        installer: CoroutineRouterSupport.(Router) -> Any?,
     ): ServiceInstaller {
         return ServiceInstaller(serviceIdentifier, installer).also {
             if (!handlers.containsKey(serviceIdentifier)) {

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -30,6 +30,7 @@ import ai.tock.bot.engine.action.ActionNotificationType
 import ai.tock.bot.engine.event.Event
 import ai.tock.bot.engine.user.PlayerId
 import io.vertx.ext.web.Router
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 
 /**
  * Controller to connect [Connector] and [BotDefinition].
@@ -63,7 +64,7 @@ interface ConnectorController {
      * @param notificationType notification type if any
      * @param errorListener called when a message has not been delivered
      */
-    fun notify(
+    suspend fun notify(
         recipientId: PlayerId,
         intent: IntentAware,
         step: StoryStepDef? = null,
@@ -84,8 +85,21 @@ interface ConnectorController {
      */
     fun handle(
         event: Event,
-        data: ConnectorData = ConnectorData(ConnectorCallbackBase(event.applicationId, connector.connectorType)),
+        data: ConnectorData = ConnectorData(ConnectorCallbackBase(event.connectorId, connector.connectorType)),
     )
+
+    /**
+     * Handles an event sent by the connector. the primary goal of this controller.
+     *
+     * This method may return before the event is actually processed.
+     *
+     * @param event the event to handle
+     * @param data the optional additional data from the connector
+     */
+    suspend fun handleIncomingEvent(
+        event: Event,
+        data: ConnectorData = ConnectorData(ConnectorCallbackBase(event.connectorId, connector.connectorType)),
+    ) = handle(event, data)
 
     /**
      * Return a probability of the support by the bot of this action
@@ -104,6 +118,14 @@ interface ConnectorController {
     fun registerServices(
         serviceIdentifier: String,
         installer: (Router) -> Unit,
+    )
+
+    /**
+     * Register services at startup.
+     */
+    fun coRegisterServices(
+        serviceIdentifier: String,
+        installer: CoroutineRouterSupport.(Router) -> Unit,
     )
 
     /**

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -89,9 +89,7 @@ interface ConnectorController {
     )
 
     /**
-     * Handles an event sent by the connector. the primary goal of this controller.
-     *
-     * This method may return before the event is actually processed.
+     * Handles an event received by the connector. the primary goal of this controller.
      *
      * @param event the event to handle
      * @param data the optional additional data from the connector
@@ -109,7 +107,7 @@ interface ConnectorController {
      */
     fun support(
         action: Action,
-        data: ConnectorData = ConnectorData(ConnectorCallbackBase(action.applicationId, connector.connectorType)),
+        data: ConnectorData = ConnectorData(ConnectorCallbackBase(action.connectorId, connector.connectorType)),
     ): Double
 
     /**

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -54,7 +54,7 @@ interface ConnectorController {
     val botConfiguration: BotApplicationConfiguration
 
     /**
-     * Sends a notification to the connector.
+     * Sends a notification (_push messages_) through the connector.
      * A [BotBus] is created and the corresponding story is called.
      *
      * @param recipientId the recipient identifier
@@ -94,7 +94,7 @@ interface ConnectorController {
      * @param event the event to handle
      * @param data the optional additional data from the connector
      */
-    suspend fun handleIncomingEvent(
+    suspend fun handleUserEvent(
         event: Event,
         data: ConnectorData = ConnectorData(ConnectorCallbackBase(event.connectorId, connector.connectorType)),
     ) = handle(event, data)

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -76,7 +76,7 @@ interface ConnectorController {
     }
 
     /**
-     * Handles an event sent by the connector. the primary goal of this controller.
+     * Handles an event sent by the connector (the primary goal of this controller)
      *
      * This method may return before the event is actually processed.
      *
@@ -89,7 +89,7 @@ interface ConnectorController {
     )
 
     /**
-     * Handles an event received by the connector. the primary goal of this controller.
+     * Handles an event received by the connector (the primary goal of this controller)
      *
      * @param event the event to handle
      * @param data the optional additional data from the connector

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -46,11 +46,9 @@ import ai.tock.stt.STT
 import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
 import io.vertx.kotlin.coroutines.CoroutineRouterSupport
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import java.net.URL
 import java.util.concurrent.CopyOnWriteArrayList

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -37,7 +37,6 @@ import ai.tock.bot.engine.user.UserTimelineDAO
 import ai.tock.shared.Executor
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.coroutines.ExperimentalTockCoroutines
-import ai.tock.shared.coroutines.launchCoroutine
 import ai.tock.shared.error
 import ai.tock.shared.injector
 import ai.tock.shared.intProperty
@@ -46,8 +45,12 @@ import ai.tock.shared.provide
 import ai.tock.stt.STT
 import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import java.net.URL
 import java.util.concurrent.CopyOnWriteArrayList
@@ -103,7 +106,7 @@ internal class TockConnectorController(
     /**
      * Handles an event sent by the connector.
      *
-     * If [event] is an [Action], the processing is done asynchronously using the shared [Executor],
+     * The actual processing is done asynchronously on the vertx event loop,
      * with this method returning immediately.
      *
      * @param event the event to handle
@@ -111,6 +114,16 @@ internal class TockConnectorController(
      */
     @OptIn(ExperimentalTockCoroutines::class)
     override fun handle(
+        event: Event,
+        data: ConnectorData,
+    ) {
+        verticle.launch {
+            handleIncomingEvent(event, data)
+        }
+    }
+
+    @OptIn(ExperimentalTockCoroutines::class)
+    override suspend fun handleIncomingEvent(
         event: Event,
         data: ConnectorData,
     ) {
@@ -125,10 +138,8 @@ internal class TockConnectorController(
         try {
             if (!botDefinition.eventListener.listenEvent(this, data, event)) {
                 when (event) {
-                    is Action ->
-                        executor.launchCoroutine {
-                            handleAction(event, 0, data)
-                        }
+                    is Action -> handleAction(event, 0, data)
+
                     else -> callback.eventSkipped(event)
                 }
             } else {
@@ -247,6 +258,15 @@ internal class TockConnectorController(
     override fun registerServices(
         serviceIdentifier: String,
         installer: (Router) -> Unit,
+    ) {
+        coRegisterServices(serviceIdentifier) {
+            installer(it)
+        }
+    }
+
+    override fun coRegisterServices(
+        serviceIdentifier: String,
+        installer: CoroutineRouterSupport.(Router) -> Unit,
     ) {
         verticle.registerServices(serviceIdentifier) { router ->
             // healthcheck

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -46,12 +46,11 @@ import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
 import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import io.vertx.kotlin.coroutines.awaitBlocking
-import java.net.URI
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
-import java.net.URL
+import java.net.URI
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -200,9 +199,10 @@ internal class TockConnectorController(
                     // Notify callback that timeline has been loaded
                     callback.initialUserTimelineLoaded(userTimeline)
 
-                    val transformedAction = awaitBlocking {
-                        tryToParseVoiceAudio(action, userTimeline)
-                    }
+                    val transformedAction =
+                        awaitBlocking {
+                            tryToParseVoiceAudio(action, userTimeline)
+                        }
 
                     bot.handleAction(transformedAction, userTimeline, this, data)
 

--- a/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/TockConnectorController.kt
@@ -34,7 +34,6 @@ import ai.tock.bot.engine.user.UserLock
 import ai.tock.bot.engine.user.UserPreferences
 import ai.tock.bot.engine.user.UserTimeline
 import ai.tock.bot.engine.user.UserTimelineDAO
-import ai.tock.shared.Executor
 import ai.tock.shared.booleanProperty
 import ai.tock.shared.coroutines.ExperimentalTockCoroutines
 import ai.tock.shared.error
@@ -46,12 +45,15 @@ import ai.tock.stt.STT
 import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
 import io.vertx.kotlin.coroutines.CoroutineRouterSupport
+import io.vertx.kotlin.coroutines.awaitBlocking
+import java.net.URI
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import java.net.URL
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
 
 private val synchronousMode = booleanProperty("tock_timeline_persistence_synchronous_mode", true)
 private val asynchronousMode = booleanProperty("tock_timeline_persistence_asynchronous_mode", false)
@@ -70,8 +72,6 @@ internal class TockConnectorController(
 
     companion object {
         private val logger = KotlinLogging.logger {}
-        private val maxLockedAttempts = intProperty("tock_bot_max_locked_attempts", 10)
-        private val lockedAttemptsWaitInMs = longProperty("tock_bot_locked_attempts_wait_in_ms", 500L)
         private val parseAudioFileEnabled = booleanProperty("tock_bot_audio_nlp_enabled", true)
         private val audioNlpFileLimit = intProperty("tock_bot_audio_nlp_max_size", 1024 * 1024)
 
@@ -93,7 +93,9 @@ internal class TockConnectorController(
         }
     }
 
-    private val executor: Executor by injector.instance()
+    private val maxLockedAttempts = intProperty("tock_bot_max_locked_attempts", 10)
+    private val lockedAttemptsWait = longProperty("tock_bot_locked_attempts_wait_in_ms", 500L).milliseconds
+
     private val userLock: UserLock by injector.instance()
     private val userTimelineDAO: UserTimelineDAO by injector.instance()
 
@@ -116,12 +118,12 @@ internal class TockConnectorController(
         data: ConnectorData,
     ) {
         verticle.launch {
-            handleIncomingEvent(event, data)
+            handleUserEvent(event, data)
         }
     }
 
     @OptIn(ExperimentalTockCoroutines::class)
-    override suspend fun handleIncomingEvent(
+    override suspend fun handleUserEvent(
         event: Event,
         data: ConnectorData,
     ) {
@@ -153,14 +155,14 @@ internal class TockConnectorController(
         userTimeline: UserTimeline,
     ): Action {
         if (parseAudioFileEnabled && action is SendAttachment && action.type == audio) {
-            val bytes = URL(action.url).readBytes()
+            val bytes = URI(action.url).toURL().readBytes()
             if (bytes.size < audioNlpFileLimit) {
                 val stt: STT = injector.provide()
                 val text = stt.parse(bytes, userTimeline.userPreferences.locale)
                 if (text != null) {
                     return SendSentence(
                         action.playerId,
-                        action.applicationId,
+                        action.connectorId,
                         action.recipientId,
                         text,
                     )
@@ -198,7 +200,9 @@ internal class TockConnectorController(
                     // Notify callback that timeline has been loaded
                     callback.initialUserTimelineLoaded(userTimeline)
 
-                    val transformedAction = tryToParseVoiceAudio(action, userTimeline)
+                    val transformedAction = awaitBlocking {
+                        tryToParseVoiceAudio(action, userTimeline)
+                    }
 
                     bot.handleAction(transformedAction, userTimeline, this, data)
 
@@ -216,7 +220,7 @@ internal class TockConnectorController(
                 }
             } else if (nbAttempts < maxLockedAttempts) {
                 logger.debug { "$playerId locked - wait" }
-                delay(lockedAttemptsWaitInMs)
+                delay(lockedAttemptsWait)
                 handleAction(action, nbAttempts + 1, data)
             } else {
                 logger.debug { "$playerId locked for $maxLockedAttempts times - skip $action" }

--- a/bot/engine/src/main/kotlin/engine/config/UploadedFilesService.kt
+++ b/bot/engine/src/main/kotlin/engine/config/UploadedFilesService.kt
@@ -29,6 +29,7 @@ import ai.tock.translator.I18nLabel
 import io.vertx.core.buffer.Buffer
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import org.litote.kmongo.toId
 import java.util.UUID
 
@@ -137,7 +138,7 @@ object UploadedFilesService {
             }
         }
 
-    internal fun configure(): (Router) -> Unit {
+    internal fun configure(): CoroutineRouterSupport.(Router) -> Unit {
         return { router ->
             router.get("$basePath*").blocking { context ->
                 val id = context.request().uri().substring(basePath.length).lowercase()

--- a/bot/engine/src/main/kotlin/engine/event/SkippedEventException.kt
+++ b/bot/engine/src/main/kotlin/engine/event/SkippedEventException.kt
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-package ai.tock.bot.connector.messenger
-
-import ai.tock.bot.connector.ConnectorCallbackBase
-import ai.tock.bot.engine.action.ActionNotificationType
+package ai.tock.bot.engine.event
 
 /**
- * The messenger [ConnectorCallback].
+ * Thrown when an [Event]'s processing is skipped by the engine
  */
-internal class MessengerConnectorCallback(
-    applicationId: String,
-    val notificationType: ActionNotificationType? = null,
-    errorListener: (Throwable) -> Unit = {},
-) : ConnectorCallbackBase(applicationId, messengerConnectorType, errorListener) {
-    public override val errorListener: ((Throwable) -> Unit)?
-        get() = super.errorListener
-}
+class SkippedEventException(message: String) : RuntimeException(message)

--- a/bot/engine/src/main/kotlin/engine/nlp/NlpProxyBotService.kt
+++ b/bot/engine/src/main/kotlin/engine/nlp/NlpProxyBotService.kt
@@ -27,6 +27,7 @@ import io.vertx.core.http.HttpMethod.POST
 import io.vertx.core.http.RequestOptions
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import mu.KLogger
 import mu.KotlinLogging
 import java.net.URL
@@ -60,7 +61,7 @@ internal object NlpProxyBotService {
         tockNlpServiceSsl = (System.getenv("tock_nlp_service_SSL") ?: tockNlpServiceUrl.protocol) == "https"
     }
 
-    fun configure(vertx: Vertx): (Router) -> Unit {
+    fun configure(vertx: Vertx): CoroutineRouterSupport.(Router) -> Unit {
         return { router ->
             router.post("$tockNlpProxyOnBotPath*").handler { context ->
                 httpProxyToNlp(context, vertx, POST)

--- a/bot/engine/src/test/kotlin/definition/PushNotificationsTest.kt
+++ b/bot/engine/src/test/kotlin/definition/PushNotificationsTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.connector.Connector
+import ai.tock.bot.connector.ConnectorCallbackBase
+import ai.tock.bot.connector.ConnectorConfiguration
+import ai.tock.bot.connector.ConnectorData
+import ai.tock.bot.connector.ConnectorProvider
+import ai.tock.bot.connector.ConnectorType
+import ai.tock.bot.connector.NotifyBotStateModifier.KEEP_CURRENT_STATE
+import ai.tock.bot.engine.BotEngineTest
+import ai.tock.bot.engine.BotRepository
+import ai.tock.bot.engine.ConnectorController
+import ai.tock.bot.engine.action.SendChoice
+import ai.tock.bot.engine.event.SkippedEventException
+import ai.tock.bot.engine.user.PlayerId
+import ai.tock.bot.engine.user.PlayerType
+import ai.tock.shared.coroutines.ExperimentalTockCoroutines
+import io.mockk.CapturingSlot
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.slot
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PushNotificationsTest : BotEngineTest() {
+    companion object {
+        private const val CONNECTOR_ID = "test"
+    }
+
+    val intent = Intent("a")
+    val recipientId = PlayerId("user")
+
+    @BeforeEach
+    fun beforeEach() {
+        System.setProperty("tock_bot_locked_attempts_wait_in_ms", "5")
+        val connectorType = ConnectorType(CONNECTOR_ID)
+        val botId = botDefinition.botId
+
+        val botConfs =
+            listOf(
+                BotApplicationConfiguration(
+                    connectorType.id,
+                    botId,
+                    botDefinition.namespace,
+                    botDefinition.nlpModelName,
+                    connectorType,
+                    parameters = mapOf(CONNECTOR_ID to CONNECTOR_ID),
+                ),
+            )
+
+        every { botConfDAO.getConfigurations() } answers { botConfs }
+
+        val connectorProvider =
+            object : ConnectorProvider {
+                override val connectorType: ConnectorType = connectorType
+
+                override fun connector(connectorConfiguration: ConnectorConfiguration): Connector = connector
+            }
+        BotRepository.registerConnectorProvider(connectorProvider)
+        BotRepository.registerBotProvider(
+            object : BotProvider {
+                override fun botDefinition(): BotDefinition = botDefinition
+            },
+        )
+
+        val appSlot: CapturingSlot<BotApplicationConfiguration> = slot()
+        every { botConfDAO.save(capture(appSlot)) } answers { appSlot.captured }
+
+        BotRepository.installBots(emptyList())
+    }
+
+    @Test
+    fun `GIVEN stateModifier THEN notify calls connector notify method`() {
+        notify(CONNECTOR_ID, botDefinition.namespace, botDefinition.botId, recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
+
+        coVerify { connector.notify(any(), recipientId, intent, null, any(), any(), any()) }
+    }
+
+    @Test
+    fun `GIVEN no notificationType passed THEN notify pass null NotificationType to connector`() {
+        notify(CONNECTOR_ID, botDefinition.namespace, botDefinition.botId, recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
+
+        coVerify { connector.notify(any(), recipientId, intent, null, any(), null, any()) }
+    }
+
+    @OptIn(ExperimentalTockCoroutines::class)
+    @Test
+    suspend fun `GIVEN locked user session WHEN pushNotification is called THEN throw SkippedEventException`() {
+        coEvery { userLock.tryLock(recipientId.id) } returns false
+        coEvery { connector.notify(any(), any(), any(), null, emptyMap(), any(), any()) } coAnswers {
+            firstArg<ConnectorController>().handleUserEvent(
+                SendChoice(
+                    PlayerId(botDefinition.botId, PlayerType.bot),
+                    CONNECTOR_ID,
+                    recipientId,
+                    intent.wrappedIntent().name,
+                    null,
+                    emptyMap(),
+                ),
+                ConnectorData(
+                    ConnectorCallbackBase(CONNECTOR_ID, ConnectorType(CONNECTOR_ID), arg(6)),
+                ),
+            )
+        }
+        assertThrows<SkippedEventException> {
+            botDefinition.pushNotification(CONNECTOR_ID, recipientId, intent)
+        }
+    }
+}

--- a/bot/engine/src/test/kotlin/engine/BotRepositoryTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotRepositoryTest.kt
@@ -29,12 +29,14 @@ import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.defaultLocale
 import ai.tock.shared.mockedVertx
 import io.mockk.CapturingSlot
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.vertx.core.Future
+import io.vertx.core.internal.ContextInternal
 import io.vertx.ext.web.Router
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -223,6 +225,7 @@ internal class BotRepositoryTest : BotEngineTest() {
 
         val verticleSlot: CapturingSlot<BotVerticle> = slot()
         every { mockedVertx.deployVerticle(capture(verticleSlot)) } answers {
+            verticleSlot.captured.init(mockedVertx, mockk<ContextInternal>(relaxed = true))
             Future.succeededFuture()
         }
 
@@ -320,14 +323,14 @@ internal class BotRepositoryTest : BotEngineTest() {
         fun `GIVEN stateModifier THEN notify calls connector notify method`() {
             BotRepository.notify("test", recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
 
-            verify { connector.notify(any(), recipientId, intent, null, any(), any(), any()) }
+            coVerify { connector.notify(any(), recipientId, intent, null, any(), any(), any()) }
         }
 
         @Test
         fun `GIVEN no notificationType passed THEN notify pass null NotificationType to connector`() {
             BotRepository.notify("test", recipientId, intent)
 
-            verify { connector.notify(any(), recipientId, intent, null, any(), null, any()) }
+            coVerify { connector.notify(any(), recipientId, intent, null, any(), null, any()) }
         }
     }
 }

--- a/bot/engine/src/test/kotlin/engine/BotRepositoryTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotRepositoryTest.kt
@@ -21,15 +21,11 @@ import ai.tock.bot.connector.Connector
 import ai.tock.bot.connector.ConnectorConfiguration
 import ai.tock.bot.connector.ConnectorProvider
 import ai.tock.bot.connector.ConnectorType
-import ai.tock.bot.connector.NotifyBotStateModifier.KEEP_CURRENT_STATE
 import ai.tock.bot.definition.BotDefinition
 import ai.tock.bot.definition.BotProvider
-import ai.tock.bot.definition.Intent
-import ai.tock.bot.engine.user.PlayerId
 import ai.tock.shared.defaultLocale
 import ai.tock.shared.mockedVertx
 import io.mockk.CapturingSlot
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
@@ -38,8 +34,6 @@ import io.mockk.verify
 import io.vertx.core.Future
 import io.vertx.core.internal.ContextInternal
 import io.vertx.ext.web.Router
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import kotlin.test.assertEquals
@@ -274,63 +268,5 @@ internal class BotRepositoryTest : BotEngineTest() {
         // check verticle contains installer2 route (and so unregister has been called on installer1)
         assertEquals(3, verticleSlot.captured.router.routes.size)
         assertEquals("/2", verticleSlot.captured.router.routes[2].path)
-    }
-
-    @Nested
-    inner class Notify {
-        val intent = Intent("a")
-        val recipientId = PlayerId("user")
-
-        @BeforeEach
-        fun beforeNested() {
-            val connectorType = ConnectorType("test")
-            val botId = botDefinition.botId
-
-            val botConfs =
-                listOf(
-                    BotApplicationConfiguration(
-                        connectorType.id,
-                        botId,
-                        botDefinition.namespace,
-                        botDefinition.nlpModelName,
-                        connectorType,
-                        parameters = mapOf("test" to "test"),
-                    ),
-                )
-
-            every { botConfDAO.getConfigurations() } answers { botConfs }
-
-            val connectorProvider =
-                object : ConnectorProvider {
-                    override val connectorType: ConnectorType = connectorType
-
-                    override fun connector(connectorConfiguration: ConnectorConfiguration): Connector = connector
-                }
-            BotRepository.registerConnectorProvider(connectorProvider)
-            BotRepository.registerBotProvider(
-                object : BotProvider {
-                    override fun botDefinition(): BotDefinition = botDefinition
-                },
-            )
-
-            val appSlot: CapturingSlot<BotApplicationConfiguration> = slot()
-            every { botConfDAO.save(capture(appSlot)) } answers { appSlot.captured }
-
-            BotRepository.installBots(emptyList())
-        }
-
-        @Test
-        fun `GIVEN stateModifier THEN notify calls connector notify method`() {
-            BotRepository.notify("test", recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
-
-            coVerify { connector.notify(any(), recipientId, intent, null, any(), any(), any()) }
-        }
-
-        @Test
-        fun `GIVEN no notificationType passed THEN notify pass null NotificationType to connector`() {
-            BotRepository.notify("test", recipientId, intent)
-
-            coVerify { connector.notify(any(), recipientId, intent, null, any(), null, any()) }
-        }
     }
 }

--- a/bot/engine/src/test/kotlin/engine/BotVerticleTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotVerticleTest.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.engine
 
 import ai.tock.shared.mockedVertx
 import io.mockk.mockk
+import io.vertx.core.internal.ContextInternal
 import org.junit.jupiter.api.Test
 import kotlin.test.assertFalse
 
@@ -28,6 +29,7 @@ internal class BotVerticleTest : BotEngineTest() {
     @Test
     fun `unregisterRouter activates secondary router if one exists`() {
         val verticle = BotVerticle(false, false)
+        verticle.init(mockedVertx, mockk<ContextInternal>())
 
         var service1Installed = false
         var service2Installed = false
@@ -55,6 +57,8 @@ internal class BotVerticleTest : BotEngineTest() {
     @Test
     fun `GIVEN default BOT configuration WHEN configure BOT Verticle THEN nlp api is not exposed`() {
         val verticle = BotVerticle(false, false)
+        verticle.init(mockedVertx, mockk<ContextInternal>())
+
         // NLP Api not exposed
         verticle.configure()
 

--- a/bot/engine/src/test/kotlin/engine/TockConnectorControllerTest.kt
+++ b/bot/engine/src/test/kotlin/engine/TockConnectorControllerTest.kt
@@ -23,6 +23,7 @@ import io.mockk.slot
 import io.mockk.verify
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.Router
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import org.junit.jupiter.api.Test
 
 /**
@@ -33,7 +34,7 @@ class TockConnectorControllerTest {
     fun `test registerService install healthcheck`() {
         val botVerticle: BotVerticle = mockk()
         val serviceInstaller: BotVerticle.ServiceInstaller = mockk()
-        val capturedInstaller = slot<(Router) -> Unit>()
+        val capturedInstaller = slot<CoroutineRouterSupport.(Router) -> Unit>()
         every { botVerticle.registerServices(any(), capture(capturedInstaller)) } returns serviceInstaller
 
         val installer: (Router) -> Unit = mockk()
@@ -51,7 +52,7 @@ class TockConnectorControllerTest {
         every { router.get(any()) } returns route
         every { route.handler(any()) } returns route
 
-        capturedInstaller.invoke(router)
+        capturedInstaller.invoke(mockk(), router)
 
         verify { router.get("/path/healthcheck") }
         verify { installer.invoke(router) }

--- a/bot/toolkit-base/src/main/kotlin/BotInstaller.kt
+++ b/bot/toolkit-base/src/main/kotlin/BotInstaller.kt
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.instance
 import io.vertx.ext.web.Router
+import io.vertx.kotlin.coroutines.CoroutineRouterSupport
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -55,8 +56,19 @@ fun registerAndInstallBot(
     additionalModules: List<Kodein.Module> = emptyList(),
     vararg routerHandlers: (Router) -> Unit,
 ) {
+    registerAndInstallBot(botDefinition, additionalModules, routerHandlers.map { handler -> { handler(it) } })
+}
+
+/**
+ * Register and install a new bot.
+ */
+fun registerAndInstallBot(
+    botDefinition: BotDefinition,
+    additionalModules: List<Kodein.Module> = emptyList(),
+    routerHandlers: List<CoroutineRouterSupport.(Router) -> Unit>,
+) {
     registerBot(botDefinition)
-    installBots(routerHandlers.toList(), additionalModules)
+    installBots(routerHandlers, additionalModules)
 }
 
 /**
@@ -67,19 +79,30 @@ fun registerAndInstallBot(
     additionalModules: List<Kodein.Module> = emptyList(),
     vararg routerHandlers: (Router) -> Unit,
 ) {
+    registerAndInstallBot(botProvider, additionalModules, routerHandlers.map { handler -> { handler(it) } })
+}
+
+/**
+ * Register and install a new bot.
+ */
+fun registerAndInstallBot(
+    botProvider: BotProvider,
+    additionalModules: List<Kodein.Module> = emptyList(),
+    routerHandlers: List<CoroutineRouterSupport.(Router) -> Unit>,
+) {
     registerBot(botProvider)
-    installBots(routerHandlers.toList(), additionalModules)
+    installBots(routerHandlers, additionalModules)
 }
 
 /**
  * Install the bot(s) with the specified additional router handlers and additional Tock Modules
  */
 private fun installBots(
-    routerHandlers: List<(Router) -> Unit>,
+    routerHandlers: List<CoroutineRouterSupport.(Router) -> Unit>,
     additionalModules: List<Kodein.Module> = emptyList(),
 ) {
     BotIoc.setup(additionalModules)
-    BotRepository.installBots(routerHandlers.toList())
+    BotRepository.installBots(routerHandlers)
 }
 
 /**

--- a/nlp/admin/server/pom.xml
+++ b/nlp/admin/server/pom.xml
@@ -47,6 +47,10 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-common</artifactId>
         </dependency>
 

--- a/nlp/api/client/src/main/kotlin/TockNlpClient.kt
+++ b/nlp/api/client/src/main/kotlin/TockNlpClient.kt
@@ -83,7 +83,9 @@ class TockNlpClient(baseUrl: String = System.getenv("tock_nlp_service_url") ?: "
                         .writeTimeout(timeout, TimeUnit.MILLISECONDS)
                         .addInterceptor(
                             // adapt log level to use specific log interceptors
-                            HttpLoggingInterceptor().setLevel(
+                            HttpLoggingInterceptor { msg ->
+                                logger.debug(msg)
+                            }.setLevel(
                                 HttpLoggingInterceptor.Level.valueOf(
                                     retrofitLogLevel(
                                         retrofitDefaultLogLevel,

--- a/nlp/api/service/pom.xml
+++ b/nlp/api/service/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>vertx-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
         </dependency>

--- a/nlp/build-model-worker/pom.xml
+++ b/nlp/build-model-worker/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>vertx-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ai.tock</groupId>
             <artifactId>tock-nlp-front-ioc</artifactId>
         </dependency>

--- a/nlp/entity-evaluator/duckling/service/pom.xml
+++ b/nlp/entity-evaluator/duckling/service/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>vertx-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ai.tock</groupId>
             <artifactId>tock-nlp-duckling-duckling</artifactId>
             <classifier>jar-dependencies</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,11 @@
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
+                <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+                <version>${vertx}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
                 <artifactId>vertx-auth-common</artifactId>
                 <version>${vertx}</version>
             </dependency>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -191,6 +191,11 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
+            <artifactId>vertx-lang-kotlin-coroutines</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-common</artifactId>
         </dependency>
         <dependency>

--- a/shared/src/main/kotlin/vertx/WebVerticle.kt
+++ b/shared/src/main/kotlin/vertx/WebVerticle.kt
@@ -39,7 +39,6 @@ import ai.tock.shared.security.auth.TockAuthProvider
 import ai.tock.shared.security.auth.spi.CASAuthProviderFactory
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.vertx.core.AbstractVerticle
 import io.vertx.core.AsyncResult
 import io.vertx.core.Future
 import io.vertx.core.Handler
@@ -61,6 +60,9 @@ import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.ext.web.handler.ErrorHandler
 import io.vertx.ext.web.handler.SessionHandler
 import io.vertx.ext.web.sstore.LocalSessionStore
+import io.vertx.kotlin.coroutines.CoroutineVerticle
+import io.vertx.kotlin.coroutines.awaitBlocking
+import io.vertx.kotlin.coroutines.coAwait
 import mu.KLogger
 import mu.KotlinLogging
 import org.litote.kmongo.Id
@@ -76,7 +78,7 @@ import kotlin.LazyThreadSafetyMode.PUBLICATION
 /**
  * Base class for web Tock [io.vertx.core.Verticle]s. Provides utility methods.
  */
-abstract class WebVerticle : AbstractVerticle() {
+abstract class WebVerticle : CoroutineVerticle() {
     companion object {
         fun unauthorized(): Nothing = throw UnauthorizedException()
 
@@ -204,49 +206,35 @@ abstract class WebVerticle : AbstractVerticle() {
         return result
     }
 
-    override fun start(promise: Promise<Void>) {
-        // Handle server started event by emitting an eventbus message to address 'server.started'
-        promise.future()
-            .onComplete { ar ->
-                vertx.eventBus().publish(ServerStatus.SERVER_STARTED, ar.succeeded())
+    override suspend fun start() {
+        awaitBlocking {
+            try {
+                router.route().handler(bodyHandler())
+                addDevCorsHandler()
+                cachedAuthProvider?.also { pvd -> addAuth(pvd) }
+
+                healthcheckPath?.let { path -> router.get(path).handler(healthcheck()) }
+                livenesscheckPath?.let { path -> router.get(path).handler(livenesscheck()) }
+                readinesscheckPath?.let { path -> router.get(path).handler(readinesscheck()) }
+
+                configure()
+            } catch (t: JsonProcessingException) {
+                logger.error(t)
+                throw BadRequestException(t.message ?: "")
+            } catch (t: Throwable) {
+                logger.error(t)
+                throw t
             }
-
-        vertx.blocking<Unit>(
-            { p: Promise<Unit> ->
-                try {
-                    router.route().handler(bodyHandler())
-                    addDevCorsHandler()
-                    cachedAuthProvider?.also { pvd -> addAuth(pvd) }
-
-                    healthcheckPath?.let { path -> router.get(path).handler(healthcheck()) }
-                    livenesscheckPath?.let { path -> router.get(path).handler(livenesscheck()) }
-                    readinesscheckPath?.let { path -> router.get(path).handler(readinesscheck()) }
-
-                    configure()
-                    p.complete()
-                } catch (t: JsonProcessingException) {
-                    logger.error(t)
-                    p.fail(BadRequestException(t.message ?: ""))
-                } catch (t: Throwable) {
-                    logger.error(t)
-                    p.fail(t)
-                } finally {
-                    p.tryFail("call not completed")
-                }
-            },
-            { ar ->
-                if (ar.succeeded()) {
-                    startServer(promise)
-                } else {
-                    promise.fail(ar.cause())
-                }
-            },
-        )
+        }
+        Future.future(this::startServer).coAwait()
+        // Handle server started event by emitting an eventbus message to address 'server.started'
+        vertx.eventBus().publish(ServerStatus.SERVER_STARTED, true)
     }
 
-    override fun stop() {
+    override suspend fun stop() {
         server.close()
             .onComplete { ar -> logger.info { "$verticleName stopped result : ${ar.succeeded()}" } }
+            .coAwait()
     }
 
     fun addAuth(

--- a/shared/src/main/kotlin/vertx/WebVerticle.kt
+++ b/shared/src/main/kotlin/vertx/WebVerticle.kt
@@ -309,27 +309,27 @@ abstract class WebVerticle : CoroutineVerticle() {
             }
     }
 
-    private fun verticleProperty(propertyName: String) = "${verticleName.lowercase()}_$propertyName"
+    protected open fun verticlePropertyName(propertyName: String) = "${verticleName.lowercase()}_$propertyName"
 
     protected fun verticleIntProperty(
         propertyName: String,
         defaultValue: Int,
-    ): Int = intProperty(verticleProperty(propertyName), defaultValue)
+    ): Int = intProperty(verticlePropertyName(propertyName), defaultValue)
 
     protected fun verticleLongProperty(
         propertyName: String,
         defaultValue: Long,
-    ): Long = longProperty(verticleProperty(propertyName), defaultValue)
+    ): Long = longProperty(verticlePropertyName(propertyName), defaultValue)
 
     protected fun verticleBooleanProperty(
         propertyName: String,
         defaultValue: Boolean,
-    ): Boolean = booleanProperty(verticleProperty(propertyName), defaultValue)
+    ): Boolean = booleanProperty(verticlePropertyName(propertyName), defaultValue)
 
     protected fun verticleProperty(
         propertyName: String,
         defaultValue: String,
-    ): String = property(verticleProperty(propertyName), defaultValue)
+    ): String = property(verticlePropertyName(propertyName), defaultValue)
 
     protected fun register(
         method: HttpMethod,


### PR DESCRIPTION
resolves #2027 by adding a new `pushNotification` suspending method, which is equivalent to `notify`, but waits for the notification process to end and rethrows any error.

This requires cross-cutting changes to the engine to run the whole chain on coroutines. To leverage this new suspending code, this PR adds a dependency on `vertx-lang-kotlin-coroutines` and updates `WebVerticle` to extend `CoroutineVerticle`. This should not constitute a breaking change, especially considering these classes are pretty much for internal use only.

> [!WARNING]
> The `Connector#notify` method is now marked `suspend`, which is a breaking change. The risk of third-party connector implementations breaking is however quite low, considering this method is optional to implement, and its contract is left rather vague for custom implementations.