### PR TITLE
[DERCBOT-1794] Dataset run evaluation feature

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -45,6 +45,7 @@ import ai.tock.bot.admin.bot.rag.BotRAGConfiguration
 import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
 import ai.tock.bot.admin.bot.sentencegeneration.BotSentenceGenerationConfigurationDAO
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
+import ai.tock.bot.admin.dataset.DatasetDAO
 import ai.tock.bot.admin.dialog.ApplicationDialogFlowData
 import ai.tock.bot.admin.dialog.CountResult
 import ai.tock.bot.admin.dialog.DialogReport
@@ -150,6 +151,7 @@ object BotAdminService {
     private val observabilityConfigurationDAO: BotObservabilityConfigurationDAO get() = injector.provide()
     private val documentProcessorConfigurationDAO: BotDocumentCompressorConfigurationDAO get() = injector.provide()
     private val vectorStoreConfigurationDAO: BotVectorStoreConfigurationDAO get() = injector.provide()
+    private val datasetDAO: DatasetDAO get() = injector.provide()
     private val storyDefinitionDAO: StoryDefinitionConfigurationDAO get() = injector.provide()
     private val featureDAO: FeatureDAO get() = injector.provide()
     private val dialogFlowDAO: DialogFlowDAO get() = injector.provide()
@@ -1654,6 +1656,8 @@ object BotAdminService {
             vectorStoreConfigurationDAO.delete(config._id)
             SecurityUtils.deleteSecret(config.setting.password)
         }
+
+        datasetDAO.deleteByNamespaceAndBotId(app.namespace, app.name)
 
         // delete Indicators and Metrics
         indicatorDAO.deleteByApplicationName(app.namespace, app.name)

--- a/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminVerticle.kt
@@ -44,10 +44,12 @@ import ai.tock.bot.admin.model.SummaryStorySearchRequest
 import ai.tock.bot.admin.model.UserSearchQuery
 import ai.tock.bot.admin.module.satisfactionContentModule
 import ai.tock.bot.admin.service.DataMigrationService
+import ai.tock.bot.admin.service.DatasetRunWorker
 import ai.tock.bot.admin.service.SynchronizationService
 import ai.tock.bot.admin.story.dump.StoryDefinitionConfigurationDumpImport
 import ai.tock.bot.admin.test.TestPlanService
 import ai.tock.bot.admin.test.findTestService
+import ai.tock.bot.admin.verticle.DatasetsVerticle
 import ai.tock.bot.admin.verticle.DialogVerticle
 import ai.tock.bot.admin.verticle.EvaluationVerticle
 import ai.tock.bot.admin.verticle.GenAIVerticle
@@ -101,6 +103,7 @@ open class BotAdminVerticle : AdminVerticle() {
     private val indicatorVerticle = IndicatorVerticle()
     private val dialogVerticle = DialogVerticle()
     private val aiVerticle = GenAIVerticle()
+    private val datasetsVerticle = DatasetsVerticle()
     private val evaluationVerticle = EvaluationVerticle()
 
     override val logger: KLogger = KotlinLogging.logger {}
@@ -120,6 +123,8 @@ open class BotAdminVerticle : AdminVerticle() {
     override fun configureServices() {
         vertx.eventBus().consumer<Boolean>(ServerStatus.SERVER_STARTED) {
             if (it.body()) {
+                DatasetRunWorker.start()
+
                 if (booleanProperty(Properties.FAQ_MIGRATION_ENABLED, false)) {
                     FaqAdminService.makeMigration()
                 }
@@ -163,6 +168,7 @@ open class BotAdminVerticle : AdminVerticle() {
         indicatorVerticle.configure(this)
         dialogVerticle.configure(this)
         aiVerticle.configure(this)
+        datasetsVerticle.configure(this)
         evaluationVerticle.configure(this)
 
         blockingJsonPost("/users/search", botUser) { context, query: UserSearchQuery ->

--- a/bot/admin/server/src/main/kotlin/model/dataset/Requests.kt
+++ b/bot/admin/server/src/main/kotlin/model/dataset/Requests.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.model.dataset
+
+import ai.tock.bot.admin.model.ToValidate
+import ai.tock.shared.intProperty
+
+private const val DATASET_MAX_QUESTIONS_PROPERTY = "tock_datasets_max_questions"
+private const val DEFAULT_MAX_QUESTIONS = 200
+
+private val datasetMaxQuestions: Int by lazy {
+    intProperty(DATASET_MAX_QUESTIONS_PROPERTY, DEFAULT_MAX_QUESTIONS)
+}
+
+data class DatasetQuestionRequest(
+    val id: String? = null,
+    val question: String,
+    val groundTruth: String? = null,
+)
+
+data class DatasetCreateRequest(
+    val name: String,
+    val description: String = "",
+    val questions: List<DatasetQuestionRequest>,
+) : ToValidate {
+    override fun validate(): List<String> = validateDatasetRequest(name, questions)
+}
+
+data class DatasetUpdateRequest(
+    val name: String,
+    val description: String = "",
+    val questions: List<DatasetQuestionRequest>,
+) : ToValidate {
+    override fun validate(): List<String> = validateDatasetRequest(name, questions)
+}
+
+data class DatasetRunCreateRequest(
+    val language: String,
+) : ToValidate {
+    override fun validate(): List<String> {
+        val trimmedLanguage = language.trim()
+        return if (trimmedLanguage.isEmpty()) {
+            listOf("language is required")
+        } else {
+            emptyList()
+        }
+    }
+}
+
+data class DatasetRunCancelRequest(
+    val ignored: Boolean? = null,
+)
+
+private fun validateDatasetRequest(
+    name: String,
+    questions: List<DatasetQuestionRequest>,
+): List<String> {
+    val errors = mutableListOf<String>()
+
+    if (name.isBlank()) {
+        errors.add("Dataset name is required")
+    }
+
+    if (questions.isEmpty()) {
+        errors.add("Dataset must contain at least one question")
+    }
+
+    if (questions.size > datasetMaxQuestions) {
+        errors.add("Dataset must not contain more than $datasetMaxQuestions questions")
+    }
+
+    questions.forEachIndexed { index, question ->
+        val questionLabel = "Question #${index + 1}"
+        val trimmedQuestion = question.question.trim()
+
+        if (trimmedQuestion.isEmpty()) {
+            errors.add("$questionLabel is required")
+        }
+    }
+
+    return errors
+}

--- a/bot/admin/server/src/main/kotlin/model/dataset/Responses.kt
+++ b/bot/admin/server/src/main/kotlin/model/dataset/Responses.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.model.dataset
+
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.bot.admin.dialog.ActionReport
+import com.fasterxml.jackson.annotation.JsonInclude
+import java.time.Instant
+
+data class DatasetQuestionDTO(
+    val id: String,
+    val question: String,
+    val groundTruth: String?,
+)
+
+data class DatasetRunStatsDTO(
+    val totalQuestions: Int,
+    val completedQuestions: Int,
+    val failedQuestions: Int,
+)
+
+data class DatasetRunDTO(
+    val id: String,
+    val state: DatasetRunState,
+    val startTime: Instant,
+    val endTime: Instant?,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val settingsSnapshot: Map<String, Any?>? = null,
+    val startedBy: String,
+    val stats: DatasetRunStatsDTO,
+)
+
+data class DatasetDTO(
+    val id: String,
+    val name: String,
+    val description: String,
+    val questions: List<DatasetQuestionDTO>,
+    val runs: List<DatasetRunDTO>,
+    val createdAt: Instant,
+    val createdBy: String,
+    val updatedAt: Instant?,
+    val updatedBy: String?,
+)
+
+enum class DatasetRunActionState {
+    COMPLETED,
+    FAILED,
+}
+
+data class DatasetRunActionDTO(
+    val datasetId: String,
+    val runId: String,
+    val questionId: String,
+    val state: DatasetRunActionState,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    val action: ActionReport?,
+    val retryCount: Int,
+)

--- a/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetQuestion
+import ai.tock.bot.admin.dataset.DatasetRun
+import ai.tock.bot.admin.dataset.DatasetRunDAO
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.bot.admin.test.TestTalkService
+import ai.tock.bot.admin.test.model.BotDialogResponse
+import ai.tock.bot.engine.message.Sentence
+import ai.tock.shared.Executor
+import ai.tock.shared.injector
+import ai.tock.shared.intProperty
+import ai.tock.shared.longProperty
+import ai.tock.shared.provide
+import mu.KotlinLogging
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val DATASET_RUN_WORKER_POLL_INTERVAL_PROPERTY = "tock_dataset_run_worker_poll_interval_ms"
+private const val DATASET_RUN_WORKER_MAX_RETRIES_PROPERTY = "tock_dataset_run_worker_max_retries"
+private const val DEFAULT_DATASET_RUN_WORKER_POLL_INTERVAL_MS = 2000L
+private const val DEFAULT_DATASET_RUN_WORKER_MAX_RETRIES = 0
+private val MIN_TIMER_DELAY: Duration = Duration.ofMillis(1)
+
+fun interface DatasetQuestionExecutor {
+    fun execute(
+        run: DatasetRun,
+        questionResult: DatasetRunQuestionResult,
+        question: DatasetQuestion,
+    ): BotDialogResponse
+}
+
+object DefaultDatasetQuestionExecutor : DatasetQuestionExecutor {
+    override fun execute(
+        run: DatasetRun,
+        questionResult: DatasetRunQuestionResult,
+        question: DatasetQuestion,
+    ): BotDialogResponse =
+        TestTalkService.talk(
+            botApplicationConfigurationId =
+                run.botApplicationConfigurationId
+                    ?: error("Missing botApplicationConfigurationId for dataset run ${run._id}"),
+            namespace = run.namespace,
+            message = Sentence(question.question),
+            language = run.language,
+            userIdModifier = buildUserIdModifier(questionResult),
+            debugEnabled = true,
+            sourceWithContent = true,
+        )
+
+    private fun buildUserIdModifier(questionResult: DatasetRunQuestionResult): String =
+        if (questionResult.retryCount == 0) {
+            questionResult.userIdModifier
+        } else {
+            "${questionResult.userIdModifier}_retry${questionResult.retryCount}"
+        }
+}
+
+class DatasetRunProcessor(
+    private val datasetDAO: DatasetDAO = injector.provide(),
+    private val datasetRunDAO: DatasetRunDAO = injector.provide(),
+    private val questionExecutor: DatasetQuestionExecutor = DefaultDatasetQuestionExecutor,
+    private val maxRetries: Int = intProperty(DATASET_RUN_WORKER_MAX_RETRIES_PROPERTY, DEFAULT_DATASET_RUN_WORKER_MAX_RETRIES),
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    private val logger = KotlinLogging.logger {}
+
+    fun processNextQueuedRun(): Boolean {
+        val run = datasetRunDAO.claimNextQueuedRun() ?: return false
+        processRun(run)
+        return true
+    }
+
+    internal fun processRun(run: DatasetRun) {
+        val dataset = datasetDAO.getDatasetById(run.datasetId)
+        if (dataset == null) {
+            logger.warn { "Dataset ${run.datasetId} not found for run ${run._id}. Marking run as cancelled." }
+            datasetRunDAO.saveRun(run.copy(state = DatasetRunState.CANCELLED, endTime = now()))
+            return
+        }
+
+        val questionResultsById =
+            datasetRunDAO.getQuestionResultsByRunId(run._id)
+                .associateBy { it.questionId }
+                .toMutableMap()
+
+        dataset.questions.forEach { question ->
+            val refreshedRun = datasetRunDAO.getRunById(run._id) ?: return
+            if (refreshedRun.state == DatasetRunState.CANCELLED) {
+                return
+            }
+
+            val questionResult = questionResultsById[question.id] ?: return@forEach
+            if (questionResult.state.isTerminal()) {
+                return@forEach
+            }
+
+            questionResultsById[question.id] = executeQuestion(refreshedRun, question, questionResult)
+        }
+
+        val finalRun = datasetRunDAO.getRunById(run._id) ?: return
+        if (finalRun.state != DatasetRunState.CANCELLED) {
+            datasetRunDAO.saveRun(finalRun.copy(state = DatasetRunState.COMPLETED, endTime = now()))
+        }
+    }
+
+    private fun executeQuestion(
+        run: DatasetRun,
+        question: DatasetQuestion,
+        questionResult: DatasetRunQuestionResult,
+    ): DatasetRunQuestionResult {
+        var currentResult =
+            datasetRunDAO.saveQuestionResult(
+                questionResult.copy(
+                    state = DatasetRunQuestionResultState.RUNNING,
+                    startedAt = questionResult.startedAt ?: now(),
+                    endedAt = null,
+                    error = null,
+                ),
+            )
+
+        while (true) {
+            val outcome =
+                runCatching {
+                    questionExecutor.execute(run, currentResult, question)
+                }
+
+            val response = outcome.getOrNull()
+            if (response?.userActionId != null) {
+                return datasetRunDAO.saveQuestionResult(
+                    currentResult.copy(
+                        state = DatasetRunQuestionResultState.COMPLETED,
+                        endedAt = now(),
+                        userActionId = response.userActionId,
+                        error = null,
+                    ),
+                )
+            }
+
+            val errorMessage = outcome.exceptionOrNull()?.message ?: response.toFailureMessage()
+            if (currentResult.retryCount >= maxRetries) {
+                return datasetRunDAO.saveQuestionResult(
+                    currentResult.copy(
+                        state = DatasetRunQuestionResultState.FAILED,
+                        endedAt = now(),
+                        error = errorMessage,
+                    ),
+                )
+            }
+
+            currentResult =
+                datasetRunDAO.saveQuestionResult(
+                    currentResult.copy(
+                        retryCount = currentResult.retryCount + 1,
+                        error = errorMessage,
+                    ),
+                )
+        }
+    }
+
+    private fun DatasetRunQuestionResultState.isTerminal(): Boolean =
+        this == DatasetRunQuestionResultState.COMPLETED ||
+            this == DatasetRunQuestionResultState.FAILED ||
+            this == DatasetRunQuestionResultState.CANCELLED
+
+    private fun BotDialogResponse?.toFailureMessage(): String =
+        this?.messages?.takeIf { it.isNotEmpty() }?.joinToString(separator = " | ") { it.toString() }
+            ?: "Talk execution did not return a userActionId"
+
+    private fun now(): Instant = Instant.now(clock)
+}
+
+object DatasetRunWorker {
+    private val logger = KotlinLogging.logger {}
+    private val started = AtomicBoolean(false)
+    private val processing = AtomicBoolean(false)
+    private val pollInterval =
+        Duration.ofMillis(
+            longProperty(
+                DATASET_RUN_WORKER_POLL_INTERVAL_PROPERTY,
+                DEFAULT_DATASET_RUN_WORKER_POLL_INTERVAL_MS,
+            ),
+        )
+
+    private val executor: Executor by lazy { injector.provide() }
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) {
+            return
+        }
+
+        executor.setPeriodic(MIN_TIMER_DELAY, pollInterval) {
+            triggerProcessing()
+        }
+    }
+
+    private fun triggerProcessing() {
+        if (!processing.compareAndSet(false, true)) {
+            return
+        }
+
+        executor.executeBlocking {
+            try {
+                val processor = DatasetRunProcessor()
+                while (processor.processNextQueuedRun()) {
+                    // Drain the queue while we own the worker slot.
+                }
+            } catch (e: Exception) {
+                logger.error(e) { "Dataset run worker execution failed." }
+            } finally {
+                processing.set(false)
+            }
+        }
+    }
+}

--- a/bot/admin/server/src/main/kotlin/service/DatasetService.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetService.kt
@@ -1,0 +1,557 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
+import ai.tock.bot.admin.dataset.Dataset
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetQuestion
+import ai.tock.bot.admin.dataset.DatasetRun
+import ai.tock.bot.admin.dataset.DatasetRunDAO
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.bot.admin.dialog.ActionReport
+import ai.tock.bot.admin.dialog.DialogReport
+import ai.tock.bot.admin.dialog.DialogReportDAO
+import ai.tock.bot.admin.dialog.DialogReportQuery
+import ai.tock.bot.admin.model.dataset.DatasetCreateRequest
+import ai.tock.bot.admin.model.dataset.DatasetDTO
+import ai.tock.bot.admin.model.dataset.DatasetQuestionDTO
+import ai.tock.bot.admin.model.dataset.DatasetQuestionRequest
+import ai.tock.bot.admin.model.dataset.DatasetRunActionDTO
+import ai.tock.bot.admin.model.dataset.DatasetRunActionState
+import ai.tock.bot.admin.model.dataset.DatasetRunCreateRequest
+import ai.tock.bot.admin.model.dataset.DatasetRunDTO
+import ai.tock.bot.admin.model.dataset.DatasetRunStatsDTO
+import ai.tock.bot.admin.model.dataset.DatasetUpdateRequest
+import ai.tock.bot.admin.model.genai.BotRAGConfigurationDTO
+import ai.tock.bot.admin.test.TestTalkService
+import ai.tock.bot.connector.ConnectorType
+import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.dialog.Dialog
+import ai.tock.bot.engine.event.EventType
+import ai.tock.bot.engine.user.PlayerId
+import ai.tock.bot.engine.user.PlayerType
+import ai.tock.shared.Dice
+import ai.tock.shared.injector
+import ai.tock.shared.provide
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.litote.kmongo.Id
+import org.litote.kmongo.toId
+import java.time.Instant
+import java.util.Locale
+
+object DatasetService {
+    private val datasetDAO: DatasetDAO get() = injector.provide()
+    private val datasetRunDAO: DatasetRunDAO get() = injector.provide()
+    private val applicationConfigurationDAO: BotApplicationConfigurationDAO get() = injector.provide()
+    private val ragConfigurationDAO: BotRAGConfigurationDAO get() = injector.provide()
+    private val dialogReportDAO: DialogReportDAO get() = injector.provide()
+    private val objectMapper = jacksonObjectMapper()
+
+    fun listDatasets(
+        namespace: String,
+        botId: String,
+    ): List<DatasetDTO> =
+        datasetDAO.getDatasetsByNamespaceAndBotId(namespace, botId)
+            .map { dataset ->
+                val runs = datasetRunDAO.getRunsByDatasetId(dataset._id)
+                dataset.toDTO(
+                    runs = runs,
+                    includeSettingsSnapshot = false,
+                )
+            }
+
+    fun getDataset(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+    ): DatasetDTO {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        val runs = datasetRunDAO.getRunsByDatasetId(dataset._id)
+        return dataset.toDTO(
+            runs = runs,
+            includeSettingsSnapshot = true,
+        )
+    }
+
+    fun createDataset(
+        namespace: String,
+        botId: String,
+        request: DatasetCreateRequest,
+        userLogin: String,
+    ): DatasetDTO {
+        val now = Instant.now()
+        val dataset =
+            Dataset(
+                namespace = namespace,
+                botId = botId,
+                name = request.name.trim(),
+                description = request.description.trim(),
+                questions = request.questions.toDomainQuestions(),
+                createdAt = now,
+                createdBy = userLogin,
+            )
+
+        return datasetDAO.save(dataset).toDTO(
+            runs = emptyList(),
+            includeSettingsSnapshot = false,
+        )
+    }
+
+    fun createRun(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        request: DatasetRunCreateRequest,
+        userLogin: String,
+    ): DatasetRunDTO {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        ensureNoActiveRuns(dataset)
+
+        val testConfiguration = resolveTestRestConfiguration(namespace, botId)
+        val now = Instant.now()
+        val languageTag = request.language.trim()
+
+        val savedRun =
+            datasetRunDAO.saveRun(
+                DatasetRun(
+                    namespace = namespace,
+                    botId = botId,
+                    datasetId = dataset._id,
+                    state = DatasetRunState.QUEUED,
+                    startTime = now,
+                    startedBy = userLogin,
+                    language = Locale.forLanguageTag(languageTag),
+                    botApplicationConfigurationId = testConfiguration._id,
+                    settingsSnapshot = buildSettingsSnapshot(namespace, botId),
+                ),
+            )
+
+        datasetRunDAO.saveQuestionResults(
+            dataset.questions.map { question ->
+                DatasetRunQuestionResult(
+                    namespace = namespace,
+                    botId = botId,
+                    datasetId = dataset._id,
+                    runId = savedRun._id,
+                    questionId = question.id,
+                    userIdModifier = "dataset_${savedRun._id}_${question.id}",
+                )
+            },
+        )
+
+        val questionResults = datasetRunDAO.getQuestionResultsByRunId(savedRun._id)
+        return savedRun.toDTO(
+            includeSettingsSnapshot = false,
+            stats = questionResults.toStats(),
+        )
+    }
+
+    fun updateDataset(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        request: DatasetUpdateRequest,
+        userLogin: String,
+    ): DatasetDTO {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        ensureNoActiveRuns(dataset)
+
+        val updated =
+            dataset.copy(
+                name = request.name.trim(),
+                description = request.description.trim(),
+                questions = request.questions.toDomainQuestions(),
+                updatedAt = Instant.now(),
+                updatedBy = userLogin,
+            )
+
+        return datasetDAO.save(updated).toDTO(
+            runs = datasetRunDAO.getRunsByDatasetId(dataset._id),
+            includeSettingsSnapshot = false,
+        )
+    }
+
+    fun deleteDataset(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+    ) {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        ensureNoActiveRuns(dataset)
+        datasetDAO.delete(dataset._id)
+    }
+
+    fun getRun(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        runId: String,
+    ): DatasetRunDTO {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        val run = getRunEntity(namespace, botId, dataset._id.toString(), runId)
+        val questionResults = datasetRunDAO.getQuestionResultsByRunId(run._id)
+        return run.toDTO(
+            includeSettingsSnapshot = false,
+            stats = questionResults.toStats(),
+        )
+    }
+
+    fun cancelRun(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        runId: String,
+    ): DatasetRunDTO {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        val run = getRunEntity(namespace, botId, dataset._id.toString(), runId)
+
+        if (run.state != DatasetRunState.QUEUED && run.state != DatasetRunState.RUNNING) {
+            throw DatasetError.RunStateConflict(runId, run.state)
+        }
+
+        val cancelledRun = datasetRunDAO.saveRun(run.copy(state = DatasetRunState.CANCELLED, endTime = Instant.now()))
+        val updatedQuestionResults = cancelPendingQuestionResults(cancelledRun._id.toString())
+
+        return cancelledRun.toDTO(
+            includeSettingsSnapshot = false,
+            stats = updatedQuestionResults.toStats(),
+        )
+    }
+
+    fun getRunActions(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        runId: String,
+    ): List<DatasetRunActionDTO> {
+        val dataset = getDatasetEntity(namespace, botId, datasetId)
+        val run = getRunEntity(namespace, botId, dataset._id.toString(), runId)
+
+        if (run.state == DatasetRunState.QUEUED || run.state == DatasetRunState.RUNNING) {
+            throw DatasetError.RunNotFinished(runId, run.state)
+        }
+
+        val questionResults = datasetRunDAO.getQuestionResultsByRunId(run._id)
+        val dialogsById =
+            dialogReportDAO.findByDialogByIds(questionResults.mapNotNull { it.dialogId }.toSet())
+                .associateBy { it.id }
+
+        return questionResults.map { questionResult ->
+            val resolvedAction = resolveRunAction(run, questionResult, dialogsById[questionResult.dialogId])
+            DatasetRunActionDTO(
+                datasetId = run.datasetId.toString(),
+                runId = run._id.toString(),
+                questionId = questionResult.questionId,
+                state = resolvedAction.state,
+                action = resolvedAction.action,
+                retryCount = questionResult.retryCount,
+            )
+        }
+    }
+
+    private fun getDatasetEntity(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+    ): Dataset {
+        val id = datasetId.toId<Dataset>()
+        val dataset = datasetDAO.getDatasetById(id) ?: throw DatasetError.DatasetNotFound(datasetId)
+        if (dataset.namespace != namespace || dataset.botId != botId) {
+            throw DatasetError.DatasetNotFound(datasetId)
+        }
+        return dataset
+    }
+
+    private fun getRunEntity(
+        namespace: String,
+        botId: String,
+        datasetId: String,
+        runId: String,
+    ): DatasetRun {
+        val id = runId.toId<DatasetRun>()
+        val run = datasetRunDAO.getRunById(id) ?: throw DatasetError.RunNotFound(runId)
+        if (run.namespace != namespace || run.botId != botId || run.datasetId.toString() != datasetId) {
+            throw DatasetError.RunNotFound(runId)
+        }
+        return run
+    }
+
+    private fun resolveRunAction(
+        run: DatasetRun,
+        questionResult: DatasetRunQuestionResult,
+        cachedDialog: DialogReport?,
+    ): ResolvedRunAction =
+        when (questionResult.state) {
+            DatasetRunQuestionResultState.COMPLETED -> resolveCompletedRunAction(run, questionResult, cachedDialog)
+            else -> ResolvedRunAction(DatasetRunActionState.FAILED, null)
+        }
+
+    private fun resolveCompletedRunAction(
+        run: DatasetRun,
+        questionResult: DatasetRunQuestionResult,
+        cachedDialog: DialogReport?,
+    ): ResolvedRunAction {
+        cachedDialog?.let { dialog ->
+            val cachedAction = resolveActionFromDialog(dialog, questionResult)
+            if (cachedAction != null) {
+                cacheActionReferences(questionResult, dialog.id, cachedAction.id)
+                return ResolvedRunAction(DatasetRunActionState.COMPLETED, cachedAction)
+            }
+
+            if (questionResult.answerActionId != null) {
+                return ResolvedRunAction(DatasetRunActionState.COMPLETED, null)
+            }
+
+            return ResolvedRunAction(DatasetRunActionState.FAILED, null)
+        }
+
+        val searchedDialog =
+            findDialogForQuestionResult(run, questionResult)
+                ?: return ResolvedRunAction(DatasetRunActionState.COMPLETED, null)
+        val searchedAction = resolveActionFromDialog(searchedDialog, questionResult)
+
+        cacheActionReferences(questionResult, searchedDialog.id, searchedAction?.id)
+
+        return if (searchedAction != null) {
+            ResolvedRunAction(DatasetRunActionState.COMPLETED, searchedAction)
+        } else {
+            ResolvedRunAction(DatasetRunActionState.FAILED, null)
+        }
+    }
+
+    private fun resolveActionFromDialog(
+        dialog: DialogReport,
+        questionResult: DatasetRunQuestionResult,
+    ): ActionReport? {
+        questionResult.answerActionId?.let { answerActionId ->
+            dialog.actions.firstOrNull { it.id == answerActionId }?.let { return it }
+        }
+
+        val userActionIndex = dialog.actions.indexOfFirst { it.id.toString() == questionResult.userActionId }
+        if (userActionIndex == -1) {
+            return null
+        }
+
+        val candidateActions =
+            dialog.actions
+                .drop(userActionIndex + 1)
+                .takeWhile { it.playerId.type != PlayerType.user }
+                .filter { it.playerId.type == PlayerType.bot && it.message.eventType.action && it.message.eventType != EventType.debug }
+
+        return candidateActions.firstOrNull { it.message.eventType == EventType.sentenceWithFootnotes }
+            ?: candidateActions.firstOrNull { it.message.eventType == EventType.sentence }
+            ?: candidateActions.firstOrNull()
+    }
+
+    private fun findDialogForQuestionResult(
+        run: DatasetRun,
+        questionResult: DatasetRunQuestionResult,
+    ): DialogReport? {
+        val botApplicationConfigurationId = run.botApplicationConfigurationId ?: return null
+        val playerId =
+            PlayerId(
+                TestTalkService.buildTestPlayerId(
+                    botApplicationConfigurationId = botApplicationConfigurationId,
+                    language = run.language,
+                    userIdModifier = buildAttemptUserIdModifier(questionResult),
+                ),
+            )
+
+        return dialogReportDAO.search(
+            DialogReportQuery(
+                namespace = run.namespace,
+                nlpModel = run.botId,
+                start = 0,
+                size = 10,
+                playerId = playerId,
+                displayTests = true,
+            ),
+        ).dialogs.firstOrNull { dialog ->
+            dialog.actions.any { it.id.toString() == questionResult.userActionId }
+        }
+    }
+
+    private fun cacheActionReferences(
+        questionResult: DatasetRunQuestionResult,
+        dialogId: Id<Dialog>,
+        answerActionId: Id<Action>?,
+    ) {
+        if (questionResult.dialogId == dialogId && questionResult.answerActionId == answerActionId) {
+            return
+        }
+
+        datasetRunDAO.saveQuestionResult(
+            questionResult.copy(
+                dialogId = dialogId,
+                answerActionId = answerActionId,
+            ),
+        )
+    }
+
+    private fun buildAttemptUserIdModifier(questionResult: DatasetRunQuestionResult): String =
+        if (questionResult.retryCount == 0) {
+            questionResult.userIdModifier
+        } else {
+            "${questionResult.userIdModifier}_retry${questionResult.retryCount}"
+        }
+
+    private fun ensureNoActiveRuns(dataset: Dataset) {
+        if (datasetRunDAO.getActiveRunsByDatasetId(dataset._id).isNotEmpty()) {
+            throw DatasetError.ActiveRunConflict(dataset._id.toString())
+        }
+    }
+
+    private fun resolveTestRestConfiguration(
+        namespace: String,
+        botId: String,
+    ): BotApplicationConfiguration {
+        val candidates =
+            applicationConfigurationDAO.getConfigurationsByNamespaceAndBotId(namespace, botId)
+                .filter { it.connectorType == ConnectorType.rest }
+
+        return when (candidates.size) {
+            0 -> throw DatasetError.InvalidRequest("No REST test configuration found for bot $botId")
+            1 -> candidates.first()
+            else -> throw DatasetError.InvalidRequest("Multiple REST test configurations found for bot $botId")
+        }
+    }
+
+    private fun buildSettingsSnapshot(
+        namespace: String,
+        botId: String,
+    ): Map<String, Any?> {
+        val ragConfiguration = ragConfigurationDAO.findByNamespaceAndBotId(namespace, botId) ?: return emptyMap()
+
+        @Suppress("UNCHECKED_CAST")
+        val rawSnapshot = objectMapper.convertValue(BotRAGConfigurationDTO(ragConfiguration), Map::class.java) as Map<String, Any?>
+        @Suppress("UNCHECKED_CAST")
+        return sanitizeSnapshot(rawSnapshot) as Map<String, Any?>
+    }
+
+    private fun sanitizeSnapshot(value: Any?): Any? =
+        when (value) {
+            is Map<*, *> ->
+                value.entries
+                    .filter { it.key != "apiKey" }
+                    .associate { (key, nestedValue) -> key.toString() to sanitizeSnapshot(nestedValue) }
+            is Iterable<*> -> value.map { sanitizeSnapshot(it) }
+            else -> value
+        }
+
+    private fun cancelPendingQuestionResults(runId: String): List<DatasetRunQuestionResult> {
+        val results = datasetRunDAO.getQuestionResultsByRunId(runId.toId<DatasetRun>())
+        val updatedResults =
+            results.map { result ->
+                when (result.state) {
+                    DatasetRunQuestionResultState.PENDING,
+                    DatasetRunQuestionResultState.RUNNING,
+                    -> result.copy(state = DatasetRunQuestionResultState.CANCELLED, endedAt = Instant.now())
+
+                    else -> result
+                }
+            }
+
+        datasetRunDAO.saveQuestionResults(updatedResults)
+        return updatedResults
+    }
+
+    private fun List<DatasetQuestionRequest>.toDomainQuestions(): List<DatasetQuestion> =
+        map { question ->
+            DatasetQuestion(
+                id = question.id?.trim()?.takeIf(String::isNotEmpty) ?: Dice.newId(),
+                question = question.question.trim(),
+                groundTruth = question.groundTruth?.trim()?.takeIf(String::isNotEmpty),
+            )
+        }
+
+    private fun Dataset.toDTO(
+        runs: List<DatasetRun>,
+        includeSettingsSnapshot: Boolean,
+    ): DatasetDTO =
+        DatasetDTO(
+            id = _id.toString(),
+            name = name,
+            description = description,
+            questions = questions.map { it.toDTO() },
+            runs =
+                runs.map { run ->
+                    run.toDTO(
+                        includeSettingsSnapshot = includeSettingsSnapshot,
+                        stats = datasetRunDAO.getQuestionResultsByRunId(run._id).toStats(),
+                    )
+                },
+            createdAt = createdAt,
+            createdBy = createdBy,
+            updatedAt = updatedAt,
+            updatedBy = updatedBy,
+        )
+
+    private fun DatasetQuestion.toDTO(): DatasetQuestionDTO =
+        DatasetQuestionDTO(
+            id = id,
+            question = question,
+            groundTruth = groundTruth,
+        )
+
+    private fun DatasetRun.toDTO(
+        includeSettingsSnapshot: Boolean,
+        stats: DatasetRunStatsDTO,
+    ): DatasetRunDTO =
+        DatasetRunDTO(
+            id = _id.toString(),
+            state = state,
+            startTime = startTime,
+            endTime = endTime,
+            settingsSnapshot = settingsSnapshot.takeIf { includeSettingsSnapshot },
+            startedBy = startedBy,
+            stats = stats,
+        )
+
+    private fun List<DatasetRunQuestionResult>.toStats(): DatasetRunStatsDTO =
+        DatasetRunStatsDTO(
+            totalQuestions = size,
+            completedQuestions = count { it.state == DatasetRunQuestionResultState.COMPLETED },
+            failedQuestions = count { it.state == DatasetRunQuestionResultState.FAILED },
+        )
+}
+
+private data class ResolvedRunAction(
+    val state: DatasetRunActionState,
+    val action: ActionReport?,
+)
+
+sealed class DatasetError(message: String) : RuntimeException(message) {
+    class DatasetNotFound(datasetId: String) : DatasetError("Dataset $datasetId not found")
+
+    class RunNotFound(runId: String) : DatasetError("Run $runId not found")
+
+    class ActiveRunConflict(datasetId: String) :
+        DatasetError("Dataset $datasetId cannot be modified while a run is QUEUED or RUNNING")
+
+    class RunStateConflict(runId: String, state: DatasetRunState) :
+        DatasetError("Run $runId is already $state")
+
+    class RunNotFinished(runId: String, state: DatasetRunState) :
+        DatasetError("Run $runId is not yet finished, current state is $state")
+
+    class InvalidRequest(message: String) : DatasetError(message)
+}

--- a/bot/admin/server/src/main/kotlin/verticle/DatasetsVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/DatasetsVerticle.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.verticle
+
+import ai.tock.bot.admin.model.Valid
+import ai.tock.bot.admin.model.ValidationError
+import ai.tock.bot.admin.model.dataset.DatasetCreateRequest
+import ai.tock.bot.admin.model.dataset.DatasetRunCancelRequest
+import ai.tock.bot.admin.model.dataset.DatasetRunCreateRequest
+import ai.tock.bot.admin.model.dataset.DatasetUpdateRequest
+import ai.tock.bot.admin.service.DatasetError
+import ai.tock.bot.admin.service.DatasetService
+import ai.tock.nlp.front.client.FrontClient
+import ai.tock.nlp.front.shared.config.ApplicationDefinition
+import ai.tock.shared.exception.rest.NotFoundException
+import ai.tock.shared.security.TockUserRole
+import ai.tock.shared.vertx.WebVerticle
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.vertx.core.http.HttpMethod
+import io.vertx.ext.web.RoutingContext
+import mu.KotlinLogging
+
+class DatasetsVerticle {
+    companion object {
+        private const val PATH_PARAM_BOT_ID = "botId"
+        private const val PATH_PARAM_DATASET_ID = "datasetId"
+        private const val PATH_PARAM_RUN_ID = "runId"
+        private const val PATH_DATASETS = "/bots/:$PATH_PARAM_BOT_ID/datasets"
+        private const val PATH_DATASET = "$PATH_DATASETS/:$PATH_PARAM_DATASET_ID"
+        private const val PATH_RUNS = "$PATH_DATASET/runs"
+        private const val PATH_RUN = "$PATH_RUNS/:$PATH_PARAM_RUN_ID"
+        private const val PATH_RUN_ACTIONS = "$PATH_RUN/actions"
+        private const val PATH_RUN_CANCEL = "$PATH_RUN/cancel"
+    }
+
+    private val front = FrontClient
+
+    fun configure(webVerticle: WebVerticle) {
+        val authorizedRoles =
+            setOf(
+                TockUserRole.botUser,
+                TockUserRole.admin,
+                TockUserRole.technicalAdmin,
+            )
+
+        with(webVerticle) {
+            val currentContextApp: (RoutingContext) -> ApplicationDefinition? = { context ->
+                val botId = context.pathParam(PATH_PARAM_BOT_ID)
+                val namespace = context.organization
+                front.getApplicationByNamespaceAndName(namespace, botId)
+                    ?: throw NotFoundException(404, "Could not find $botId in namespace $namespace")
+            }
+
+            blockingJsonGet(PATH_DATASETS, authorizedRoles) { context ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.listDatasets(app.namespace, app.name)
+                    }
+                }
+            }
+
+            blockingJsonGet(PATH_DATASET, authorizedRoles) { context ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.getDataset(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                        )
+                    }
+                }
+            }
+
+            blockingJsonPost(PATH_DATASETS, authorizedRoles) { context, request: DatasetCreateRequest ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context, created = true) {
+                        Valid(request)
+                        DatasetService.createDataset(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            request = request,
+                            userLogin = context.userLogin,
+                        )
+                    }
+                }
+            }
+
+            blockingJsonPost(PATH_RUNS, authorizedRoles) { context, request: DatasetRunCreateRequest ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context, created = true) {
+                        Valid(request)
+                        DatasetService.createRun(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                            request = request,
+                            userLogin = context.userLogin,
+                        )
+                    }
+                }
+            }
+
+            blockingJsonPut(PATH_DATASET, authorizedRoles) { context, request: DatasetUpdateRequest ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        Valid(request)
+                        DatasetService.updateDataset(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                            request = request,
+                            userLogin = context.userLogin,
+                        )
+                    }
+                }
+            }
+
+            blockingJsonGet(PATH_RUN, authorizedRoles) { context ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.getRun(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                            runId = context.pathParam(PATH_PARAM_RUN_ID),
+                        )
+                    }
+                }
+            }
+
+            blockingJsonGet(PATH_RUN_ACTIONS, authorizedRoles) { context ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.getRunActions(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                            runId = context.pathParam(PATH_PARAM_RUN_ID),
+                        )
+                    }
+                }
+            }
+
+            blockingJsonPost(PATH_RUN_CANCEL, authorizedRoles) { context, _: DatasetRunCancelRequest ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.cancelRun(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                            runId = context.pathParam(PATH_PARAM_RUN_ID),
+                        )
+                    }
+                }
+            }
+
+            blockingDeleteEmptyResponse(PATH_DATASET, authorizedRoles) { context ->
+                checkNamespaceAndExecute(context, currentContextApp) { app ->
+                    tryExecuteDataset(context) {
+                        DatasetService.deleteDataset(
+                            namespace = app.namespace,
+                            botId = app.name,
+                            datasetId = context.pathParam(PATH_PARAM_DATASET_ID),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun <T> tryExecuteDataset(
+    context: RoutingContext,
+    created: Boolean = false,
+    block: () -> T,
+): T? =
+    try {
+        if (created && context.request().method() == HttpMethod.POST) {
+            context.response().statusCode = 201
+        }
+        block()
+    } catch (e: Exception) {
+        val statusCode =
+            when (e) {
+                is ValidationError -> 400
+                is IllegalArgumentException -> 400
+                is DatasetError.InvalidRequest -> 400
+                is DatasetError.ActiveRunConflict -> 409
+                is DatasetError.DatasetNotFound -> 404
+                is DatasetError.RunNotFound -> 404
+                is DatasetError.RunStateConflict -> 409
+                is DatasetError.RunNotFinished -> 409
+                is NotFoundException -> 404
+                else -> 500
+            }
+
+        KotlinLogging.logger {}.error(e) { "Datasets API error: ${e.message}" }
+
+        context.response()
+            .setStatusCode(statusCode)
+            .end(ObjectMapper().writeValueAsString(ErrorMessage(e.message)))
+
+        null
+    }

--- a/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.dataset.Dataset
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetQuestion
+import ai.tock.bot.admin.dataset.DatasetRun
+import ai.tock.bot.admin.dataset.DatasetRunDAO
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.bot.admin.test.model.BotDialogResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.litote.kmongo.newId
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class DatasetRunProcessorTest {
+    private val datasetDAO: DatasetDAO = mockk(relaxed = false)
+    private val datasetRunDAO: DatasetRunDAO = mockk(relaxed = false)
+    private val fixedClock = Clock.fixed(Instant.parse("2026-03-23T10:00:00Z"), ZoneOffset.UTC)
+
+    @Test
+    fun `processNextQueuedRun completes the run when all questions succeed`() {
+        val dataset = newDataset()
+        val run = newRun(dataset)
+        val firstQuestion = dataset.questions.first()
+        val secondQuestion = dataset.questions.last()
+        val firstResult = newQuestionResult(run, dataset, firstQuestion.id)
+        val secondResult = newQuestionResult(run, dataset, secondQuestion.id)
+        val savedQuestionResults = mutableListOf<DatasetRunQuestionResult>()
+        val savedRuns = mutableListOf<DatasetRun>()
+
+        every { datasetRunDAO.claimNextQueuedRun() } returns run
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(firstResult, secondResult)
+        every { datasetRunDAO.getRunById(any()) } returns run.copy(state = DatasetRunState.RUNNING)
+        every { datasetRunDAO.saveQuestionResult(any()) } answers {
+            firstArg<DatasetRunQuestionResult>().also { savedQuestionResults.add(it) }
+        }
+        every { datasetRunDAO.saveRun(any()) } answers {
+            firstArg<DatasetRun>().also { savedRuns.add(it) }
+        }
+
+        val processor =
+            DatasetRunProcessor(
+                datasetDAO = datasetDAO,
+                datasetRunDAO = datasetRunDAO,
+                questionExecutor =
+                    DatasetQuestionExecutor { _, questionResult, _ ->
+                        BotDialogResponse(emptyList(), userActionId = "user-action-${questionResult.questionId}")
+                    },
+                clock = fixedClock,
+            )
+
+        val processed = processor.processNextQueuedRun()
+
+        assertTrue(processed)
+        assertEquals(DatasetRunState.COMPLETED, savedRuns.last().state)
+        assertEquals(fixedClock.instant(), savedRuns.last().endTime)
+
+        val completedResults =
+            savedQuestionResults.filter { it.state == DatasetRunQuestionResultState.COMPLETED }
+                .associateBy { it.questionId }
+
+        assertEquals(2, completedResults.size)
+        assertEquals("user-action-${firstQuestion.id}", completedResults[firstQuestion.id]?.userActionId)
+        assertEquals("user-action-${secondQuestion.id}", completedResults[secondQuestion.id]?.userActionId)
+    }
+
+    @Test
+    fun `processNextQueuedRun marks question as failed after configured retries and completes the run`() {
+        val dataset = newDataset(questionCount = 1)
+        val run = newRun(dataset)
+        val question = dataset.questions.first()
+        val questionResult = newQuestionResult(run, dataset, question.id)
+        val savedQuestionResults = mutableListOf<DatasetRunQuestionResult>()
+        val savedRuns = mutableListOf<DatasetRun>()
+
+        every { datasetRunDAO.claimNextQueuedRun() } returns run
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(questionResult)
+        every { datasetRunDAO.getRunById(any()) } returns run.copy(state = DatasetRunState.RUNNING)
+        every { datasetRunDAO.saveQuestionResult(any()) } answers {
+            firstArg<DatasetRunQuestionResult>().also { savedQuestionResults.add(it) }
+        }
+        every { datasetRunDAO.saveRun(any()) } answers {
+            firstArg<DatasetRun>().also { savedRuns.add(it) }
+        }
+
+        val processor =
+            DatasetRunProcessor(
+                datasetDAO = datasetDAO,
+                datasetRunDAO = datasetRunDAO,
+                questionExecutor =
+                    DatasetQuestionExecutor { _, _, _ ->
+                        BotDialogResponse(emptyList())
+                    },
+                maxRetries = 1,
+                clock = fixedClock,
+            )
+
+        val processed = processor.processNextQueuedRun()
+
+        assertTrue(processed)
+        assertEquals(DatasetRunState.COMPLETED, savedRuns.last().state)
+
+        val failedResult = savedQuestionResults.last()
+        assertEquals(DatasetRunQuestionResultState.FAILED, failedResult.state)
+        assertEquals(1, failedResult.retryCount)
+        assertEquals("Talk execution did not return a userActionId", failedResult.error)
+    }
+
+    @Test
+    fun `processNextQueuedRun stops immediately when the claimed run is already cancelled`() {
+        val dataset = newDataset(questionCount = 1)
+        val run = newRun(dataset)
+        val questionResult = newQuestionResult(run, dataset, dataset.questions.first().id)
+
+        every { datasetRunDAO.claimNextQueuedRun() } returns run
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(questionResult)
+        every { datasetRunDAO.getRunById(any()) } returns run.copy(state = DatasetRunState.CANCELLED)
+
+        val processor =
+            DatasetRunProcessor(
+                datasetDAO = datasetDAO,
+                datasetRunDAO = datasetRunDAO,
+                questionExecutor =
+                    DatasetQuestionExecutor { _, _, _ ->
+                        BotDialogResponse(emptyList(), userActionId = "should-not-run")
+                    },
+                clock = fixedClock,
+            )
+
+        val processed = processor.processNextQueuedRun()
+
+        assertTrue(processed)
+        verify(exactly = 0) { datasetRunDAO.saveQuestionResult(any()) }
+        verify(exactly = 0) { datasetRunDAO.saveRun(any()) }
+    }
+
+    private fun newDataset(questionCount: Int = 2): Dataset =
+        Dataset(
+            namespace = "testNamespace",
+            botId = "testBotId",
+            name = "dataset-name",
+            description = "dataset-description",
+            questions = (1..questionCount).map { index -> DatasetQuestion(question = "question-$index") },
+            createdAt = fixedClock.instant(),
+            createdBy = "dataset-user",
+        )
+
+    private fun newRun(dataset: Dataset): DatasetRun =
+        DatasetRun(
+            namespace = dataset.namespace,
+            botId = dataset.botId,
+            datasetId = dataset._id,
+            state = DatasetRunState.RUNNING,
+            startTime = fixedClock.instant(),
+            startedBy = "dataset-user",
+            botApplicationConfigurationId = newId(),
+        )
+
+    private fun newQuestionResult(
+        run: DatasetRun,
+        dataset: Dataset,
+        questionId: String,
+    ): DatasetRunQuestionResult =
+        DatasetRunQuestionResult(
+            namespace = dataset.namespace,
+            botId = dataset.botId,
+            datasetId = dataset._id,
+            runId = run._id,
+            questionId = questionId,
+            userIdModifier = "dataset_${run._id}_$questionId",
+        )
+}

--- a/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
@@ -1,0 +1,534 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.AbstractTest
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
+import ai.tock.bot.admin.dataset.Dataset
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetQuestion
+import ai.tock.bot.admin.dataset.DatasetRun
+import ai.tock.bot.admin.dataset.DatasetRunDAO
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.bot.admin.dialog.ActionReport
+import ai.tock.bot.admin.dialog.DialogReport
+import ai.tock.bot.admin.dialog.DialogReportDAO
+import ai.tock.bot.admin.dialog.DialogReportQuery
+import ai.tock.bot.admin.dialog.DialogReportQueryResult
+import ai.tock.bot.admin.model.Valid
+import ai.tock.bot.admin.model.ValidationError
+import ai.tock.bot.admin.model.dataset.DatasetCreateRequest
+import ai.tock.bot.admin.model.dataset.DatasetRunActionState
+import ai.tock.bot.admin.model.dataset.DatasetRunCreateRequest
+import ai.tock.bot.connector.ConnectorType
+import ai.tock.bot.engine.action.ActionMetadata
+import ai.tock.bot.engine.dialog.Dialog
+import ai.tock.bot.engine.message.DebugMessage
+import ai.tock.bot.engine.message.Sentence
+import ai.tock.bot.engine.message.SentenceWithFootnotes
+import ai.tock.bot.engine.user.PlayerId
+import ai.tock.bot.engine.user.PlayerType
+import ai.tock.shared.tockInternalInjector
+import ai.tock.translator.UserInterfaceType
+import com.github.salomonbrys.kodein.Kodein
+import com.github.salomonbrys.kodein.KodeinInjector
+import com.github.salomonbrys.kodein.bind
+import com.github.salomonbrys.kodein.singleton
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.litote.kmongo.newId
+import org.litote.kmongo.toId
+import java.time.Instant
+import java.util.Locale
+
+class DatasetServiceTest : AbstractTest() {
+    companion object {
+        private const val NAMESPACE = "testNamespace"
+        private const val BOT_ID = "testBotId"
+        private const val USER = "dataset-user"
+
+        private val datasetDAO: DatasetDAO = mockk(relaxed = false)
+        private val datasetRunDAO: DatasetRunDAO = mockk(relaxed = false)
+        private val ragConfigurationDAO: BotRAGConfigurationDAO = mockk(relaxed = true)
+        private val dialogReportDAO: DialogReportDAO = mockk(relaxed = false)
+
+        init {
+            tockInternalInjector = KodeinInjector()
+            val module =
+                Kodein.Module(allowSilentOverride = true) {
+                    bind<DatasetDAO>() with singleton { datasetDAO }
+                    bind<DatasetRunDAO>() with singleton { datasetRunDAO }
+                    bind<BotRAGConfigurationDAO>() with singleton { ragConfigurationDAO }
+                    bind<DialogReportDAO>() with singleton { dialogReportDAO }
+                }
+            tockInternalInjector.inject(
+                Kodein {
+                    import(AbstractTest.defaultModulesBinding())
+                    import(module, allowOverride = true)
+                },
+            )
+        }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearMocks(datasetDAO, datasetRunDAO, ragConfigurationDAO, dialogReportDAO, AbstractTest.applicationConfigurationDAO)
+    }
+
+    @Test
+    fun `createRun creates a queued run and pre-creates question results`() {
+        val dataset = newDataset()
+        val restConfiguration = newRestConfiguration()
+        val runSlot = slot<DatasetRun>()
+        val questionResultsSlot = slot<List<DatasetRunQuestionResult>>()
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getActiveRunsByDatasetId(dataset._id) } returns emptyList()
+        every { AbstractTest.applicationConfigurationDAO.getConfigurationsByNamespaceAndBotId(NAMESPACE, BOT_ID) } returns listOf(restConfiguration)
+        every { ragConfigurationDAO.findByNamespaceAndBotId(NAMESPACE, BOT_ID) } returns null
+        every { datasetRunDAO.saveRun(capture(runSlot)) } answers { runSlot.captured }
+        every { datasetRunDAO.saveQuestionResults(capture(questionResultsSlot)) } returns Unit
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } answers { questionResultsSlot.captured }
+
+        val result =
+            DatasetService.createRun(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                request = DatasetRunCreateRequest(language = "fr"),
+                userLogin = USER,
+            )
+
+        assertEquals(DatasetRunState.QUEUED, result.state)
+        assertEquals(USER, result.startedBy)
+        assertNull(result.settingsSnapshot)
+        assertEquals(2, result.stats.totalQuestions)
+        assertEquals(0, result.stats.completedQuestions)
+        assertEquals(0, result.stats.failedQuestions)
+
+        val savedRun = runSlot.captured
+        assertEquals(dataset._id, savedRun.datasetId)
+        assertEquals(DatasetRunState.QUEUED, savedRun.state)
+        assertEquals(restConfiguration._id, savedRun.botApplicationConfigurationId)
+        assertEquals(Locale.forLanguageTag("fr"), savedRun.language)
+        assertEquals(USER, savedRun.startedBy)
+        assertTrue(savedRun.settingsSnapshot.isEmpty())
+
+        val savedQuestionResults = questionResultsSlot.captured
+        assertEquals(dataset.questions.size, savedQuestionResults.size)
+        savedQuestionResults.forEachIndexed { index, resultEntry ->
+            assertEquals(dataset.questions[index].id, resultEntry.questionId)
+            assertEquals(DatasetRunQuestionResultState.PENDING, resultEntry.state)
+            assertEquals(savedRun._id, resultEntry.runId)
+            assertEquals("dataset_${savedRun._id}_${dataset.questions[index].id}", resultEntry.userIdModifier)
+        }
+    }
+
+    @Test
+    fun `createRun throws when several REST configurations are available`() {
+        val dataset = newDataset()
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getActiveRunsByDatasetId(dataset._id) } returns emptyList()
+        every { AbstractTest.applicationConfigurationDAO.getConfigurationsByNamespaceAndBotId(NAMESPACE, BOT_ID) } returns
+            listOf(
+                newRestConfiguration("test-app-a"),
+                newRestConfiguration("test-app-b"),
+            )
+
+        val exception =
+            assertThrows<DatasetError.InvalidRequest> {
+                DatasetService.createRun(
+                    namespace = NAMESPACE,
+                    botId = BOT_ID,
+                    datasetId = dataset._id.toString(),
+                    request = DatasetRunCreateRequest(language = "fr"),
+                    userLogin = USER,
+                )
+            }
+
+        assertEquals("Multiple REST test configurations found for bot $BOT_ID", exception.message)
+    }
+
+    @Test
+    fun `getRun returns the run without settings snapshot`() {
+        val dataset = newDataset()
+        val run =
+            DatasetRun(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                state = DatasetRunState.QUEUED,
+                startTime = Instant.now(),
+                startedBy = USER,
+                settingsSnapshot = mapOf("indexSessionId" to "session-id"),
+            )
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getRunById(any()) } returns run
+        every {
+            datasetRunDAO.getQuestionResultsByRunId(run._id)
+        } returns
+            listOf(
+                DatasetRunQuestionResult(
+                    namespace = NAMESPACE,
+                    botId = BOT_ID,
+                    datasetId = dataset._id,
+                    runId = run._id,
+                    questionId = dataset.questions.first().id,
+                    state = DatasetRunQuestionResultState.COMPLETED,
+                    userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
+                ),
+                DatasetRunQuestionResult(
+                    namespace = NAMESPACE,
+                    botId = BOT_ID,
+                    datasetId = dataset._id,
+                    runId = run._id,
+                    questionId = dataset.questions.last().id,
+                    state = DatasetRunQuestionResultState.FAILED,
+                    userIdModifier = "dataset_${run._id}_${dataset.questions.last().id}",
+                ),
+            )
+
+        val result =
+            DatasetService.getRun(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                runId = run._id.toString(),
+            )
+
+        assertEquals(run._id.toString(), result.id)
+        assertEquals(DatasetRunState.QUEUED, result.state)
+        assertNull(result.settingsSnapshot)
+        assertEquals(2, result.stats.totalQuestions)
+        assertEquals(1, result.stats.completedQuestions)
+        assertEquals(1, result.stats.failedQuestions)
+    }
+
+    @Test
+    fun `cancelRun cancels active run and updates pending question results`() {
+        val dataset = newDataset()
+        val run =
+            DatasetRun(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                state = DatasetRunState.RUNNING,
+                startTime = Instant.now(),
+                startedBy = USER,
+            )
+        val pendingResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.first().id,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
+            )
+        val completedResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.last().id,
+                state = DatasetRunQuestionResultState.COMPLETED,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.last().id}",
+            )
+        val savedRunSlot = slot<DatasetRun>()
+        val updatedResultsSlot = slot<List<DatasetRunQuestionResult>>()
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getRunById(any()) } returns run
+        every { datasetRunDAO.saveRun(capture(savedRunSlot)) } answers { savedRunSlot.captured }
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(pendingResult, completedResult)
+        every { datasetRunDAO.saveQuestionResults(capture(updatedResultsSlot)) } returns Unit
+
+        val result =
+            DatasetService.cancelRun(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                runId = run._id.toString(),
+            )
+
+        assertEquals(DatasetRunState.CANCELLED, result.state)
+        assertNotNull(result.endTime)
+        assertEquals(2, result.stats.totalQuestions)
+        assertEquals(1, result.stats.completedQuestions)
+        assertEquals(0, result.stats.failedQuestions)
+
+        val cancelledRun = savedRunSlot.captured
+        assertEquals(DatasetRunState.CANCELLED, cancelledRun.state)
+        assertNotNull(cancelledRun.endTime)
+
+        val updatedResults = updatedResultsSlot.captured
+        assertEquals(DatasetRunQuestionResultState.CANCELLED, updatedResults.first().state)
+        assertEquals(DatasetRunQuestionResultState.COMPLETED, updatedResults.last().state)
+
+        verify(exactly = 1) { datasetRunDAO.saveQuestionResults(any()) }
+    }
+
+    @Test
+    fun `dataset create request rejects blank name`() {
+        val exception =
+            assertThrows<ValidationError> {
+                Valid(
+                    DatasetCreateRequest(
+                        name = "   ",
+                        description = "desc",
+                        questions = listOf(ai.tock.bot.admin.model.dataset.DatasetQuestionRequest(question = "question")),
+                    ),
+                )
+            }
+
+        assertEquals("Dataset name is required", exception.message)
+    }
+
+    @Test
+    fun `getRunActions returns completed action and caches resolved references`() {
+        val dataset = newDataset()
+        val run = newFinishedRun(dataset, DatasetRunState.COMPLETED)
+        val questionResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.first().id,
+                state = DatasetRunQuestionResultState.COMPLETED,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
+                userActionId = "user-action-id",
+            )
+        val answerAction = botSentenceWithFootnotesAction("answer-action-id")
+        val dialog =
+            DialogReport(
+                actions =
+                    listOf(
+                        userSentenceAction("user-action-id"),
+                        botDebugAction("debug-action-id"),
+                        answerAction,
+                    ),
+                userInterface = UserInterfaceType.textChat,
+                id = newId<Dialog>(),
+            )
+        val updatedQuestionResultSlot = slot<DatasetRunQuestionResult>()
+        val querySlot = slot<DialogReportQuery>()
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getRunById(any()) } returns run
+        every { datasetRunDAO.getQuestionResultsByRunId(run._id) } returns listOf(questionResult)
+        every { dialogReportDAO.findByDialogByIds(emptySet()) } returns emptySet()
+        every { dialogReportDAO.search(capture(querySlot)) } returns DialogReportQueryResult(total = 1, dialogs = listOf(dialog))
+        every { datasetRunDAO.saveQuestionResult(capture(updatedQuestionResultSlot)) } answers { updatedQuestionResultSlot.captured }
+
+        val result =
+            DatasetService.getRunActions(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                runId = run._id.toString(),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(DatasetRunActionState.COMPLETED, result.first().state)
+        assertEquals(answerAction.id.toString(), result.first().action?.id.toString())
+        assertEquals(dialog.id, updatedQuestionResultSlot.captured.dialogId)
+        assertEquals(answerAction.id, updatedQuestionResultSlot.captured.answerActionId)
+        assertEquals("test_${run.botApplicationConfigurationId}_${run.language}_${questionResult.userIdModifier}", querySlot.captured.playerId?.id)
+    }
+
+    @Test
+    fun `getRunActions returns completed with null action when completed dialog has been purged`() {
+        val dataset = newDataset()
+        val run = newFinishedRun(dataset, DatasetRunState.COMPLETED)
+        val questionResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.first().id,
+                state = DatasetRunQuestionResultState.COMPLETED,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
+                userActionId = "user-action-id",
+            )
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getRunById(any()) } returns run
+        every { datasetRunDAO.getQuestionResultsByRunId(run._id) } returns listOf(questionResult)
+        every { dialogReportDAO.findByDialogByIds(emptySet()) } returns emptySet()
+        every { dialogReportDAO.search(any()) } returns DialogReportQueryResult(total = 0, dialogs = emptyList())
+
+        val result =
+            DatasetService.getRunActions(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                runId = run._id.toString(),
+            )
+
+        assertEquals(1, result.size)
+        assertEquals(DatasetRunActionState.COMPLETED, result.first().state)
+        assertNull(result.first().action)
+        verify(exactly = 0) { datasetRunDAO.saveQuestionResult(any()) }
+    }
+
+    @Test
+    fun `getRunActions maps failed and cancelled question results to failed actions`() {
+        val dataset = newDataset()
+        val run = newFinishedRun(dataset, DatasetRunState.CANCELLED)
+        val failedQuestionResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.first().id,
+                state = DatasetRunQuestionResultState.FAILED,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
+                retryCount = 2,
+            )
+        val cancelledQuestionResult =
+            DatasetRunQuestionResult(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id,
+                runId = run._id,
+                questionId = dataset.questions.last().id,
+                state = DatasetRunQuestionResultState.CANCELLED,
+                userIdModifier = "dataset_${run._id}_${dataset.questions.last().id}",
+            )
+
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getRunById(any()) } returns run
+        every { datasetRunDAO.getQuestionResultsByRunId(run._id) } returns listOf(failedQuestionResult, cancelledQuestionResult)
+        every { dialogReportDAO.findByDialogByIds(emptySet()) } returns emptySet()
+
+        val result =
+            DatasetService.getRunActions(
+                namespace = NAMESPACE,
+                botId = BOT_ID,
+                datasetId = dataset._id.toString(),
+                runId = run._id.toString(),
+            )
+
+        assertEquals(2, result.size)
+        assertTrue(result.all { it.state == DatasetRunActionState.FAILED && it.action == null })
+        assertEquals(2, result.first().retryCount)
+        verify(exactly = 0) { dialogReportDAO.search(any()) }
+    }
+
+    private fun newDataset(): Dataset =
+        Dataset(
+            namespace = NAMESPACE,
+            botId = BOT_ID,
+            name = "dataset-name",
+            description = "dataset-description",
+            questions =
+                listOf(
+                    DatasetQuestion(question = "question-1"),
+                    DatasetQuestion(question = "question-2"),
+                ),
+            createdAt = Instant.now(),
+            createdBy = USER,
+        )
+
+    private fun newFinishedRun(
+        dataset: Dataset,
+        state: DatasetRunState,
+    ): DatasetRun =
+        DatasetRun(
+            namespace = NAMESPACE,
+            botId = BOT_ID,
+            datasetId = dataset._id,
+            state = state,
+            startTime = Instant.now(),
+            endTime = Instant.now(),
+            startedBy = USER,
+            language = Locale.FRENCH,
+            botApplicationConfigurationId = newId(),
+        )
+
+    private fun newRestConfiguration(applicationId: String = "test-app"): BotApplicationConfiguration =
+        BotApplicationConfiguration(
+            applicationId = applicationId,
+            botId = BOT_ID,
+            namespace = NAMESPACE,
+            nlpModel = "test-model",
+            connectorType = ConnectorType.rest,
+            name = applicationId,
+            targetConfigurationId = newId(),
+        )
+
+    private fun userSentenceAction(id: String): ActionReport =
+        ActionReport(
+            playerId = PlayerId("user", PlayerType.user),
+            recipientId = PlayerId(BOT_ID, PlayerType.bot),
+            date = Instant.now(),
+            message = Sentence("question"),
+            connectorType = null,
+            userInterfaceType = UserInterfaceType.textChat,
+            id = id.toId(),
+            intent = null,
+            applicationId = null,
+            metadata = ActionMetadata(),
+        )
+
+    private fun botDebugAction(id: String): ActionReport =
+        ActionReport(
+            playerId = PlayerId(BOT_ID, PlayerType.bot),
+            recipientId = PlayerId("user", PlayerType.user),
+            date = Instant.now(),
+            message = DebugMessage("debug", null),
+            connectorType = null,
+            userInterfaceType = UserInterfaceType.textChat,
+            id = id.toId(),
+            intent = null,
+            applicationId = null,
+            metadata = ActionMetadata(),
+        )
+
+    private fun botSentenceWithFootnotesAction(id: String): ActionReport =
+        ActionReport(
+            playerId = PlayerId(BOT_ID, PlayerType.bot),
+            recipientId = PlayerId("user", PlayerType.user),
+            date = Instant.now(),
+            message = SentenceWithFootnotes("answer"),
+            connectorType = null,
+            userInterfaceType = UserInterfaceType.textChat,
+            id = id.toId(),
+            intent = null,
+            applicationId = null,
+            metadata = ActionMetadata(isGenAiRagAnswer = true),
+        )
+}

--- a/bot/admin/test/core/src/main/kotlin/ClientMessageConverter.kt
+++ b/bot/admin/test/core/src/main/kotlin/ClientMessageConverter.kt
@@ -39,60 +39,42 @@ import ai.tock.bot.engine.message.Sentence
 import ai.tock.bot.engine.user.UserLocation
 import ai.tock.translator.UserInterfaceType
 
-fun SendAttachment.AttachmentType.toClientAttachmentType(): ClientAttachmentType {
-    return ClientAttachmentType.valueOf(name)
-}
+fun SendAttachment.AttachmentType.toClientAttachmentType(): ClientAttachmentType = ClientAttachmentType.valueOf(name)
 
-fun ClientAttachmentType.toAttachmentType(): SendAttachment.AttachmentType {
-    return SendAttachment.AttachmentType.valueOf(name)
-}
+fun ClientAttachmentType.toAttachmentType(): SendAttachment.AttachmentType = SendAttachment.AttachmentType.valueOf(name)
 
-fun Location.toClientLocation(): ClientLocation {
-    return ClientLocation(location?.let { ClientUserLocation(it.lat, it.lng) })
-}
+fun Location.toClientLocation(): ClientLocation = ClientLocation(location?.let { ClientUserLocation(it.lat, it.lng) })
 
-fun ClientLocation.toLocation(): Location {
-    return Location(location?.let { UserLocation(it.lat, it.lng) })
-}
+fun ClientLocation.toLocation(): Location = Location(location?.let { UserLocation(it.lat, it.lng) })
 
-fun ConnectorType.toClientConnectorType(): ClientConnectorType {
-    return ClientConnectorType(id, userInterfaceType.toClientUserInterfaceType())
-}
+fun ConnectorType.toClientConnectorType(): ClientConnectorType = ClientConnectorType(id, userInterfaceType.toClientUserInterfaceType())
 
-fun ClientConnectorType.toConnectorType(): ConnectorType {
-    return ConnectorType(id, userInterfaceType.toUserInterfaceType())
-}
+fun ClientConnectorType.toConnectorType(): ConnectorType = ConnectorType(id, userInterfaceType.toUserInterfaceType())
 
-fun UserInterfaceType.toClientUserInterfaceType(): ClientUserInterfaceType {
-    return ClientUserInterfaceType.valueOf(name)
-}
+fun UserInterfaceType.toClientUserInterfaceType(): ClientUserInterfaceType = ClientUserInterfaceType.valueOf(name)
 
-fun ClientUserInterfaceType.toUserInterfaceType(): UserInterfaceType {
-    return UserInterfaceType.valueOf(name)
-}
+fun ClientUserInterfaceType.toUserInterfaceType(): UserInterfaceType = UserInterfaceType.valueOf(name)
 
-fun Message.toClientMessage(): ClientMessage {
-    return when (this) {
+fun Message.toClientMessage(): ClientMessage =
+    when (this) {
         is Sentence -> ClientSentence(text, messages.map { it.toClientSentenceElement() }.toMutableList())
         is Choice -> ClientChoice(intentName, parameters)
         is Attachment -> ClientAttachment(url, type.toClientAttachmentType())
         is Location -> toClientLocation()
         else -> error("unsupported message $this")
     }
-}
 
-fun ClientMessage.toMessage(): Message {
-    return when (this) {
+fun ClientMessage.toMessage(): Message =
+    when (this) {
         is ClientSentence -> Sentence(text, messages.map { it.toSentenceElement() }.toMutableList())
         is ClientChoice -> Choice(intentName, parameters)
         is ClientAttachment -> Attachment(url, type.toAttachmentType())
         is ClientLocation -> toLocation()
         else -> error("unsupported message $this")
     }
-}
 
-fun GenericMessage.toClientSentenceElement(): ClientGenericMessage {
-    return ClientGenericMessage(
+fun GenericMessage.toClientSentenceElement(): ClientGenericMessage =
+    ClientGenericMessage(
         connectorType.toClientConnectorType(),
         attachments.map { it.toClientMessage() as ClientAttachment },
         choices.map { it.toClientMessage() as ClientChoice },
@@ -101,10 +83,9 @@ fun GenericMessage.toClientSentenceElement(): ClientGenericMessage {
         metadata,
         subElements.map { it.toClientSentenceSubElement() },
     )
-}
 
-fun ClientGenericMessage.toSentenceElement(): GenericMessage {
-    return GenericMessage(
+fun ClientGenericMessage.toSentenceElement(): GenericMessage =
+    GenericMessage(
         connectorType.toConnectorType(),
         attachments.map { it.toMessage() as Attachment },
         choices.map { it.toMessage() as Choice },
@@ -113,24 +94,21 @@ fun ClientGenericMessage.toSentenceElement(): GenericMessage {
         metadata,
         subElements.map { it.toSentenceSubElement() },
     )
-}
 
-fun GenericElement.toClientSentenceSubElement(): ClientGenericElement {
-    return ClientGenericElement(
+fun GenericElement.toClientSentenceSubElement(): ClientGenericElement =
+    ClientGenericElement(
         attachments.map { it.toClientMessage() as ClientAttachment },
         choices.map { it.toClientMessage() as ClientChoice },
         texts,
         locations.map { it.toClientLocation() },
         metadata,
     )
-}
 
-fun ClientGenericElement.toSentenceSubElement(): GenericElement {
-    return GenericElement(
+fun ClientGenericElement.toSentenceSubElement(): GenericElement =
+    GenericElement(
         attachments.map { it.toMessage() as Attachment },
         choices.map { it.toMessage() as Choice },
         texts,
         locations.map { it.toLocation() },
         metadata,
     )
-}

--- a/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestCoreService.kt
@@ -16,52 +16,33 @@
 
 package ai.tock.bot.admin.test
 
-import ai.tock.bot.admin.bot.BotApplicationConfiguration
-import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
 import ai.tock.bot.admin.test.model.BotDialogRequest
-import ai.tock.bot.admin.test.model.BotDialogResponse
 import ai.tock.bot.admin.test.model.TestPlanUpdate
-import ai.tock.bot.connector.rest.client.ConnectorRestClient
-import ai.tock.bot.connector.rest.client.model.ClientMessageRequest
-import ai.tock.bot.connector.rest.client.model.ClientSentence
 import ai.tock.nlp.admin.AdminVerticle
 import ai.tock.nlp.admin.model.ApplicationScopedQuery
 import ai.tock.nlp.front.client.FrontClient
 import ai.tock.shared.Dice
-import ai.tock.shared.error
-import ai.tock.shared.exception.rest.UnauthorizedException
-import ai.tock.shared.injector
-import ai.tock.shared.property
-import ai.tock.shared.provide
 import ai.tock.shared.security.TockUserRole.botUser
 import ai.tock.shared.vertx.WebVerticle
 import ai.tock.shared.vertx.WebVerticle.Companion
 import io.vertx.ext.web.RoutingContext
-import mu.KotlinLogging
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
 import org.litote.kmongo.toId
 import java.time.Duration
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
 
 class TestCoreService : TestService {
-    private val logger = KotlinLogging.logger {}
-    private val defaultRestConnectorBaseUrl =
-        property("tock_bot_admin_rest_default_base_url", "please set base url of the bot")
-    private val restConnectorClientCache: MutableMap<String, ConnectorRestClient> = ConcurrentHashMap()
-
     override fun registerServices(): (AdminVerticle).() -> Unit =
         {
-            fun RoutingContext.loadTestPlan(): TestPlan {
-                return TestPlanService.getTestPlan(pathId("planId"))?.run {
+            fun RoutingContext.loadTestPlan(): TestPlan =
+                TestPlanService.getTestPlan(pathId("planId"))?.run {
                     if (organization != namespace) {
                         Companion.unauthorized()
                     } else {
                         this
                     }
                 } ?: Companion.notFound()
-            }
 
             blockingJsonGet("/test/plans", botUser) { context ->
                 TestPlanService.getTestPlansByNamespace(context.organization)
@@ -137,56 +118,12 @@ class TestCoreService : TestService {
                 if (context.organization == query.namespace) {
                     val debugEnabled = context.queryParams()["debug"]?.toBoolean() ?: false
                     val sourceWithContent = context.queryParams()["sourceWithContent"]?.toBoolean() ?: false
-                    talk(query, debugEnabled, sourceWithContent)
+                    TestTalkService.talk(query, debugEnabled, sourceWithContent)
                 } else {
                     Companion.unauthorized()
                 }
             }
         }
-
-    private fun talk(
-        request: BotDialogRequest,
-        debugEnabled: Boolean,
-        sourceWithContent: Boolean,
-    ): BotDialogResponse {
-        val conf = getBotConfiguration(request.botApplicationConfigurationId, request.namespace)
-        return try {
-            val restClient = getRestClient(conf)
-            val response =
-                restClient.talk(
-                    conf.path ?: conf.applicationId,
-                    request.currentLanguage,
-                    ClientMessageRequest(
-                        "test_${conf._id}_${request.currentLanguage}_${request.userIdModifier}",
-                        "test_bot_${conf._id}_${request.currentLanguage}",
-                        request.message.toClientMessage(),
-                        conf.targetConnectorType.toClientConnectorType(),
-                        test = true,
-                        debugEnabled = debugEnabled,
-                        sourceWithContent = sourceWithContent,
-                    ),
-                )
-
-            if (response.isSuccessful) {
-                response.body()?.run {
-                    BotDialogResponse(messages, userLocale, userActionId, hasNlpStats)
-                } ?: BotDialogResponse(emptyList())
-            } else {
-                logger.error { "error with $conf : ${response.errorBody()?.string()}" }
-                BotDialogResponse(listOf(ClientSentence("technical error :( ${response.errorBody()?.string()}]")))
-            }
-        } catch (throwable: Throwable) {
-            logger.error(throwable)
-            BotDialogResponse(listOf(ClientSentence("technical error :( ${throwable.message}")))
-        }
-    }
-
-    private fun getRestClient(conf: BotApplicationConfiguration): ConnectorRestClient {
-        val baseUrl = conf.baseUrl?.let { if (it.isBlank()) null else it } ?: defaultRestConnectorBaseUrl
-        return restConnectorClientCache.getOrPut(baseUrl) {
-            ConnectorRestClient(baseUrl)
-        }
-    }
 
     /**
      * This function saves the current test plan in the mongo database and
@@ -198,26 +135,15 @@ class TestCoreService : TestService {
         testPlan: TestPlan,
         executionId: Id<TestPlanExecution>,
     ): TestPlanExecution =
-        getBotConfiguration(testPlan.botApplicationConfigurationId, namespace)
+        TestTalkService
+            .getBotConfiguration(testPlan.botApplicationConfigurationId, namespace)
             .let {
                 TestPlanService.saveAndRunTestPlan(
-                    getRestClient(it),
+                    TestTalkService.getRestClient(it),
                     testPlan,
                     executionId,
                 )
             }
-
-    private fun getBotConfiguration(
-        botApplicationConfigurationId: Id<BotApplicationConfiguration>,
-        namespace: String,
-    ): BotApplicationConfiguration {
-        val applicationConfigurationDAO: BotApplicationConfigurationDAO = injector.provide()
-        val conf = applicationConfigurationDAO.getConfigurationById(botApplicationConfigurationId)
-        if (conf?.namespace != namespace) {
-            throw UnauthorizedException()
-        }
-        return conf
-    }
 
     private fun executeTestPlan(testPlan: TestPlan): Id<TestPlanExecution> {
         val executionId = Dice.newId()
@@ -233,8 +159,8 @@ class TestCoreService : TestService {
         // save the test plan execution into the database
         TestPlanService.saveTestPlanExecution(exec)
         TestPlanService.runTestPlan(
-            getRestClient(
-                getBotConfiguration(
+            TestTalkService.getRestClient(
+                TestTalkService.getBotConfiguration(
                     testPlan.botApplicationConfigurationId,
                     testPlan.namespace,
                 ),

--- a/bot/admin/test/core/src/main/kotlin/TestPlanService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestPlanService.kt
@@ -56,24 +56,16 @@ object TestPlanService {
     private val applicationIdPathCache: Cache<String, String> =
         CacheBuilder.newBuilder().expireAfterAccess(Duration.ofMinutes(1)).build()
 
-    fun getPlanExecutions(plan: TestPlan): List<TestPlanExecution> {
-        return testPlanDAO.getPlanExecutions(plan._id)
-    }
+    fun getPlanExecutions(plan: TestPlan): List<TestPlanExecution> = testPlanDAO.getPlanExecutions(plan._id)
 
     fun getTestPlansByNamespaceAndNlpModel(
         namespace: String,
         nlpModel: String,
-    ): List<TestPlan> {
-        return testPlanDAO.getTestPlans().filter { it.namespace == namespace && it.nlpModel == nlpModel }
-    }
+    ): List<TestPlan> = testPlanDAO.getTestPlans().filter { it.namespace == namespace && it.nlpModel == nlpModel }
 
-    fun getTestPlansByNamespace(namespace: String): List<TestPlan> {
-        return testPlanDAO.getTestPlans().filter { it.namespace == namespace }
-    }
+    fun getTestPlansByNamespace(namespace: String): List<TestPlan> = testPlanDAO.getTestPlans().filter { it.namespace == namespace }
 
-    fun getTestPlansByApplication(applicationId: String): List<TestPlan> {
-        return testPlanDAO.getPlansByApplicationId(applicationId)
-    }
+    fun getTestPlansByApplication(applicationId: String): List<TestPlan> = testPlanDAO.getPlansByApplicationId(applicationId)
 
     fun removeDialogFromTestPlan(
         plan: TestPlan,
@@ -97,16 +89,12 @@ object TestPlanService {
         testPlanDAO.saveTestPlan(plan)
     }
 
-    fun getTestPlan(planId: Id<TestPlan>): TestPlan? {
-        return testPlanDAO.getTestPlan(planId)
-    }
+    fun getTestPlan(planId: Id<TestPlan>): TestPlan? = testPlanDAO.getTestPlan(planId)
 
     fun getTestPlanExecution(
         testPlan: TestPlan,
         testExecutionId: Id<TestPlanExecution>,
-    ): TestPlanExecution? {
-        return testPlanDAO.getTestPlanExecution(testPlan, testExecutionId)
-    }
+    ): TestPlanExecution? = testPlanDAO.getTestPlanExecution(testPlan, testExecutionId)
 
     fun saveTestPlanExecution(testPlanExecution: TestPlanExecution) {
         testPlanDAO.saveTestExecution(testPlanExecution)
@@ -231,8 +219,11 @@ object TestPlanService {
                         val body = answer.body()
                         logger.debug { "ANSWER -- : $body" }
                         // go over the bot answer to remove emoticons
-                        botMessages = body?.messages?.map { it as ClientSentence }
-                            ?.map { it.copy(text = it.text?.cleanSurrogateChars()) }?.toMutableList() ?: mutableListOf()
+                        botMessages = body
+                            ?.messages
+                            ?.map { it as ClientSentence }
+                            ?.map { it.copy(text = it.text?.cleanSurrogateChars()) }
+                            ?.toMutableList() ?: mutableListOf()
                         logger.debug { "ANSWER without surrogate -- : $botMessages" }
                     } else {
                         logger.error { "ERROR : " + answer.errorBody()?.string() }
@@ -325,7 +316,8 @@ object TestPlanService {
             return "Text differs : \"${this.text}\" / expected \"${expectedMessage.text}\""
         }
 
-        return messages.zip(expectedMessage.messages)
+        return messages
+            .zip(expectedMessage.messages)
             .mapNotNull { (subMessage, expectedSubMessage) -> subMessage.partiallyEquals(expectedSubMessage) }
             .firstOrNull()
     }
@@ -336,13 +328,17 @@ private fun ClientGenericMessage.partiallyEquals(expected: ClientGenericMessage)
         return "Message text differs : \"$texts\" / expected \"${expected.texts}\""
     }
 
-    choices.zip(expected.choices)
+    choices
+        .zip(expected.choices)
         .mapNotNull { (obtainedChoice, expectedChoice) -> obtainedChoice.partiallyEquals(expectedChoice) }
-        .firstOrNull()?.let { return it }
+        .firstOrNull()
+        ?.let { return it }
 
-    subElements.zip(expected.subElements)
+    subElements
+        .zip(expected.subElements)
         .mapNotNull { (obtainedSubElement, expectedSubElement) -> obtainedSubElement.partiallyEquals(expectedSubElement) }
-        .firstOrNull()?.let { return it }
+        .firstOrNull()
+        ?.let { return it }
 
     return null
 }
@@ -352,7 +348,8 @@ private fun ClientGenericElement.partiallyEquals(expected: ClientGenericElement)
         return "Sub-element text differs : \"$texts\" / expected \"${expected.texts}\""
     }
 
-    return choices.zip(expected.choices)
+    return choices
+        .zip(expected.choices)
         .mapNotNull { (obtainedChoice, expectedChoice) -> obtainedChoice.partiallyEquals(expectedChoice) }
         .firstOrNull()
 }

--- a/bot/admin/test/core/src/main/kotlin/TestTalkService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestTalkService.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.test
+
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.test.model.BotDialogRequest
+import ai.tock.bot.admin.test.model.BotDialogResponse
+import ai.tock.bot.connector.rest.client.ConnectorRestClient
+import ai.tock.bot.connector.rest.client.model.ClientMessageRequest
+import ai.tock.bot.connector.rest.client.model.ClientSentence
+import ai.tock.bot.engine.message.Message
+import ai.tock.shared.defaultLocale
+import ai.tock.shared.error
+import ai.tock.shared.exception.rest.UnauthorizedException
+import ai.tock.shared.injector
+import ai.tock.shared.property
+import ai.tock.shared.provide
+import mu.KotlinLogging
+import org.litote.kmongo.Id
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+
+object TestTalkService {
+    private val logger = KotlinLogging.logger {}
+    private val defaultRestConnectorBaseUrl =
+        property("tock_bot_admin_rest_default_base_url", "please set base url of the bot")
+    private val restConnectorClientCache: MutableMap<String, ConnectorRestClient> = ConcurrentHashMap()
+
+    fun talk(
+        request: BotDialogRequest,
+        debugEnabled: Boolean,
+        sourceWithContent: Boolean,
+    ): BotDialogResponse =
+        talk(
+            botApplicationConfigurationId = request.botApplicationConfigurationId,
+            namespace = request.namespace,
+            message = request.message,
+            language = request.currentLanguage,
+            userIdModifier = request.userIdModifier,
+            debugEnabled = debugEnabled,
+            sourceWithContent = sourceWithContent,
+        )
+
+    fun talk(
+        botApplicationConfigurationId: Id<BotApplicationConfiguration>,
+        namespace: String,
+        message: Message,
+        language: Locale?,
+        userIdModifier: String,
+        debugEnabled: Boolean,
+        sourceWithContent: Boolean,
+    ): BotDialogResponse {
+        val conf = getBotConfiguration(botApplicationConfigurationId, namespace)
+        return try {
+            val restClient = getRestClient(conf)
+            val response =
+                restClient.talk(
+                    conf.path ?: conf.applicationId,
+                    language ?: defaultLocale,
+                    ClientMessageRequest(
+                        buildTestPlayerId(conf._id, language, userIdModifier),
+                        buildTestBotId(conf._id, language),
+                        message.toClientMessage(),
+                        conf.targetConnectorType.toClientConnectorType(),
+                        test = true,
+                        debugEnabled = debugEnabled,
+                        sourceWithContent = sourceWithContent,
+                    ),
+                )
+
+            if (response.isSuccessful) {
+                response.body()?.run {
+                    BotDialogResponse(messages, userLocale, userActionId, hasNlpStats)
+                } ?: BotDialogResponse(emptyList())
+            } else {
+                logger.error { "error with $conf : ${response.errorBody()?.string()}" }
+                BotDialogResponse(listOf(ClientSentence("technical error :( ${response.errorBody()?.string()}]")))
+            }
+        } catch (throwable: Throwable) {
+            logger.error(throwable)
+            BotDialogResponse(listOf(ClientSentence("technical error :( ${throwable.message}")))
+        }
+    }
+
+    fun getRestClient(conf: BotApplicationConfiguration): ConnectorRestClient {
+        val baseUrl = conf.baseUrl?.let { if (it.isBlank()) null else it } ?: defaultRestConnectorBaseUrl
+        return restConnectorClientCache.getOrPut(baseUrl) {
+            ConnectorRestClient(baseUrl)
+        }
+    }
+
+    fun buildTestPlayerId(
+        botApplicationConfigurationId: Id<BotApplicationConfiguration>,
+        language: Locale?,
+        userIdModifier: String,
+    ): String = "test_${botApplicationConfigurationId}_${language ?: defaultLocale}_$userIdModifier"
+
+    fun buildTestBotId(
+        botApplicationConfigurationId: Id<BotApplicationConfiguration>,
+        language: Locale?,
+    ): String = "test_bot_${botApplicationConfigurationId}_${language ?: defaultLocale}"
+
+    fun getBotConfiguration(
+        botApplicationConfigurationId: Id<BotApplicationConfiguration>,
+        namespace: String,
+    ): BotApplicationConfiguration {
+        val applicationConfigurationDAO: BotApplicationConfigurationDAO = injector.provide()
+        val conf = applicationConfigurationDAO.getConfigurationById(botApplicationConfigurationId)
+        if (conf?.namespace != namespace) {
+            throw UnauthorizedException()
+        }
+        return conf
+    }
+}

--- a/bot/admin/web/angular.json
+++ b/bot/admin/web/angular.json
@@ -33,7 +33,8 @@
               "node_modules/jodit/es2021/jodit.css",
               "node_modules/katex/dist/katex.min.css"
             ],
-            "scripts": []
+            "scripts": [],
+            "webWorkerTsConfig": "tsconfig.worker.json"
           },
           "configurations": {
             "production": {

--- a/bot/admin/web/src/app/bot-admin-app.component.ts
+++ b/bot/admin/web/src/app/bot-admin-app.component.ts
@@ -339,6 +339,11 @@ export class BotAdminAppComponent implements AuthListener, OnInit, OnDestroy {
             link: '/quality/samples',
             title: 'Evaluations',
             icon: 'eyedropper'
+          },
+          {
+            link: '/quality/datasets',
+            title: 'Datasets',
+            icon: 'palette2'
           }
         ]
       },

--- a/bot/admin/web/src/app/core-nlp/applications.service.ts
+++ b/bot/admin/web/src/app/core-nlp/applications.service.ts
@@ -64,7 +64,9 @@ export class ApplicationService implements OnDestroy {
   resetConfiguration() {
     this.getLocales().subscribe((locales) => (this.state.locales = locales));
     this.getNlpEngineTypes().subscribe((engines) => (this.state.supportedNlpEngines = engines));
-    this.getNamespaces().subscribe((namespaces) => (this.state.namespaces = namespaces));
+    this.getNamespaces().subscribe((namespaces) => {
+      this.state.namespaces = namespaces.sort((a, b) => a.namespace.localeCompare(b.namespace));
+    });
     this.getApplications().subscribe((applications) => {
       this.state.applications = applications;
       this.state.currentApplication = null;

--- a/bot/admin/web/src/app/quality/datatsets/api-contract-datasets.md
+++ b/bot/admin/web/src/app/quality/datatsets/api-contract-datasets.md
@@ -1,0 +1,276 @@
+# Contrat d'interface — Datasets API
+
+Le `namespace` est résolu côté serveur via le cookie de session — il n'apparaît pas dans les URLs.
+Le `botId` correspond au `name` du bot courant, fourni par le `StateService` côté front.
+
+Les URLs sont donc de la forme `/bots/:botId/datasets`.
+
+Pour l'exécution d'un dataset :
+
+- la `language` est fournie explicitement par le front au lancement du run,
+- le serveur résout lui-même la configuration REST de test effective à partir du `botId`,
+- si aucune configuration REST exploitable n'est trouvée, le run n'est pas créé.
+
+---
+
+## Types
+
+```typescript
+enum DatasetRunState {
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED', // Traitement terminé, sans préjuger du résultat des actions
+  CANCELLED = 'CANCELLED' // Run interrompu volontairement avant complétion
+}
+
+enum DatasetRunActionState {
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED'
+}
+
+interface DatasetQuestion {
+  id: string;
+  question: string;
+  groundTruth: string;
+}
+
+// settingsSnapshot est absent des réponses de GET /datasets et GET /runs/:runId (polling)
+// settingsSnapshot est présent dans les réponses de GET /datasets/:datasetId
+interface DatasetRun {
+  id: string;
+  state: DatasetRunState;
+  startTime: string; // ISO 8601
+  endTime: string | null; // ISO 8601 — renseigné dès que state = COMPLETED | CANCELLED
+  settingsSnapshot?: Partial<RagSettings>;
+  startedBy: string;
+}
+
+interface Dataset {
+  id: string;
+  name: string;
+  description: string;
+  questions: DatasetQuestion[];
+  runs: DatasetRun[];
+  createdAt: string; // ISO 8601
+  createdBy: string;
+  updatedAt: string | null; // ISO 8601
+  updatedBy: string | null;
+}
+
+interface DatasetRunAction {
+  datasetId: string;
+  runId: string;
+  questionId: string;
+  state: DatasetRunActionState;
+  // null dans deux cas distincts à traiter différemment côté front :
+  //   - state = FAILED   → l'action a échoué sans produire de rapport, comportement normal
+  //   - state = COMPLETED → le dialogue associé a été purgé de la base, afficher un avertissement
+  action: ActionReport | null;
+  retryCount: number;
+}
+```
+
+---
+
+## Endpoints
+
+### `GET /bots/:botId/datasets`
+
+Récupère la liste de tous les datasets du bot.
+
+> Les runs sont retournés **sans** `settingsSnapshot` afin de limiter la taille des échanges.
+
+**Response `200`**
+
+```typescript
+Dataset[] // runs[].settingsSnapshot absent
+```
+
+---
+
+### `GET /bots/:botId/datasets/:datasetId`
+
+Récupère un dataset complet. Utilisé par la vue détail pour permettre la comparaison
+des settings entre runs.
+
+> Les runs sont retournés **avec** `settingsSnapshot`.
+
+**Response `200`**
+
+```typescript
+Dataset; // runs[].settingsSnapshot présent
+```
+
+**Response `404`** — dataset inconnu
+
+---
+
+### `POST /bots/:botId/datasets`
+
+Crée un nouveau dataset.
+
+**Request body**
+
+```typescript
+{
+  name: string;
+  description: string;
+  questions: {
+    question: string;
+    groundTruth: string;
+  }
+  [];
+}
+```
+
+**Response `201`**
+
+```typescript
+Dataset; // id généré, runs: [], settingsSnapshot non applicable
+```
+
+---
+
+### `PUT /bots/:botId/datasets/:datasetId`
+
+Met à jour un dataset (nom, description, questions). Les runs existants ne sont pas affectés.
+
+**Request body**
+
+```typescript
+{
+  name: string;
+  description: string;
+  questions: {
+    id?: string; // présent = update, absent = création
+    question: string;
+    groundTruth: string;
+  }[];
+}
+```
+
+**Response `200`**
+
+```typescript
+Dataset; // runs[].settingsSnapshot absent
+```
+
+**Response `409`** — un run est déjà `QUEUED` ou `RUNNING` sur ce dataset
+
+---
+
+### `DELETE /bots/:botId/datasets/:datasetId`
+
+Supprime un dataset et tous ses runs.
+
+**Response `204`** — No content
+
+**Response `409`** — un run est déjà `QUEUED` ou `RUNNING` sur ce dataset
+
+---
+
+### `POST /bots/:botId/datasets/:datasetId/runs`
+
+Déclenche un nouveau run. Le serveur snapshote les RAG settings courants au moment du lancement.
+
+> Un run ne peut être créé que si aucun run n'est déjà en état `QUEUED` ou `RUNNING`.
+
+> Le run retourné est sans `settingsSnapshot`.
+
+> Le serveur résout la configuration REST de test effective à partir du `botId`.
+> Si la résolution est impossible, le run est refusé.
+
+**Request body**
+
+```typescript
+{
+  language: string; // locale courante côté front, ex: "fr"
+}
+```
+
+**Response `201`**
+
+```typescript
+DatasetRun; // state: QUEUED, endTime: null, settingsSnapshot absent
+```
+
+**Response `409`** — un run est déjà actif
+
+```typescript
+{
+  error: string;
+}
+```
+
+**Response `400`** — aucune configuration REST exploitable, ou plusieurs configurations candidates
+
+```typescript
+{
+  error: string;
+}
+```
+
+---
+
+### `POST /bots/:botId/datasets/:datasetId/runs/:runId/cancel`
+
+Demande l'annulation d'un run en cours. Le run passe en état `CANCELLED` et son `endTime` est renseigné.
+L'entrée est conservée en base avec ses actions partiellement exécutées.
+
+Uniquement possible si le run est en état `QUEUED` ou `RUNNING`.
+
+**Request body** — vide `{}`
+
+**Response `200`**
+
+```typescript
+DatasetRun; // state: CANCELLED, endTime renseigné, settingsSnapshot absent
+```
+
+**Response `404`** — run inconnu
+
+**Response `409`** — le run est déjà `COMPLETED` ou `CANCELLED`
+
+---
+
+### `GET /bots/:botId/datasets/:datasetId/runs/:runId`
+
+Récupère l'état courant d'un run. Utilisé en polling tant que `state` est `QUEUED` ou `RUNNING`.
+
+> Le polling doit s'arrêter dès que `state` passe à `COMPLETED` ou `CANCELLED`.
+> `endTime` est alors renseigné.
+
+> Le run retourné est sans `settingsSnapshot`.
+
+**Response `200`**
+
+```typescript
+DatasetRun; // settingsSnapshot absent
+```
+
+**Response `404`** — run inconnu
+
+---
+
+### `GET /bots/:botId/datasets/:datasetId/runs/:runId/actions`
+
+Récupère les résultats détaillés d'un run — une entrée par question du dataset.
+Disponible uniquement pour un run en état `COMPLETED` ou `CANCELLED`.
+
+Le champ `action` peut être `null` pour deux raisons distinctes, à distinguer via `state` :
+
+| `state`     | `action` | Signification                              | Comportement attendu côté front           |
+| ----------- | -------- | ------------------------------------------ | ----------------------------------------- |
+| `FAILED`    | `null`   | L'action a échoué sans produire de rapport | Afficher l'état d'échec normalement       |
+| `COMPLETED` | `null`   | Le dialogue associé a été purgé de la base | Afficher un avertissement à l'utilisateur |
+| `COMPLETED` | présent  | Résultat nominal                           | Afficher le rapport                       |
+
+**Response `200`**
+
+```typescript
+DatasetRunAction[]
+```
+
+**Response `404`** — run inconnu
+
+**Response `409`** — run pas encore terminé

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
@@ -119,32 +119,49 @@
     </form>
   </nb-card-body>
 
-  <nb-card-footer class="card-footer-actions">
+  <nb-card-footer
+    class="card-footer-actions"
+    [ngClass]="{ 'justify-content-between': isEditMode }"
+  >
     <button
+      *ngIf="isEditMode"
       nbButton
       ghost="true"
-      [disabled]="isLoading"
+      status="primary"
       tabindex="-1"
-      (click)="dialogRef.close()"
+      [disabled]="isLoading"
+      (click)="exportDataset()"
     >
-      CANCEL
+      EXPORT DATASET
     </button>
 
-    <button
-      #submitButton
-      nbButton
-      status="primary"
-      [nbTooltip]="isEditMode ? 'Save changes' : 'Create dataset'"
-      class="d-flex align-items-center"
-      [nbSpinner]="isLoading"
-      [disabled]="isLoading"
-      (click)="submit()"
-    >
-      <nb-icon
-        [icon]="isEditMode ? 'check-lg' : 'plus-lg'"
-        class="mr-2"
-      ></nb-icon>
-      {{ isEditMode ? 'SAVE' : 'CREATE' }}
-    </button>
+    <div class="d-flex gap-1">
+      <button
+        nbButton
+        ghost="true"
+        [disabled]="isLoading"
+        tabindex="-1"
+        (click)="dialogRef.close()"
+      >
+        CANCEL
+      </button>
+
+      <button
+        #submitButton
+        nbButton
+        status="primary"
+        [nbTooltip]="isEditMode ? 'Save changes' : 'Create dataset'"
+        class="d-flex align-items-center"
+        [nbSpinner]="isLoading"
+        [disabled]="isLoading"
+        (click)="submit()"
+      >
+        <nb-icon
+          [icon]="isEditMode ? 'check-lg' : 'plus-lg'"
+          class="mr-2"
+        ></nb-icon>
+        {{ isEditMode ? 'SAVE' : 'CREATE' }}
+      </button>
+    </div>
   </nb-card-footer>
 </nb-card>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
@@ -1,0 +1,150 @@
+<nb-card class="mb-2">
+  <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+    <div class="pt-1">{{ isEditMode ? 'Edit dataset' : 'New dataset' }}</div>
+
+    <button
+      type="button"
+      nbButton
+      shape="round"
+      nbTooltip="Close"
+      (click)="dialogRef.close()"
+    >
+      <nb-icon icon="x-lg"></nb-icon>
+    </button>
+  </nb-card-header>
+
+  <nb-card-body>
+    <form [formGroup]="form">
+      <div class="row">
+        <div class="col-12">
+          <tock-form-control
+            name="name"
+            label="Dataset name"
+            [controls]="getFormControl('name')"
+            [showError]="isSubmitted"
+          >
+            <nb-form-field>
+              <input
+                nbInput
+                fullWidth
+                placeholder="Name of the dataset"
+                formControlName="name"
+              />
+            </nb-form-field>
+          </tock-form-control>
+        </div>
+
+        <div class="col-12">
+          <tock-form-control
+            name="description"
+            label="Dataset description"
+            [controls]="getFormControl('description')"
+            [showError]="isSubmitted"
+          >
+            <nb-form-field>
+              <textarea
+                nbInput
+                fullWidth
+                placeholder="Description of the dataset"
+                formControlName="description"
+              ></textarea>
+            </nb-form-field>
+          </tock-form-control>
+        </div>
+
+        <div class="col-12">
+          <tock-form-control
+            name="questions"
+            label="Questions"
+            [controls]="getFormControl('questions')"
+            [showError]="isSubmitted"
+          >
+            <div formArrayName="questions">
+              <div
+                *ngFor="let questionGroup of questions.controls; let i = index"
+                [formGroupName]="i"
+                class="mb-3"
+              >
+                <div class="d-flex gap-05 align-items-center">
+                  <div class="flex-grow-1">
+                    <textarea
+                      #questionInput
+                      nbInput
+                      fullWidth
+                      rows="2"
+                      formControlName="question"
+                      placeholder="Question {{ i + 1 }}…"
+                      [status]="isSubmitted && questionGroup.controls.question.invalid && !isLastEntry(i) ? 'danger' : 'basic'"
+                      (input)="onQuestionInput(i)"
+                      (paste)="onQuestionPaste($event, i)"
+                      class="scrollbar-narrow"
+                    ></textarea>
+
+                    <small
+                      *ngIf="isSubmitted && questionGroup.controls.question.errors?.maxlength && !isLastEntry(i)"
+                      class="text-danger"
+                    >
+                      Question exceeds the {{ questionGroup.controls.question.errors.maxlength.requiredLength }} character limit.
+                    </small>
+                  </div>
+
+                  <button
+                    *ngIf="!isLastEntry(i) || questions.length === 1"
+                    nbButton
+                    ghost
+                    shape="round"
+                    status="danger"
+                    nbTooltip="Delete question"
+                    tabindex="-1"
+                    (click)="removeQuestion(i)"
+                  >
+                    <nb-icon icon="trash"></nb-icon>
+                  </button>
+                </div>
+
+                <textarea
+                  *ngIf="questionGroup.controls.question.value.trim()"
+                  nbInput
+                  fullWidth
+                  formControlName="groundTruth"
+                  placeholder="Ground truth (optional)"
+                  rows="2"
+                  class="mt-1 scrollbar-narrow"
+                ></textarea>
+              </div>
+            </div>
+          </tock-form-control>
+        </div>
+      </div>
+    </form>
+  </nb-card-body>
+
+  <nb-card-footer class="card-footer-actions">
+    <button
+      nbButton
+      ghost="true"
+      [disabled]="isLoading"
+      tabindex="-1"
+      (click)="dialogRef.close()"
+    >
+      CANCEL
+    </button>
+
+    <button
+      #submitButton
+      nbButton
+      status="primary"
+      [nbTooltip]="isEditMode ? 'Save changes' : 'Create dataset'"
+      class="d-flex align-items-center"
+      [nbSpinner]="isLoading"
+      [disabled]="isLoading"
+      (click)="submit()"
+    >
+      <nb-icon
+        [icon]="isEditMode ? 'check-lg' : 'plus-lg'"
+        class="mr-2"
+      ></nb-icon>
+      {{ isEditMode ? 'SAVE' : 'CREATE' }}
+    </button>
+  </nb-card-footer>
+</nb-card>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
@@ -5,6 +5,8 @@ import { Subject, takeUntil } from 'rxjs';
 import { StateService } from '../../../core-nlp/state.service';
 import { Dataset } from '../models';
 import { DatasetsService } from '../services/datasets.service';
+import { getExportFileName } from '../../../shared/utils';
+import { saveAs } from 'file-saver-es';
 
 interface QuestionForm {
   question: FormControl<string>;
@@ -23,6 +25,7 @@ function atLeastOneFilledQuestion(control: AbstractControl): ValidationErrors | 
   return hasFilled ? null : { custom: 'At least one question is required.' };
 }
 
+const question_minLength = 2;
 const question_maxLength = 1500;
 const groundtruth_maxLength = 1500;
 
@@ -77,7 +80,7 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
     dataset.questions.forEach((q) => {
       this.questions.push(
         new FormGroup<QuestionForm>({
-          question: new FormControl(q.question, [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+          question: new FormControl(q.question, [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]),
           groundTruth: new FormControl(q.groundTruth ?? '', [Validators.maxLength(groundtruth_maxLength)])
         })
       );
@@ -117,7 +120,7 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
   private _appendEmptyQuestion(): void {
     this.questions.push(
       new FormGroup<QuestionForm>({
-        question: new FormControl('', [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+        question: new FormControl('', [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]),
         groundTruth: new FormControl('', [Validators.maxLength(groundtruth_maxLength)])
       })
     );
@@ -131,12 +134,12 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
     this.questions.updateValueAndValidity();
   }
 
-  private _getFilledQuestions() {
+  private _getFilledQuestions(omitIds: boolean = false): { id?: string; question: string; groundTruth: string }[] {
     return this.questions.controls
       .filter((g) => g.controls.question.value.trim())
       .map((g, i) => ({
         // Preserve the original question ID when editing so the backend can diff
-        ...(this.isEditMode && this.dataset.questions[i] ? { id: this.dataset.questions[i].id } : {}),
+        ...(this.isEditMode && !omitIds && this.dataset.questions[i] ? { id: this.dataset.questions[i].id } : {}),
         question: g.controls.question.value.trim(),
         groundTruth: g.controls.groundTruth.value.trim()
       }));
@@ -158,8 +161,6 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
   }
 
   private _create(): void {
-    const { namespace, name: botId } = this.stateService.currentApplication;
-
     this.datasetsService
       .createDataset({
         name: this.form.controls.name.value,
@@ -191,6 +192,27 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
           this.toastrService.danger('An error occured', 'Error', { duration: 5000 });
         }
       });
+  }
+
+  exportDataset(): void {
+    const dataStr = JSON.stringify({
+      name: this.form.controls.name.value,
+      description: this.form.controls.description.value,
+      questions: this._getFilledQuestions(true) // Omit question IDs in export since they are only relevant for diffing during updates
+    });
+
+    const exportFileName = getExportFileName(
+      this.stateService.currentApplication.namespace,
+      this.stateService.currentApplication.name,
+      'dataset',
+      'json'
+    );
+
+    const blob = new Blob([dataStr], {
+      type: 'application/json'
+    });
+
+    saveAs(blob, exportFileName);
   }
 
   onQuestionPaste(event: ClipboardEvent, index: number): void {
@@ -228,7 +250,7 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
         // No existing row at this position: create a new form group
         this.questions.push(
           new FormGroup<QuestionForm>({
-            question: new FormControl(line, [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+            question: new FormControl(line, [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]),
             groundTruth: new FormControl('', [Validators.maxLength(groundtruth_maxLength)])
           })
         );

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
@@ -1,0 +1,257 @@
+import { Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import { AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { NbDialogRef, NbToastrService } from '@nebular/theme';
+import { Subject, takeUntil } from 'rxjs';
+import { StateService } from '../../../core-nlp/state.service';
+import { Dataset } from '../models';
+import { DatasetsService } from '../services/datasets.service';
+
+interface QuestionForm {
+  question: FormControl<string>;
+  groundTruth: FormControl<string>;
+}
+
+interface DatasetForm {
+  name: FormControl<string>;
+  description: FormControl<string>;
+  questions: FormArray<FormGroup<QuestionForm>>;
+}
+
+function atLeastOneFilledQuestion(control: AbstractControl): ValidationErrors | null {
+  const array = control as FormArray;
+  const hasFilled = array.controls.some((g) => (g as FormGroup).get('question')?.value?.trim());
+  return hasFilled ? null : { custom: 'At least one question is required.' };
+}
+
+const question_maxLength = 1500;
+const groundtruth_maxLength = 1500;
+
+@Component({
+  selector: 'tock-dataset-create',
+  templateUrl: './dataset-create.component.html',
+  styleUrl: './dataset-create.component.scss'
+})
+export class DatasetCreateComponent implements OnInit, OnDestroy {
+  private readonly destroy$: Subject<boolean> = new Subject();
+
+  isSubmitted: boolean = false;
+  isLoading: boolean = false;
+
+  // Injected by the dialog caller when editing an existing dataset
+  dataset?: Dataset;
+
+  get isEditMode(): boolean {
+    return !!this.dataset;
+  }
+
+  form = new FormGroup<DatasetForm>({
+    name: new FormControl('', [Validators.required, Validators.minLength(5), Validators.maxLength(100)]),
+    description: new FormControl('', [Validators.maxLength(750)]),
+    questions: new FormArray<FormGroup<QuestionForm>>([], [atLeastOneFilledQuestion])
+  });
+
+  @ViewChildren('questionInput') questionInputs: QueryList<ElementRef<HTMLInputElement>>;
+  @ViewChild('submitButton') submitButton: ElementRef<HTMLButtonElement>;
+
+  constructor(
+    public dialogRef: NbDialogRef<DatasetCreateComponent>,
+    private stateService: StateService,
+    private datasetsService: DatasetsService,
+    private toastrService: NbToastrService
+  ) {}
+
+  ngOnInit(): void {
+    if (this.isEditMode) {
+      this._populateForm(this.dataset);
+    } else {
+      this._appendEmptyQuestion();
+    }
+  }
+
+  private _populateForm(dataset: Dataset): void {
+    this.form.patchValue({
+      name: dataset.name,
+      description: dataset.description
+    });
+
+    dataset.questions.forEach((q) => {
+      this.questions.push(
+        new FormGroup<QuestionForm>({
+          question: new FormControl(q.question, [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+          groundTruth: new FormControl(q.groundTruth ?? '', [Validators.maxLength(groundtruth_maxLength)])
+        })
+      );
+    });
+
+    // Append the empty trailing row for adding new questions
+    this._appendEmptyQuestion();
+  }
+
+  get canSave(): boolean {
+    return this.isSubmitted ? this.form.valid : this.form.dirty;
+  }
+
+  get questions(): FormArray<FormGroup<QuestionForm>> {
+    return this.form.controls.questions;
+  }
+
+  getFormControl(name: keyof DatasetForm): FormControl {
+    return this.form.get(name) as FormControl;
+  }
+
+  getFormArray(name: keyof DatasetForm): FormArray {
+    return this.form.get(name) as FormArray;
+  }
+
+  isLastEntry(index: number): boolean {
+    return index === this.questions.length - 1;
+  }
+
+  onQuestionInput(index: number): void {
+    if (this.isLastEntry(index) && this.questions.at(index).controls.question.value.trim()) {
+      this._appendEmptyQuestion();
+    }
+    this.questions.updateValueAndValidity();
+  }
+
+  private _appendEmptyQuestion(): void {
+    this.questions.push(
+      new FormGroup<QuestionForm>({
+        question: new FormControl('', [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+        groundTruth: new FormControl('', [Validators.maxLength(groundtruth_maxLength)])
+      })
+    );
+  }
+
+  removeQuestion(index: number): void {
+    this.questions.removeAt(index);
+    if (this.questions.length === 0) {
+      this._appendEmptyQuestion();
+    }
+    this.questions.updateValueAndValidity();
+  }
+
+  private _getFilledQuestions() {
+    return this.questions.controls
+      .filter((g) => g.controls.question.value.trim())
+      .map((g, i) => ({
+        // Preserve the original question ID when editing so the backend can diff
+        ...(this.isEditMode && this.dataset.questions[i] ? { id: this.dataset.questions[i].id } : {}),
+        question: g.controls.question.value.trim(),
+        groundTruth: g.controls.groundTruth.value.trim()
+      }));
+  }
+
+  submit(): void {
+    this.isSubmitted = true;
+    this.questions.updateValueAndValidity();
+
+    if (!this.form.valid) return;
+
+    this.isLoading = true;
+
+    if (this.isEditMode) {
+      this._update();
+    } else {
+      this._create();
+    }
+  }
+
+  private _create(): void {
+    const { namespace, name: botId } = this.stateService.currentApplication;
+
+    this.datasetsService
+      .createDataset({
+        name: this.form.controls.name.value,
+        description: this.form.controls.description.value,
+        questions: this._getFilledQuestions()
+      })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (created: Dataset) => this.dialogRef.close(created),
+        error: () => {
+          this.isLoading = false;
+          this.toastrService.danger('An error occured', 'Error', { duration: 5000 });
+        }
+      });
+  }
+
+  private _update(): void {
+    this.datasetsService
+      .updateDataset(this.dataset.id, {
+        name: this.form.controls.name.value,
+        description: this.form.controls.description.value,
+        questions: this._getFilledQuestions()
+      })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (updated: Dataset) => this.dialogRef.close(updated),
+        error: () => {
+          this.isLoading = false;
+          this.toastrService.danger('An error occured', 'Error', { duration: 5000 });
+        }
+      });
+  }
+
+  onQuestionPaste(event: ClipboardEvent, index: number): void {
+    const plainText = event.clipboardData?.getData('text');
+    if (!plainText) return;
+
+    // Check for spreadsheet origin by inspecting the HTML clipboard format.
+    // When copying from Excel / Google Sheets / LibreOffice Calc, the clipboard
+    // always contains a text/html payload structured as an HTML table.
+    const html = event.clipboardData?.getData('text/html') ?? '';
+    const isFromSpreadsheet = /<table[\s>]/i.test(html);
+
+    // Split on all line break variants (Windows \r\n, Unix \n, legacy Mac \r)
+    const lines = plainText
+      .split(/\r\n|\r|\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+
+    // Fall back to native paste if:
+    // - only one line, OR
+    // - multiple lines but content does NOT come from a spreadsheet
+    //   (likely a multi-line question typed or pasted from a text editor)
+    if (lines.length <= 1 || !isFromSpreadsheet) return;
+
+    // Prevent native paste since we handle distribution ourselves
+    event.preventDefault();
+
+    lines.forEach((line, i) => {
+      const targetIndex = index + i;
+
+      if (targetIndex < this.questions.length) {
+        // Reuse an existing form group (including the current trailing empty row)
+        this.questions.at(targetIndex).controls.question.setValue(line);
+      } else {
+        // No existing row at this position: create a new form group
+        this.questions.push(
+          new FormGroup<QuestionForm>({
+            question: new FormControl(line, [Validators.minLength(5), Validators.maxLength(question_maxLength)]),
+            groundTruth: new FormControl('', [Validators.maxLength(groundtruth_maxLength)])
+          })
+        );
+      }
+    });
+
+    // Ensure there is always one trailing empty row for adding new questions
+    const last = this.questions.at(this.questions.length - 1);
+    if (last.controls.question.value.trim()) {
+      this._appendEmptyQuestion();
+    }
+
+    this.questions.updateValueAndValidity();
+
+    // Move focus to the trailing empty row after paste
+    setTimeout(() => {
+      const inputs = this.questionInputs.toArray();
+      inputs[index + lines.length]?.nativeElement.focus();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
@@ -64,8 +64,13 @@
               </span>
             </ng-container>
           </ng-container>
-          <!-- <span class="tag text-nowrap settings">RAG > INTENT</span>
-          <span class="tag text-nowrap settings">INTENT > RAG</span> -->
+          <span
+            *ngIf="actionTypeTransition"
+            class="tag text-nowrap changed"
+            [nbTooltip]="'Answer type changed between runs: ' + actionTypeTransition"
+          >
+            {{ actionTypeTransition }}
+          </span>
         </div>
 
         <button
@@ -108,7 +113,7 @@
             <div class="text-uppercase monospace text-primary font-size-small">Run A</div>
             <div
               *ngIf="currentActionDisplayState === DatasetRunActionDisplayState.SUCCESS"
-              class="tag text-muted"
+              class="tag text-muted font-size-small"
             >
               {{ getActionTypeLabel('A') }}
             </div>
@@ -146,7 +151,7 @@
             <div class="text-uppercase monospace text-success font-size-small">Run B</div>
             <div
               *ngIf="comparisonActionDisplayState === DatasetRunActionDisplayState.SUCCESS"
-              class="tag text-muted"
+              class="tag text-muted font-size-small"
             >
               {{ getActionTypeLabel('B') }}
             </div>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
@@ -1,0 +1,329 @@
+<!--
+  ~ Copyright (C) 2017/2025 SNCF Connect & Tech
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<nb-card [ngClass]="{'mb-4':!folded,'mb-1':folded,}">
+  <nb-card-body class="p-0">
+    <div class="border-bottom p-3">
+      <div class="d-flex gap-1 align-items-center">
+        <div class="flex-grow-1 min-width-0">
+          <div
+            class="font-weight-bold pointer"
+            [class.ellipsis]="truncateTitle"
+            [class.white-space-pre-line]="!truncateTitle"
+            (click)="switchTruncateTitle()"
+          >
+            {{ question.question }}
+          </div>
+          <div
+            *ngIf="question.groundTruth"
+            class="font-size-small text-muted pointer"
+            [class.ellipsis]="truncateTitle"
+            [class.white-space-pre-line]="!truncateTitle"
+            (click)="switchTruncateTitle()"
+          >
+            <span class="tag">Ground truth</span> {{ question.groundTruth }}
+          </div>
+        </div>
+
+        <div class="d-flex gap-05">
+          <ng-container *ngIf="sourceDiff">
+            <ng-container *ngIf="sourceDiff as sourcesDiff">
+              <span
+                *ngIf="sourcesDiff.added.length"
+                class="tag text-nowrap added"
+                nbTooltip="Added source(s)"
+              >
+                <i class="bi bi-file-earmark-fill"></i> {{ sourcesDiff.added.length }} added
+              </span>
+              <span
+                *ngIf="sourcesDiff.modified.length"
+                class="tag text-nowrap changed"
+                nbTooltip="Modified source(s)"
+              >
+                <i class="bi bi-file-earmark-fill"></i> {{ sourcesDiff.modified.length }} modified
+              </span>
+              <span
+                *ngIf="sourcesDiff.removed.length"
+                class="tag text-nowrap removed"
+                nbTooltip="Removed source(s)"
+              >
+                <i class="bi bi-file-earmark-fill"></i> {{ sourcesDiff.removed.length }} removed
+              </span>
+            </ng-container>
+          </ng-container>
+          <!-- <span class="tag text-nowrap settings">RAG > INTENT</span>
+          <span class="tag text-nowrap settings">INTENT > RAG</span> -->
+        </div>
+
+        <button
+          nbButton
+          ghost
+          (click)="folded = !folded"
+        >
+          <nb-icon
+            *ngIf="!folded"
+            class="align-middle"
+            icon="chevron-down-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+          <nb-icon
+            *ngIf="folded"
+            class="align-middle"
+            icon="chevron-left-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+      </div>
+    </div>
+
+    <div
+      *ngIf="loading && !folded"
+      [nbSpinner]="loading"
+      class="p-4"
+    ></div>
+
+    <div
+      #hideableContainer
+      class="py-3 hideable-container border-bottom"
+      [class.collapsed]="isCollapsed"
+      *ngIf="!loading && !folded"
+    >
+      <!-- title -->
+      <div [class.comparison]="comparisonAction">
+        <div class="px-3">
+          <div class="d-flex gap-05 justify-content-between align-items-center">
+            <div class="text-uppercase monospace text-primary font-size-small">Run A</div>
+            <div
+              *ngIf="currentActionDisplayState === DatasetRunActionDisplayState.SUCCESS"
+              class="tag text-muted"
+            >
+              {{ getActionTypeLabel('A') }}
+            </div>
+
+            <button
+              nbButton
+              size="small"
+              ghost
+              nbTooltip="Switch message formatting"
+              class="mt-1"
+              (click)="switchFormatting()"
+            >
+              <nb-icon
+                *ngIf="!formatting"
+                icon="body-text"
+              ></nb-icon>
+              <nb-icon
+                *ngIf="formatting"
+                icon="code-square"
+              ></nb-icon>
+            </button>
+          </div>
+        </div>
+
+        <div
+          *ngIf="comparisonAction"
+          class="separator"
+        ></div>
+
+        <div
+          *ngIf="comparisonAction"
+          class="px-3"
+        >
+          <div class="d-flex gap-05 justify-content-between align-items-center">
+            <div class="text-uppercase monospace text-success font-size-small">Run B</div>
+            <div
+              *ngIf="comparisonActionDisplayState === DatasetRunActionDisplayState.SUCCESS"
+              class="tag text-muted"
+            >
+              {{ getActionTypeLabel('B') }}
+            </div>
+
+            <button
+              nbButton
+              size="small"
+              ghost
+              nbTooltip="Switch message formatting"
+              class="mt-1"
+              (click)="switchFormatting()"
+            >
+              <nb-icon
+                *ngIf="!formatting"
+                icon="body-text"
+              ></nb-icon>
+              <nb-icon
+                *ngIf="formatting"
+                icon="code-square"
+              ></nb-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- answer -->
+      <div [class.comparison]="comparisonAction">
+        <div class="px-3">
+          <ng-container [ngSwitch]="currentActionDisplayState">
+            <div
+              *ngSwitchCase="null"
+              class="text-muted text-center"
+            >
+              It appears that this question was not part of the dataset during this run.
+            </div>
+            <div
+              *ngSwitchCase="DatasetRunActionDisplayState.FAILED"
+              class="text-danger text-center"
+            >
+              This action failed during run and produced no output.
+            </div>
+            <div
+              *ngSwitchCase="DatasetRunActionDisplayState.PURGED"
+              class="text-warning text-center"
+            >
+              The dialogue associated with this result has been purged and is no longer available.
+            </div>
+
+            <ng-container *ngSwitchCase="DatasetRunActionDisplayState.SUCCESS">
+              <div
+                *ngIf="formatting"
+                class="chat-ui-message-content-styling"
+                [innerHTML]="currentActionAnswer"
+              ></div>
+              <div *ngIf="!formatting">{{ currentAction?.action?.message?.text }}</div>
+            </ng-container>
+          </ng-container>
+        </div>
+
+        <div
+          *ngIf="!loading && comparisonAction"
+          class="separator"
+        ></div>
+
+        <div
+          *ngIf="!loading && comparisonAction"
+          class="px-3"
+        >
+          <ng-container [ngSwitch]="comparisonActionDisplayState">
+            <div
+              *ngSwitchCase="DatasetRunActionDisplayState.FAILED"
+              class="text-danger text-center"
+            >
+              This action failed during run and produced no output.
+            </div>
+            <div
+              *ngSwitchCase="DatasetRunActionDisplayState.PURGED"
+              class="text-warning text-center"
+            >
+              The dialogue associated with this result has been purged and is no longer available.
+            </div>
+            <ng-container *ngSwitchCase="DatasetRunActionDisplayState.SUCCESS">
+              <div
+                *ngIf="formatting"
+                class="chat-ui-message-content-styling"
+                [innerHTML]="comparisonActionAnswer"
+              ></div>
+              <div *ngIf="!formatting">{{ comparisonAction?.action?.message?.text }}</div>
+            </ng-container>
+          </ng-container>
+        </div>
+      </div>
+
+      <!-- sources -->
+      <div
+        [class.comparison]="comparisonAction"
+        *ngIf="currentAction?.action?.message?.footnotes?.length || comparisonAction?.action?.message?.footnotes?.length"
+      >
+        <div class="px-3 border-top pt-3">
+          <div class="d-flex flex-column gap-05">
+            <ng-container *ngIf="currentAction?.action?.message?.footnotes?.length">
+              <ng-container *ngFor="let source of currentFootnotesOrdered">
+                <div
+                  class="tag pointer"
+                  [class.added]="isSourceAdded(source)"
+                  [class.changed]="isSourceChanged(source)"
+                  [nbTooltip]="getSourceDiffTooltip(source)"
+                  (click)="showSourceDetail(source)"
+                >
+                  <i class="bi bi-file-earmark-fill"></i> {{ source.title }}
+                </div>
+                <div *ngIf="source._detail">
+                  <div class="mt-1 mx-2 font-size-small">
+                    <div><strong>TITLE:</strong> {{ source.title ?? 'N/A' }}</div>
+                    <div><strong>URL:</strong> {{ source.url ?? 'N/A' }}</div>
+                    <div>
+                      <strong>CONTENT:</strong><br />
+                      {{ source.content }}
+                    </div>
+                  </div>
+                </div>
+              </ng-container>
+            </ng-container>
+          </div>
+        </div>
+
+        <div
+          *ngIf="currentAction?.action?.message?.footnotes?.length || comparisonAction?.action?.message?.footnotes?.length"
+          class="separator"
+        ></div>
+
+        <div
+          *ngIf="currentAction?.action?.message?.footnotes?.length || comparisonAction?.action?.message?.footnotes?.length"
+          class="px-3 border-top pt-3"
+        >
+          <div
+            *ngIf="!loading && comparisonAction"
+            class="d-flex flex-column gap-05"
+          >
+            <ng-container *ngIf="comparisonAction?.action?.message?.footnotes?.length">
+              <ng-container *ngFor="let source of comparisonFootnotesOrdered">
+                <div
+                  class="tag muted pointer"
+                  [class.removed]="isSourceRemoved(source)"
+                  [class.changed]="isSourceChanged(source)"
+                  [nbTooltip]="getSourceDiffTooltip(source)"
+                  (click)="showSourceDetail(source)"
+                >
+                  <i class="bi bi-file-earmark-fill"></i> {{ source.title }}
+                </div>
+                <div *ngIf="source._detail">
+                  <div class="mt-1 mx-2 font-size-small">
+                    <div><strong>TITLE:</strong> {{ source.title ?? 'N/A' }}</div>
+                    <div><strong>URL:</strong> {{ source.url ?? 'N/A' }}</div>
+                    <div>
+                      <strong>CONTENT:</strong><br />
+                      {{ source.content }}
+                    </div>
+                  </div>
+                </div>
+              </ng-container>
+            </ng-container>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button
+      *ngIf="!folded && showToggleButton"
+      nbButton
+      ghost
+      fullWidth
+      size="tiny"
+      (click)="toggleCollapse()"
+      class="d-flex flex-column"
+    >
+      {{ isCollapsed ? 'Show more' : 'Show less' }}
+    </button>
+  </nb-card-body>
+</nb-card>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.scss
@@ -1,0 +1,99 @@
+:host {
+  --hideable-container-inner-shadow: inset 0px -7px 9px -10px rgba(0, 0, 0, 0.3);
+  --diff-added-color: #4d8262;
+  --diff-removed-color: #903535;
+  --pre-code-bg-color: var(--background-basic-color-3);
+
+  --tag-bg-default: var(--background-basic-color-3);
+
+  --tag-text-green: #24857a;
+  --tag-bg-green: #98eae0;
+
+  --tag-text-orange: #ba7301;
+  --tag-bg-orange: #f5a5247d;
+
+  --tag-text-red: #a41616;
+  --tag-bg-red: #de09097d;
+}
+.nb-theme-dark {
+  :host {
+    --hideable-container-inner-shadow: inset 0px -7px 9px -10px rgba(0, 0, 0, 0.9);
+    --diff-added-color: #c2ffdb;
+    --diff-removed-color: #fbd5d5;
+    --pre-code-bg-color: rgb(from var(--background-basic-color-3) r g b / 0.7);
+
+    --tag-bg-default: var(--background-basic-color-2);
+
+    --tag-text-green: #2dd4bf;
+    --tag-bg-green: #1d50577d;
+
+    --tag-text-orange: #f5a524;
+    --tag-bg-orange: #7d54127d;
+
+    --tag-text-red: #f55624;
+    --tag-bg-red: #7d12127d;
+  }
+}
+
+:host ::ng-deep span.added {
+  color: var(--diff-added-color);
+}
+
+:host ::ng-deep span.removed {
+  color: var(--diff-removed-color);
+}
+
+:host ::ng-deep .chat-ui-message-content-styling pre code {
+  background-color: var(--pre-code-bg-color);
+}
+
+.hideable-container {
+  overflow: hidden;
+  transition: max-height 1.5s ease;
+  max-height: 10000px;
+
+  &.collapsed {
+    transition: max-height 1s ease;
+    max-height: 300px;
+    box-shadow: var(--hideable-container-inner-shadow);
+  }
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.5rem;
+
+  > div:not(.separator) {
+    min-width: 0;
+    overflow-x: auto;
+  }
+
+  .separator {
+    width: 1px;
+    background-color: var(--border-basic-color-4);
+  }
+
+  &.large {
+    gap: 2em;
+  }
+}
+
+.tag {
+  background-color: var(--tag-bg-default);
+  border-radius: 0.3em;
+  padding: 0.1em 0.3em 0.2em 0.3em;
+
+  &.added {
+    color: var(--tag-text-green);
+    background-color: var(--tag-bg-green);
+  }
+  &.changed {
+    color: var(--tag-text-orange);
+    background-color: var(--tag-bg-orange);
+  }
+  &.removed {
+    color: var(--tag-text-red);
+    background-color: var(--tag-bg-red);
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.ts
@@ -41,6 +41,8 @@ export class DatasetDetailEntryComponent implements OnChanges {
   // Computed once per ngOnChanges — null when no comparison or sources are not RAG
   sourceDiff: SourcesDiffResult | null = null;
 
+  actionTypeTransition: string | null = null;
+
   // Display state derived from action state + action nullability
   currentActionDisplayState: DatasetRunActionDisplayState | null = null;
   comparisonActionDisplayState: DatasetRunActionDisplayState | null = null;
@@ -71,6 +73,8 @@ export class DatasetDetailEntryComponent implements OnChanges {
     const [currentOrdered, comparisonOrdered] = this._computeSourceOrder();
     this.currentFootnotesOrdered = currentOrdered;
     this.comparisonFootnotesOrdered = comparisonOrdered;
+
+    this.actionTypeTransition = this._computeActionTypeTransition();
 
     this._generateAnswerDiff();
   }
@@ -227,6 +231,17 @@ export class DatasetDetailEntryComponent implements OnChanges {
     }
 
     return { added, modified, removed };
+  }
+
+  private _computeActionTypeTransition(): string | null {
+    if (!this.comparisonAction || !this.currentAction) return null;
+
+    const labelA = this.getActionTypeLabel('A');
+    const labelB = this.getActionTypeLabel('B');
+
+    if (labelA === labelB || labelA === '-' || labelB === '-') return null;
+
+    return `${labelA} < ${labelB}`; // ex: "INTENT > RAG" ou "RAG > INTENT"
   }
 
   private _computeDisplayState(action: DatasetRunAction | null): DatasetRunActionDisplayState | null {

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.ts
@@ -1,0 +1,312 @@
+import { Component, ElementRef, inject, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  DatasetQuestion,
+  DatasetRunAction,
+  DatasetRunActionState,
+  DatasetRunActionDisplayState,
+  SourcesDiffResult,
+  SourceInfos
+} from '../../models';
+import { MarkdownDiffService } from '../../services/markdown-diff.service';
+import { markedParserForDiff } from '../../../../shared/utils/markup.utils';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { EventType } from '../../../../core/model/configuration';
+
+@Component({
+  selector: 'tock-dataset-detail-entry',
+  templateUrl: './dataset-detail-entry.component.html',
+  styleUrl: './dataset-detail-entry.component.scss'
+})
+export class DatasetDetailEntryComponent implements OnChanges {
+  readonly DatasetRunActionDisplayState = DatasetRunActionDisplayState;
+
+  loading: boolean = true;
+  folded: boolean = false;
+  isCollapsed: boolean = true;
+  showToggleButton: boolean = false;
+  maxContentHeight = 300;
+  truncateTitle: boolean = true;
+  formatting: boolean = true;
+
+  @Input() currentRunActions: DatasetRunAction[];
+  @Input() comparisonRunActions: DatasetRunAction[];
+  @Input() question: DatasetQuestion;
+
+  currentAction: DatasetRunAction | null = null;
+  comparisonAction: DatasetRunAction | null = null;
+
+  currentActionAnswer: SafeHtml | null = null;
+  comparisonActionAnswer: SafeHtml | null = null;
+
+  // Computed once per ngOnChanges — null when no comparison or sources are not RAG
+  sourceDiff: SourcesDiffResult | null = null;
+
+  // Display state derived from action state + action nullability
+  currentActionDisplayState: DatasetRunActionDisplayState | null = null;
+  comparisonActionDisplayState: DatasetRunActionDisplayState | null = null;
+
+  currentFootnotesOrdered: SourceInfos[] = [];
+  comparisonFootnotesOrdered: SourceInfos[] = [];
+
+  @ViewChild('hideableContainer') hideableContainer!: ElementRef;
+
+  private readonly diffService = inject(MarkdownDiffService);
+  private readonly sanitizer = inject(DomSanitizer);
+
+  ngOnChanges(_changes: SimpleChanges): void {
+    this.loading = true;
+    this.currentActionAnswer = null;
+    this.comparisonActionAnswer = null;
+
+    this.currentAction = this.currentRunActions?.find((a) => a.questionId === this.question.id) ?? null;
+    this.comparisonAction = this.comparisonRunActions?.find((a) => a.questionId === this.question.id) ?? null;
+
+    this.currentActionDisplayState = this._computeDisplayState(this.currentAction);
+    this.comparisonActionDisplayState = this._computeDisplayState(this.comparisonAction);
+
+    // Compute source diff synchronously — exposed as a property so the template
+    // never triggers recalculation on its own during change detection cycles.
+    this.sourceDiff = this._computeSourceDiff();
+
+    const [currentOrdered, comparisonOrdered] = this._computeSourceOrder();
+    this.currentFootnotesOrdered = currentOrdered;
+    this.comparisonFootnotesOrdered = comparisonOrdered;
+
+    this._generateAnswerDiff();
+  }
+
+  switchTruncateTitle(): void {
+    this.truncateTitle = !this.truncateTitle;
+  }
+
+  switchFormatting(): void {
+    this.formatting = !this.formatting;
+  }
+
+  // ── Content height toggle ─────────────────────────────────────────────────
+
+  toggleCollapse(): void {
+    this.isCollapsed = !this.isCollapsed;
+  }
+
+  checkContentHeight(): void {
+    if (!this.hideableContainer?.nativeElement) return;
+    this.showToggleButton = this.hideableContainer.nativeElement.scrollHeight > this.maxContentHeight;
+  }
+
+  // ── Source diff helpers (template-facing, read-only) ──────────────────────
+
+  isSourceAdded(source: SourceInfos): boolean {
+    return this.sourceDiff?.added.some((s) => this._getSourceKey(s) === this._getSourceKey(source)) ?? false;
+  }
+
+  isSourceChanged(source: SourceInfos): boolean {
+    return this.sourceDiff?.modified.some((s) => this._getSourceKey(s) === this._getSourceKey(source)) ?? false;
+  }
+
+  isSourceRemoved(source: SourceInfos): boolean {
+    return this.sourceDiff?.removed.some((s) => this._getSourceKey(s) === this._getSourceKey(source)) ?? false;
+  }
+
+  getSourceDiffTooltip(source: SourceInfos): string {
+    const key = this._getSourceKey(source);
+    if (this.sourceDiff?.added.some((s) => this._getSourceKey(s) === key)) return 'This source was added in the latest run.';
+    if (this.sourceDiff?.modified.some((s) => this._getSourceKey(s) === key)) return 'This source was modified in the latest run.';
+    if (this.sourceDiff?.removed.some((s) => this._getSourceKey(s) === key)) return 'This source was removed in the latest run.';
+    return 'This source is unchanged.';
+  }
+
+  showSourceDetail(source): void {
+    source._detail = !source._detail;
+  }
+
+  // ── Action type label ─────────────────────────────────────────────────────
+
+  getActionTypeLabel(side: 'A' | 'B'): string {
+    const action = side === 'A' ? this.currentAction : this.comparisonAction;
+    if (!action?.action) return '-';
+    if (action.action.metadata?.isGenAiRagAnswer) return 'RAG';
+    return this._eventTypeLabel(EventType[action.action.message.eventType as string]);
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async _generateAnswerDiff(): Promise<void> {
+    try {
+      const currentText = this.currentAction?.action?.message?.text;
+      const comparisonText = this.comparisonAction?.action?.message?.text;
+
+      if (currentText && comparisonText) {
+        const result = await this.diffService.diff(currentText, comparisonText);
+        this.currentActionAnswer = this.sanitizer.bypassSecurityTrustHtml(markedParserForDiff.parse(result.textA) as string);
+        this.comparisonActionAnswer = this.sanitizer.bypassSecurityTrustHtml(markedParserForDiff.parse(result.textB) as string);
+      } else if (currentText) {
+        this.currentActionAnswer = this.sanitizer.bypassSecurityTrustHtml(markedParserForDiff.parse(currentText) as string);
+      }
+    } catch (err) {
+      console.error('Failed to generate answer diff', err);
+    } finally {
+      this.loading = false;
+      // Defer height check to the next tick so the DOM reflects the new content
+      setTimeout(() => this.checkContentHeight());
+    }
+  }
+
+  private _computeSourceDiff(): SourcesDiffResult | null {
+    const currentFootnotes = this.currentAction?.action?.message?.footnotes;
+    const comparisonFootnotes = this.comparisonAction?.action?.message?.footnotes;
+
+    if (
+      !this.comparisonAction ||
+      !this.currentAction?.action?.metadata?.isGenAiRagAnswer ||
+      !this.comparisonAction?.action?.metadata?.isGenAiRagAnswer ||
+      !currentFootnotes ||
+      !comparisonFootnotes
+    ) {
+      return null;
+    }
+
+    // Content hash is the only stable identity for a chunk across ingestions.
+    // If content is absent we cannot reliably compare — bail out.
+    const allHaveContent = [...currentFootnotes, ...comparisonFootnotes].every((s) => !!s.content);
+    if (!allHaveContent) return null;
+
+    // key = document identity (url or title) + djb2 hash of content.
+    // Stable across ingestions, discriminant across chunks of the same document.
+    const chunkKey = (s: SourceInfos) => `${s.url ?? s.title}::${this._hashContent(s.content!)}`;
+
+    // Document-level key — groups all chunks belonging to the same source document.
+    const docKey = (s: SourceInfos) => s.url || s.title;
+
+    const keysA = new Map<string, SourceInfos>(currentFootnotes.map((s) => [chunkKey(s), s]));
+    const keysB = new Map<string, SourceInfos>(comparisonFootnotes.map((s) => [chunkKey(s), s]));
+
+    // Chunks present in A (current/recent run) but absent from B (older run) → added in the recent run.
+    const added: SourceInfos[] = [];
+    for (const [key, src] of keysA) {
+      if (!keysB.has(key)) added.push(src);
+    }
+
+    // Chunks present in B (older run) but absent from A (recent run) → removed in the recent run.
+    const removed: SourceInfos[] = [];
+    for (const [key, src] of keysB) {
+      if (!keysA.has(key)) removed.push(src);
+    }
+
+    // Modified: documents that appear on both sides but whose set of content hashes
+    // differs (at least one chunk changed, added, or removed within the document).
+    // We report one representative SourceInfos per modified document (the first chunk
+    // from the current run) so the template can display a single badge per document.
+    const modified: SourceInfos[] = [];
+
+    const groupByDoc = (footnotes: SourceInfos[]): Map<string, SourceInfos[]> =>
+      footnotes.reduce((map, s) => {
+        const k = docKey(s);
+        map.set(k, [...(map.get(k) ?? []), s]);
+        return map;
+      }, new Map<string, SourceInfos[]>());
+
+    const docGroupsA = groupByDoc(currentFootnotes);
+    const docGroupsB = groupByDoc(comparisonFootnotes);
+
+    for (const [dk, chunksA] of docGroupsA) {
+      const chunksB = docGroupsB.get(dk);
+
+      // Document entirely absent from B — already captured in `removed`, skip.
+      if (!chunksB) continue;
+
+      const hashSetA = new Set(chunksA.map(chunkKey));
+      const hashSetB = new Set(chunksB.map(chunkKey));
+
+      const hasChange = [...hashSetA].some((h) => !hashSetB.has(h)) || [...hashSetB].some((h) => !hashSetA.has(h));
+
+      if (hasChange) {
+        // Use the first chunk of the current run as the display representative.
+        modified.push(chunksA[0]);
+      }
+    }
+
+    return { added, modified, removed };
+  }
+
+  private _computeDisplayState(action: DatasetRunAction | null): DatasetRunActionDisplayState | null {
+    if (!action) return null;
+    if (action.state === DatasetRunActionState.FAILED) return DatasetRunActionDisplayState.FAILED;
+    if (action.state === DatasetRunActionState.COMPLETED && !action.action) return DatasetRunActionDisplayState.PURGED;
+    return DatasetRunActionDisplayState.SUCCESS;
+  }
+
+  private _getSourceKey(source: SourceInfos): string {
+    // Prefer content hash as stable identity across ingestions.
+    // Fall back to url or title if content is unavailable.
+    if (source.content) return `${source.url ?? source.title}::${this._hashContent(source.content)}`;
+    return source.url || source.title;
+  }
+
+  // djb2 hash — fast, no crypto overhead, sufficient for diff identity.
+  private _hashContent(str: string): string {
+    let h = 5381;
+    for (let i = 0; i < str.length; i++) {
+      h = ((h << 5) + h) ^ str.charCodeAt(i);
+    }
+    return (h >>> 0).toString(36);
+  }
+
+  // Builds a shared reference order for both sides:
+  // 1. Sources present on both sides, in A's order of appearance
+  // 2. Sources only in A (removed from B) — appended after
+  // 3. Sources only in B (added in A) — appended after
+  // Both returned arrays follow this same doc-level ordering,
+  // with each document's chunks preserving their original relative order.
+  private _computeSourceOrder(): [SourceInfos[], SourceInfos[]] {
+    const currentFootnotes = this.currentAction?.action?.message?.footnotes ?? [];
+    const comparisonFootnotes = this.comparisonAction?.action?.message?.footnotes ?? [];
+
+    if (!currentFootnotes.length && !comparisonFootnotes.length) return [[], []];
+
+    const docKey = (s: SourceInfos) => s.url || s.title;
+
+    const docKeysA = [...new Set(currentFootnotes.map(docKey))];
+    const docKeysB = new Set(comparisonFootnotes.map(docKey));
+
+    // 1. Common docs — in A's order
+    const commonKeys = docKeysA.filter((k) => docKeysB.has(k));
+
+    // 2. Only in A (removed) — in A's order
+    const onlyInA = docKeysA.filter((k) => !docKeysB.has(k));
+
+    // 3. Only in B (added) — in B's order
+    const docKeysB_ordered = [...new Set(comparisonFootnotes.map(docKey))];
+    const onlyInB = docKeysB_ordered.filter((k) => !new Set(docKeysA).has(k));
+
+    const referenceOrder = [...commonKeys, ...onlyInA, ...onlyInB];
+    const rank = new Map<string, number>(referenceOrder.map((k, i) => [k, i] as [string, number]));
+
+    const sort = (footnotes: SourceInfos[]) =>
+      [...footnotes].sort((a, b) => {
+        const ra = rank.get(docKey(a)) ?? Infinity;
+        const rb = rank.get(docKey(b)) ?? Infinity;
+        if (ra !== rb) return ra - rb;
+        // Same document: preserve original chunk order
+        return footnotes.indexOf(a) - footnotes.indexOf(b);
+      });
+
+    return [sort(currentFootnotes), sort(comparisonFootnotes)];
+  }
+
+  private _eventTypeLabel(eventType: EventType): string {
+    switch (eventType) {
+      case EventType.sentence:
+      case EventType.sentenceWithFootnotes:
+        return 'INTENT';
+      case EventType.attachment:
+        return 'ATTACHMENT';
+      case EventType.choice:
+        return 'CHOICE';
+      case EventType.location:
+        return 'LOCATION';
+      default:
+        return '-';
+    }
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.html
@@ -1,0 +1,258 @@
+<div class="d-flex align-items-center mb-3">
+  <div class="flex-grow-1">
+    <h1 class="m-0">Dataset run</h1>
+    <div class="lead">{{ dataset?.name }}</div>
+    <small>
+      {{ dataset?.description }}
+    </small>
+  </div>
+</div>
+
+<tock-sticky-menu
+  *ngIf="!loading"
+  [hideable]="true"
+>
+  <div class="vs-wrapper mb-1">
+    <nb-card class="mb-0">
+      <nb-card-body>
+        <div class="d-flex gap-05 justify-content-between">
+          <span class="text-uppercase monospace text-primary text-nowrap"> Run A </span>
+          <span class="text-muted font-size-small ellipsis"> {{ currentRun.id }} </span>
+        </div>
+
+        <div class="d-flex flex-wrap column-gap-1 justify-content-between text-muted font-size-small mt-1">
+          <span class="text-nowrap">{{ currentRun.startTime | date: 'y/MM/dd - HH:mm' }}</span>
+          <i class="bi bi-chevron-bar-left"></i>
+          <span class="text-nowrap font-weight-bold">{{ getRunDuration(currentRun) }}</span>
+          <i class="bi bi-chevron-bar-right"></i>
+          <span class="text-nowrap">{{ currentRun.endTime | date: 'y/MM/dd - HH:mm' }}</span>
+        </div>
+
+        <div class="d-flex flex-wrap gap-05 justify-content-between mt-2">
+          <div
+            class="flex-fill justify-content-center tag prompt pointer"
+            [class.diff]="showComparison && hasPromptsDiff()"
+            nbTooltip="Click to see the prompts used when executing this run"
+            (click)="compareSettings(settingsDiffCurrentTabs.AnsweringPrompt)"
+          >
+            prompts
+          </div>
+          <div
+            class="flex-fill justify-content-center tag settings pointer"
+            [class.diff]="showComparison && hasSettingsDiff()"
+            nbTooltip="Click to see the settings used when executing this run"
+            (click)="compareSettings(settingsDiffCurrentTabs.RagSettings)"
+          >
+            settings
+          </div>
+          <div
+            class="flex-fill justify-content-center tag corpus"
+            [class.diff]="showComparison && hasIndexingSessionDiff()"
+            nbTooltip="Indexing session id"
+          >
+            {{ currentRun.settingsSnapshot.indexSessionId }}
+          </div>
+        </div>
+      </nb-card-body>
+
+      <nb-card-footer
+        *ngIf="comparableRuns.length > 1"
+        class="p-0 background-basic-color-2 d-flex align-items-stretch"
+      >
+        <button
+          *ngIf="canScrollLeft('current')"
+          class="scroll-arrow"
+          nbButton
+          size="tiny"
+          ghost
+          (mousedown)="startScroll('current', 'left')"
+          (mouseup)="stopScroll()"
+          (mouseleave)="stopScroll()"
+        >
+          <nb-icon
+            icon="chevron-left-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+
+        <div
+          #runsScrollA
+          class="d-flex gap-05 px-2 py-1 prev-entries flex-grow-1"
+          [class.scrolled-left]="canScrollLeft('current')"
+          (scroll)="onRunsScroll('current')"
+        >
+          <button
+            *ngFor="let entry of comparableRuns; let i = index"
+            nbButton
+            size="tiny"
+            shape="round"
+            [status]="entry.id === currentRun.id ? 'info' : 'basic'"
+            [disabled]="entry.id !== currentRun.id && !isRunSelectable('current', entry)"
+            [nbTooltip]="getPrevEntryTooltip(entry)"
+            (click)="selectCurrentRun(entry)"
+          >
+            {{ i }}
+          </button>
+        </div>
+
+        <button
+          *ngIf="canScrollRight('current')"
+          class="scroll-arrow"
+          nbButton
+          size="tiny"
+          ghost
+          (mousedown)="startScroll('current', 'right')"
+          (mouseup)="stopScroll()"
+          (mouseleave)="stopScroll()"
+        >
+          <nb-icon
+            icon="chevron-right-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+      </nb-card-footer>
+    </nb-card>
+
+    <button
+      *ngIf="comparisonRun"
+      nbButton
+      shape="round"
+      status="basic"
+      class="vs-badge align-self-center"
+      [class.comparison-off]="!showComparison"
+      [nbTooltip]="showComparison ? 'Disable comparison' : 'Enable comparison'"
+      (click)="toggleShowComparison()"
+    >
+      VS
+    </button>
+
+    <nb-card
+      *ngIf="comparisonRun && !showComparison"
+      class="mb-0 vs-no-comparison"
+    >
+      <nb-card-body class="d-flex flex-column align-items-center justify-content-center gap-1">
+        <span class="text-muted font-size-small">Comparison disabled</span>
+        <button
+          nbButton
+          ghost
+          size="tiny"
+          status="basic"
+          (click)="toggleShowComparison()"
+        >
+          Enable
+        </button>
+      </nb-card-body>
+    </nb-card>
+
+    <nb-card
+      class="mb-0"
+      *ngIf="comparisonRun && showComparison"
+    >
+      <nb-card-body>
+        <div class="d-flex gap-05 justify-content-between">
+          <span class="text-uppercase monospace text-success text-nowrap"> Run B </span>
+          <span class="text-muted font-size-small ellipsis"> {{ comparisonRun.id }} </span>
+        </div>
+
+        <div class="d-flex flex-wrap column-gap-1 justify-content-between text-muted font-size-small mt-1">
+          <span class="text-nowrap">{{ comparisonRun.startTime | date: 'y/MM/dd - HH:mm' }}</span>
+          <i class="bi bi-chevron-bar-left"></i>
+          <span class="text-nowrap font-weight-bold">{{ getRunDuration(comparisonRun) }}</span>
+          <i class="bi bi-chevron-bar-right"></i>
+          <span class="text-nowrap">{{ comparisonRun.endTime | date: 'y/MM/dd - HH:mm' }}</span>
+        </div>
+
+        <div class="d-flex flex-wrap gap-05 justify-content-between mt-2">
+          <div
+            class="flex-fill justify-content-center tag prompt pointer"
+            nbTooltip="Click to see answering the prompt used when executing this run"
+            (click)="compareSettings(settingsDiffCurrentTabs.AnsweringPrompt)"
+          >
+            prompts
+          </div>
+          <div
+            class="flex-fill justify-content-center tag settings pointer"
+            nbTooltip="Click to see the settings used when executing this run"
+            (click)="compareSettings(settingsDiffCurrentTabs.RagSettings)"
+          >
+            settings
+          </div>
+          <div
+            class="flex-fill justify-content-center tag corpus"
+            nbTooltip="Indexing session id"
+          >
+            {{ comparisonRun.settingsSnapshot.indexSessionId }}
+          </div>
+        </div>
+      </nb-card-body>
+
+      <nb-card-footer class="p-0 background-basic-color-2 d-flex align-items-stretch">
+        <button
+          *ngIf="canScrollLeft('compared')"
+          class="scroll-arrow"
+          nbButton
+          size="tiny"
+          ghost
+          (mousedown)="startScroll('compared', 'left')"
+          (mouseup)="stopScroll()"
+          (mouseleave)="stopScroll()"
+        >
+          <nb-icon
+            icon="chevron-left-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+
+        <div
+          #runsScrollB
+          class="d-flex gap-05 px-2 py-1 prev-entries flex-grow-1"
+          [class.scrolled-left]="canScrollLeft('compared')"
+          (scroll)="onRunsScroll('compared')"
+        >
+          <button
+            *ngFor="let entry of comparableRuns; let i = index"
+            nbButton
+            size="tiny"
+            shape="round"
+            [status]="entry.id === comparisonRun.id ? 'success' : 'basic'"
+            [disabled]="entry.id !== comparisonRun.id && !isRunSelectable('compared', entry)"
+            [nbTooltip]="getPrevEntryTooltip(entry)"
+            (click)="selectComparableRun(entry)"
+          >
+            {{ i }}
+          </button>
+        </div>
+
+        <button
+          *ngIf="canScrollRight('compared')"
+          class="scroll-arrow"
+          nbButton
+          size="tiny"
+          ghost
+          (mousedown)="startScroll('compared', 'right')"
+          (mouseup)="stopScroll()"
+          (mouseleave)="stopScroll()"
+        >
+          <nb-icon
+            icon="chevron-right-outline"
+            pack="nebular-essentials"
+          ></nb-icon>
+        </button>
+      </nb-card-footer>
+    </nb-card>
+  </div>
+</tock-sticky-menu>
+
+<div
+  *ngIf="!loading"
+  class="mt-4"
+>
+  <ng-container *ngFor="let question of dataset.questions">
+    <tock-dataset-detail-entry
+      *ngIf="currentRunActions"
+      [currentRunActions]="currentRunActions"
+      [comparisonRunActions]="showComparison ? comparisonRunActions : null"
+      [question]="question"
+    ></tock-dataset-detail-entry>
+  </ng-container>
+</div>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.scss
@@ -1,0 +1,201 @@
+:host {
+  /* Purple */
+  --color-purple-text: #503a90;
+  --color-purple-bg: #a78bfa7d;
+  --color-purple-border: rgba(80, 58, 144, 0.3);
+  --color-purple-bg-diff: #7c3aed;
+  --color-purple-text-diff: #ffffff;
+  --color-purple-border-diff: rgba(124, 58, 237, 0.5);
+
+  /* Orange */
+  --color-orange-text: #ba7301;
+  --color-orange-bg: #f5a5247d;
+  --color-orange-border: rgba(186, 115, 1, 0.3);
+  --color-orange-bg-diff: #ffa500;
+  --color-orange-text-diff: #000000;
+  --color-orange-border-diff: rgba(255, 165, 0, 0.5);
+
+  /* Teal */
+  --color-teal-text: #066b5f;
+  --color-teal-bg: #2dd4bf7d;
+  --color-teal-border: rgba(6, 107, 95, 0.3);
+  --color-teal-bg-diff: #00d4c0;
+  --color-teal-text-diff: #ffffff;
+  --color-teal-border-diff: rgba(0, 212, 192, 0.5);
+}
+
+.nb-theme-dark {
+  :host {
+    /* Purple */
+    --color-purple-text: #a78bfa;
+    --color-purple-bg: #5749827d;
+    --color-purple-border: rgba(167, 139, 250, 0.3);
+    --color-purple-bg-diff: #8b5cf6;
+    --color-purple-text-diff: #ffffff;
+    --color-purple-border-diff: rgba(139, 92, 246, 0.5);
+
+    /* Orange */
+    --color-orange-text: #f5a524;
+    --color-orange-bg: #7d54127d;
+    --color-orange-border: rgba(245, 165, 36, 0.3);
+    --color-orange-bg-diff: #f97316;
+    --color-orange-text-diff: #4e1c03;
+    --color-orange-border-diff: rgba(249, 115, 22, 0.5);
+
+    /* Teal */
+    --color-teal-text: #2dd4bf;
+    --color-teal-bg: #19776b7d;
+    --color-teal-border: rgba(45, 212, 191, 0.3);
+    --color-teal-bg-diff: #00b8a8;
+    --color-teal-text-diff: #ffffff;
+    --color-teal-border-diff: rgba(0, 184, 168, 0.5);
+  }
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-family: var(--font-mono);
+  border: 1px solid;
+
+  &.muted {
+    background-color: var(--background-basic-color-2) !important;
+    border-color: var(--color-teal-border);
+  }
+
+  &.prompt {
+    color: var(--color-purple-text);
+    background: var(--color-purple-bg);
+    border-color: var(--color-purple-border);
+    &.diff {
+      background: var(--color-purple-bg-diff);
+      color: var(--color-purple-text-diff);
+      border-color: var(--color-purple-border-diff);
+      font-weight: bold;
+    }
+  }
+
+  &.settings {
+    color: var(--color-orange-text);
+    background: var(--color-orange-bg);
+    border-color: var(--color-orange-border);
+    &.diff {
+      background: var(--color-orange-bg-diff);
+      color: var(--color-orange-text-diff);
+      border-color: var(--color-orange-border-diff);
+      font-weight: bold;
+    }
+  }
+
+  &.corpus {
+    color: var(--color-teal-text);
+    background: var(--color-teal-bg);
+    border-color: var(--color-teal-border);
+    &.diff {
+      background: var(--color-teal-bg-diff);
+      color: var(--color-teal-text-diff);
+      border-color: var(--color-teal-border-diff);
+      font-weight: bold;
+    }
+  }
+}
+
+.vs-wrapper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: start;
+  .vs-badge {
+    position: relative;
+    padding: 0.7em;
+    background: var(--card-background-color);
+    color: var(--card-text-color);
+    border: var(--card-border-width) var(--card-border-style) var(--card-border-color);
+    overflow: hidden;
+
+    &.comparison-off::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 150%;
+      height: 1.5px;
+      background: currentColor;
+      opacity: 0.6;
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
+  }
+}
+
+.vs-no-comparison {
+  flex: 1;
+  min-height: 100px;
+  height: 100%;
+  border-style: dotted;
+  border-width: 3px;
+}
+
+.scroll-arrow {
+  flex-shrink: 0;
+  border-radius: 0;
+  padding: 0 0.3em;
+}
+
+.prev-entries {
+  overflow-x: auto;
+  flex-wrap: nowrap;
+  scrollbar-width: none; // Firefox
+
+  &::-webkit-scrollbar {
+    display: none; // Chrome/Safari
+  }
+
+  // Fade droit — signale que le contenu déborde à droite
+  &::after {
+    content: '';
+    position: sticky;
+    right: -8px;
+    flex-shrink: 0;
+    width: 2.5rem;
+    align-self: stretch;
+    background: linear-gradient(to right, transparent, var(--background-basic-color-2));
+    pointer-events: none;
+  }
+
+  // Fade gauche — visible uniquement quand on a scrollé (classe .scrolled-left)
+  &.scrolled-left::before {
+    content: '';
+    position: sticky;
+    left: -8px;
+    flex-shrink: 0;
+    width: 2.5rem;
+    align-self: stretch;
+    background: linear-gradient(to left, transparent, var(--background-basic-color-2));
+    pointer-events: none;
+  }
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.5rem;
+
+  > div:not(.separator) {
+    min-width: 0; /* Empêche le contenu de forcer l'expansion */
+    // overflow-wrap: break-word; /* Optionnel : gère le débordement du texte */
+    overflow-x: auto;
+  }
+
+  .separator {
+    width: 1px;
+    background-color: var(--border-basic-color-4);
+  }
+
+  &.large {
+    gap: 2em;
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail.component.ts
@@ -1,0 +1,303 @@
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of, Subject, takeUntil } from 'rxjs';
+import { filter, skip, switchMap, take } from 'rxjs/operators';
+import { BotConfigurationService } from '../../../core/bot-configuration.service';
+
+import { Dataset, DatasetRun, DatasetRunAction, DatasetRunState } from '../models';
+
+import { SettingsService } from '../../../core-nlp/settings.service';
+import { DialogService } from '../../../core-nlp/dialog.service';
+import { DatasetDetailSettingsDiffComponent, SettingsDiffCurrentTabs } from './settings-diff/settings-diff.component';
+import { hasDiffExcluding } from '../../../shared/utils';
+import { DatasetsService } from '../services/datasets.service';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'tock-dataset-detail',
+  templateUrl: './dataset-detail.component.html',
+  styleUrl: './dataset-detail.component.scss'
+})
+export class DatasetDetailComponent implements OnInit, AfterViewInit, OnDestroy {
+  private readonly destroy$: Subject<boolean> = new Subject();
+
+  loading: boolean = true;
+
+  dataset: Dataset;
+
+  currentRun: DatasetRun;
+  comparisonRun: DatasetRun;
+
+  showComparison: boolean = true;
+
+  toggleShowComparison(): void {
+    this.showComparison = !this.showComparison;
+  }
+
+  currentRunActions: DatasetRunAction[];
+  comparisonRunActions: DatasetRunAction[];
+
+  // Pre-computed once per dataset load, used by the template's *ngFor — avoids
+  // recomputing on every change detection cycle
+  comparableRuns: DatasetRun[] = [];
+
+  settingsDiffCurrentTabs = SettingsDiffCurrentTabs;
+
+  @ViewChildren('runsScrollA, runsScrollB') runsScrollContainers: QueryList<ElementRef<HTMLDivElement>>;
+
+  // Scroll state per side — updated on scroll events and after view init
+  private _scrollState: Record<'current' | 'compared', { left: boolean; right: boolean }> = {
+    current: { left: false, right: false },
+    compared: { left: false, right: false }
+  };
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    private route: ActivatedRoute,
+    private router: Router,
+    public settings: SettingsService,
+    private dialogService: DialogService,
+    private datasetsService: DatasetsService,
+    private datePipe: DatePipe,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngAfterViewInit(): void {
+    // Initialize scroll state once containers are in the DOM
+    this.runsScrollContainers.changes.subscribe(() => this._refreshScrollState());
+    this._refreshScrollState();
+  }
+
+  // ── Scroll arrow helpers ──────────────────────────────────────────────────
+
+  private _getScrollEl(side: 'current' | 'compared'): HTMLDivElement | null {
+    const els = this.runsScrollContainers?.toArray();
+    if (!els?.length) return null;
+    // runsScrollA is index 0, runsScrollB is index 1 (QueryList order matches template order)
+    return side === 'current' ? els[0]?.nativeElement : els[1]?.nativeElement;
+  }
+
+  private _refreshScrollState(): void {
+    (['current', 'compared'] as const).forEach((side) => {
+      const el = this._getScrollEl(side);
+      if (!el) return;
+      this._scrollState[side] = {
+        left: el.scrollLeft > 0,
+        right: el.scrollLeft + el.clientWidth < el.scrollWidth - this._scrollRightMargin
+      };
+    });
+    this.cdr.detectChanges();
+  }
+
+  onRunsScroll(side: 'current' | 'compared'): void {
+    const el = this._getScrollEl(side);
+    if (!el) return;
+    this._scrollState[side] = {
+      left: el.scrollLeft > 0,
+      right: el.scrollLeft + el.clientWidth < el.scrollWidth - this._scrollRightMargin
+    };
+  }
+
+  canScrollLeft(side: 'current' | 'compared'): boolean {
+    return this._scrollState[side].left;
+  }
+
+  canScrollRight(side: 'current' | 'compared'): boolean {
+    return this._scrollState[side].right;
+  }
+
+  private _scrollInterval: ReturnType<typeof setInterval> | null = null;
+  private readonly _scrollRightMargin = 60; // px — stop before the real right edge
+
+  startScroll(side: 'current' | 'compared', direction: 'left' | 'right'): void {
+    this.stopScroll();
+    const el = this._getScrollEl(side);
+    if (!el) return;
+    const step = direction === 'right' ? 4 : -4;
+    this._scrollInterval = setInterval(() => {
+      const maxScroll = el.scrollWidth - el.clientWidth - this._scrollRightMargin;
+      if (direction === 'right' && el.scrollLeft >= maxScroll) {
+        this.stopScroll();
+        return;
+      }
+      el.scrollLeft += step;
+    }, 16); // ~60fps
+  }
+
+  stopScroll(): void {
+    if (this._scrollInterval !== null) {
+      clearInterval(this._scrollInterval);
+      this._scrollInterval = null;
+    }
+  }
+
+  // Emits once when the dataset has been successfully loaded — used to gate
+  // the bot-switch detection so it only activates after the initial load is done.
+  private readonly datasetLoaded$ = new Subject<void>();
+
+  ngOnInit(): void {
+    // Step 1 — initial load: read the route param once, wait for first valid configuration.
+    this.route.params
+      .pipe(
+        take(1),
+        switchMap((params) =>
+          this.botConfiguration.configurations.pipe(
+            filter((confs) => !!confs.length),
+            take(1),
+            switchMap(() => [params])
+          )
+        )
+      )
+      .subscribe((params) => this.fetchDataset(params['id']));
+
+    // Step 2 — bot switch detection: only starts listening after the dataset is loaded.
+    // This prevents the initial burst of configurations emissions from triggering
+    // a premature navigation back to the board.
+    this.datasetLoaded$
+      .pipe(
+        take(1),
+        switchMap(() =>
+          this.botConfiguration.configurations.pipe(
+            filter((confs) => !!confs.length),
+            skip(1)
+          )
+        ),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => this.router.navigate(['/quality/datasets']));
+  }
+
+  fetchDataset(datasetId: string): void {
+    this.loading = true;
+
+    // Always fetch the full dataset individually — GET /datasets returns DatasetLight
+    // entries without settingsSnapshot, which are required in this view.
+    this.datasetsService
+      .getDataset(datasetId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (dataset) => this._initFromDataset(dataset),
+        error: () => this.router.navigate(['/quality/datasets'])
+      });
+  }
+
+  private _initFromDataset(dataset: Dataset): void {
+    this.dataset = dataset;
+    this.datasetLoaded$.next();
+    this.comparableRuns = this._buildComparableRuns(dataset);
+    this.currentRun = this.comparableRuns[0] ?? null;
+
+    // If a compareRunId query param is present, use it to pre-select Run B —
+    // allows the board entry "compare with latest run" button to deep-link directly
+    // into a specific comparison. Falls back to run -1 if the id is not found
+    // among comparable runs (e.g. run is not COMPLETED).
+    const compareRunId = this.route.snapshot.queryParams['compareRunId'];
+    if (compareRunId) {
+      this.comparisonRun = this.comparableRuns.find((r) => r.id === compareRunId) ?? this.comparableRuns[1] ?? null;
+    } else {
+      this.comparisonRun = this.comparableRuns[1] ?? null;
+    }
+
+    if (this.currentRun) this.fetchRunEntries();
+    this.loading = false;
+  }
+
+  fetchRunEntries(): void {
+    if (!this.currentRun) return;
+
+    forkJoin({
+      current: this.datasetsService.getRunActions(this.dataset.id, this.currentRun.id),
+      comparison: this.comparisonRun ? this.datasetsService.getRunActions(this.dataset.id, this.comparisonRun.id) : of([])
+    })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(({ current, comparison }) => {
+        this.currentRunActions = current as DatasetRunAction[];
+        this.comparisonRunActions = comparison as DatasetRunAction[];
+      });
+  }
+
+  selectCurrentRun(run: DatasetRun): void {
+    this.currentRun = run;
+    this.fetchRunEntries();
+  }
+
+  selectComparableRun(run: DatasetRun): void {
+    this.comparisonRun = run;
+    this.fetchRunEntries();
+  }
+
+  isRunSelectable(which: 'current' | 'compared', entry: DatasetRun): boolean {
+    if (entry.id === this.currentRun?.id || entry.id === this.comparisonRun?.id) return false;
+
+    if (which === 'current' && this.comparisonRun && entry.startTime < this.comparisonRun.startTime) {
+      return false;
+    }
+
+    if (which === 'compared' && this.currentRun && entry.startTime > this.currentRun.startTime) {
+      return false;
+    }
+
+    return true;
+  }
+
+  getPrevEntryTooltip(run: DatasetRun) {
+    return `Run started by ${run.startedBy} on ${this.datePipe.transform(run.startTime, 'y/MM/dd - HH:mm')}`;
+  }
+
+  getRunDuration(run: DatasetRun): string {
+    if (!run.endTime) return '-';
+    const durationMs = new Date(run.endTime).getTime() - new Date(run.startTime).getTime();
+    return this.datasetsService.formatDuration(durationMs);
+  }
+
+  // ── Private helpers ───────────────────────────────────────────────────────
+
+  private _buildComparableRuns(dataset: Dataset): DatasetRun[] {
+    return (dataset.runs ?? [])
+      .filter((r) => r.state === DatasetRunState.COMPLETED)
+      .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+  }
+
+  // ── Settings diff helpers ─────────────────────────────────────────────────
+
+  compareSettings(tab: SettingsDiffCurrentTabs): void {
+    this.dialogService.openDialog(DatasetDetailSettingsDiffComponent, {
+      context: {
+        currentRun: this.currentRun,
+        comparisonRun: this.comparisonRun,
+        currentTab: tab
+      }
+    });
+  }
+
+  hasPromptsDiff(): boolean {
+    if (!this.comparisonRun) return false;
+    return (
+      this.currentRun.settingsSnapshot.questionAnsweringPrompt.template !==
+      this.comparisonRun.settingsSnapshot.questionAnsweringPrompt.template ||
+      this.currentRun.settingsSnapshot.questionCondensingPrompt.template !==
+      this.comparisonRun.settingsSnapshot.questionCondensingPrompt.template
+    );
+  }
+
+  hasSettingsDiff(): boolean {
+    if (!this.comparisonRun) return false;
+    return hasDiffExcluding(this.currentRun.settingsSnapshot, this.comparisonRun.settingsSnapshot, [
+      'questionAnsweringPrompt',
+      'questionCondensingPrompt',
+      'indexSessionId'
+    ]);
+  }
+
+  hasIndexingSessionDiff(): boolean {
+    if (!this.comparisonRun) return false;
+    return this.currentRun.settingsSnapshot.indexSessionId !== this.comparisonRun.settingsSnapshot.indexSessionId;
+  }
+
+  ngOnDestroy(): void {
+    this.stopScroll();
+    this.datasetLoaded$.complete();
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.html
@@ -1,0 +1,88 @@
+<nb-card class="min-width-90vw min-height-90vh">
+  <nb-card-header class="p-0">
+    <div class="d-flex justify-content-between align-items-start gap-1 px-4 py-3">
+      Settings comparison
+
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Close"
+        (click)="dialogRef.close('cancel')"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </div>
+
+    <div class="d-flex justify-content-between w-100 px-4 tabs">
+      <div class="d-flex gap-05">
+        <button
+          nbButton
+          class="tab-button"
+          [status]="currentTab === currentTabs.AnsweringPrompt ? 'primary' : 'basic'"
+          (click)="switchCurrentTab(currentTabs.AnsweringPrompt)"
+        >
+          Answering Prompt
+        </button>
+        <button
+          nbButton
+          class="tab-button"
+          [status]="currentTab === currentTabs.CondensingPrompt ? 'primary' : 'basic'"
+          (click)="switchCurrentTab(currentTabs.CondensingPrompt)"
+        >
+          Condensing Prompt
+        </button>
+
+        <button
+          nbButton
+          class="tab-button"
+          [status]="currentTab === currentTabs.RagSettings ? 'primary' : 'basic'"
+          (click)="switchCurrentTab(currentTabs.RagSettings)"
+        >
+          Rag Settings
+        </button>
+      </div>
+    </div>
+  </nb-card-header>
+
+  <nb-card-body>
+    <div [ngClass]="comparisonRun ? 'comparison' : ''">
+      <div>
+        <h4 class="text-uppercase monospace text-primary">Run A</h4>
+        <div
+          *ngIf="currentTab !== currentTabs.RagSettings && htmlRunA"
+          class="chat-ui-message-content-styling"
+          [innerHTML]="htmlRunA"
+        ></div>
+
+        <div
+          *ngIf="currentTab === currentTabs.RagSettings"
+          class="chat-ui-message-content-styling"
+        >
+          <pre><code class="lineHeight-1-5" [innerHTML]="getJson('current')"></code></pre>
+        </div>
+      </div>
+
+      <div
+        class="separator"
+        *ngIf="comparisonRun"
+      ></div>
+
+      <div *ngIf="comparisonRun">
+        <h4 class="text-uppercase monospace text-success">Run B</h4>
+        <div
+          *ngIf="currentTab !== currentTabs.RagSettings && htmlRunB"
+          class="chat-ui-message-content-styling"
+          [innerHTML]="htmlRunB"
+        ></div>
+
+        <div
+          *ngIf="currentTab === currentTabs.RagSettings"
+          class="chat-ui-message-content-styling"
+        >
+          <pre><code class="lineHeight-1-5" [innerHTML]="getJson('compare')"></code></pre>
+        </div>
+      </div>
+    </div>
+  </nb-card-body>
+</nb-card>

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.scss
@@ -1,0 +1,71 @@
+.tabs {
+  border-bottom: 2px solid var(--button-filled-primary-background-color);
+  .tab-button {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    padding: 0.4em 1em 0.35em 1em !important;
+  }
+}
+
+.comparison {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+
+  > div:not(.separator) {
+    min-width: 0; /* Empêche le contenu de forcer l'expansion */
+    overflow-x: auto;
+  }
+
+  .separator {
+    width: 1px;
+    background-color: var(--border-basic-color-4);
+  }
+
+  &.large {
+    gap: 2em;
+  }
+}
+
+// PROMPTS DIFFS
+:host ::ng-deep span.added {
+  color: #0ab94e;
+  font-weight: 600;
+}
+
+:host ::ng-deep span.removed {
+  color: #c90a0a;
+}
+
+.nb-theme-dark {
+  :host ::ng-deep span.added {
+    color: #46df85;
+  }
+
+  :host ::ng-deep span.removed {
+    color: #ff6868;
+  }
+}
+
+// JSON DIFFS
+:host ::ng-deep .diff-added {
+  color: #36a162;
+}
+:host ::ng-deep .diff-removed {
+  color: #be4040;
+}
+:host ::ng-deep .diff-changed {
+  color: #a98808;
+}
+
+.nb-theme-dark {
+  :host ::ng-deep .diff-added {
+    color: #46df85;
+  }
+  :host ::ng-deep .diff-removed {
+    color: #ff6868;
+  }
+  :host ::ng-deep .diff-changed {
+    color: #e9bf08;
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/settings-diff/settings-diff.component.ts
@@ -1,0 +1,93 @@
+import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { DatasetRun } from '../../models';
+import { NbDialogRef } from '@nebular/theme';
+import { markedParser } from '../../../../shared/utils/markup.utils';
+import { SettingsService } from '../../../../core-nlp/settings.service';
+import { MarkdownDiffService } from '../../services/markdown-diff.service';
+import { ObjectDiffService } from '../../services/object-diff.service';
+
+export enum SettingsDiffCurrentTabs {
+  CondensingPrompt = 'condensing-prompt',
+  AnsweringPrompt = 'answering-prompt',
+  RagSettings = 'rag-settings'
+}
+
+@Component({
+  selector: 'tock-dataset-detail-settings-diff',
+  templateUrl: './settings-diff.component.html',
+  styleUrl: './settings-diff.component.scss'
+})
+export class DatasetDetailSettingsDiffComponent implements OnInit, OnDestroy {
+  private readonly destroy$: Subject<boolean> = new Subject();
+
+  loading: boolean = true;
+
+  currentTabs = SettingsDiffCurrentTabs;
+
+  @Input() currentRun: DatasetRun;
+  @Input() comparisonRun: DatasetRun;
+  @Input() currentTab: SettingsDiffCurrentTabs = SettingsDiffCurrentTabs.AnsweringPrompt;
+
+  htmlRunA: string | null = null;
+  htmlRunB: string | null = null;
+
+  private readonly markdownDiffService = inject(MarkdownDiffService);
+  private readonly objectDiffService = inject(ObjectDiffService);
+
+  constructor(public dialogRef: NbDialogRef<DatasetDetailSettingsDiffComponent>, public settings: SettingsService) {}
+
+  ngOnInit(): void {
+    this.setMarkup();
+  }
+
+  switchCurrentTab(which: SettingsDiffCurrentTabs) {
+    this.currentTab = which;
+    if (this.currentTab !== SettingsDiffCurrentTabs.RagSettings) {
+      this.setMarkup();
+    }
+  }
+
+  async setMarkup(): Promise<void> {
+    if (this.currentTab === SettingsDiffCurrentTabs.AnsweringPrompt) {
+      if (this.comparisonRun) {
+        const result = await this.markdownDiffService.diff(
+          this.currentRun.settingsSnapshot.questionAnsweringPrompt?.template,
+          this.comparisonRun.settingsSnapshot.questionAnsweringPrompt?.template
+        );
+        this.htmlRunA = markedParser.parse(result.textA) as string;
+        this.htmlRunB = markedParser.parse(result.textB) as string;
+      } else {
+        this.htmlRunA = markedParser.parse(this.currentRun.settingsSnapshot.questionAnsweringPrompt?.template) as string;
+      }
+    }
+
+    if (this.currentTab === SettingsDiffCurrentTabs.CondensingPrompt) {
+      if (this.comparisonRun) {
+        const result = await this.markdownDiffService.diff(
+          this.currentRun.settingsSnapshot.questionCondensingPrompt?.template,
+          this.comparisonRun.settingsSnapshot.questionCondensingPrompt?.template
+        );
+        this.htmlRunA = markedParser.parse(result.textA) as string;
+        this.htmlRunB = markedParser.parse(result.textB) as string;
+      } else {
+        this.htmlRunA = markedParser.parse(this.currentRun.settingsSnapshot.questionCondensingPrompt?.template) as string;
+      }
+    }
+  }
+
+  getJson(run: 'current' | 'compare') {
+    if (this.comparisonRun) {
+      const result = this.objectDiffService.diff(this.currentRun.settingsSnapshot, this.comparisonRun.settingsSnapshot);
+      if (run === 'current') return result.htmlA;
+      if (run === 'compare') return result.htmlB;
+    } else {
+      return JSON.stringify(this.currentRun.settingsSnapshot, null, 2);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.html
@@ -1,0 +1,227 @@
+<nb-card class="shadow-sm hover-lift mb-3">
+  <nb-card-body class="list-grid">
+    <div>
+      <div class="list-entry-name font-weight-bold">{{ dataset.name }}</div>
+      <div class="list-entry-desc text-muted">{{ dataset.description }}</div>
+    </div>
+
+    <div
+      (click)="switchQuestionsDetail()"
+      class="pointer unselectable"
+      nbTooltip="Show questions"
+    >
+      <div
+        class="rounded px-2 py-1"
+        [ngClass]="{ 'background-basic-color-2': displayQuestionsDetail }"
+      >
+        <div class="list-entry-name">{{ dataset.questions.length }}</div>
+        <div class="list-entry-desc text-muted">questions</div>
+      </div>
+    </div>
+
+    <div
+      (click)="switchRunsDetail()"
+      class="pointer unselectable"
+      nbTooltip="Show runs"
+    >
+      <div
+        class="rounded px-2 py-1"
+        [ngClass]="{ 'background-basic-color-2': displayRunsDetail }"
+      >
+        <div class="list-entry-name">{{ dataset.runs.length }}</div>
+        <div class="list-entry-desc text-muted">runs</div>
+      </div>
+    </div>
+
+    <div class="d-flex flex-column justify-content-center">
+      <div
+        class="list-entry-name initial-capitalize"
+        *ngIf="getLatestRun() as latestRun"
+        [ngClass]="getStateColor(latestRun.state)"
+      >
+        {{ latestRun.state }}
+      </div>
+      <div
+        class="list-entry-desc text-muted"
+        *ngIf="getLatestRun() as latestRun"
+      >
+        {{ latestRun.startTime | date: 'y/MM/dd - HH:mm' }}
+      </div>
+    </div>
+
+    <div>
+      <div
+        class="list-entry-desc"
+        *ngIf="getLatestRun() as latestRun"
+        [ngClass]="{
+          'text-muted': ![datasetRunState.QUEUED, datasetRunState.RUNNING].includes(latestRun.state),
+          'text-info': latestRun.state === datasetRunState.RUNNING,
+          'text-warning': latestRun.state === datasetRunState.QUEUED
+        }"
+      >
+        <!-- {{ latestRunDuration$ | async }} -->
+        {{ runDurations$[latestRun.id] | async }}
+      </div>
+    </div>
+
+    <div>
+      <div class="d-flex justify-content-end">
+        <button
+          nbButton
+          ghost
+          shape="round"
+          status="info"
+          nbTooltip="View runs details"
+          class="mb-2"
+          [disabled]="!canViewHistory"
+          routerLink="/quality/datasets/detail/{{ dataset.id }}"
+        >
+          <nb-icon icon="bar-chart"></nb-icon>
+        </button>
+
+        <button
+          *ngIf="canCancel"
+          nbButton
+          ghost
+          shape="round"
+          status="warning"
+          nbTooltip="Cancel active run"
+          class="mb-2"
+          (click)="cancelRun(getLatestRun())"
+        >
+          <nb-icon icon="stop-circle"></nb-icon>
+        </button>
+
+        <button
+          *ngIf="canPlay"
+          nbButton
+          ghost
+          shape="round"
+          status="success"
+          nbTooltip="Run dataset"
+          class="mb-2"
+          (click)="runDataset()"
+        >
+          <nb-icon icon="play-circle"></nb-icon>
+        </button>
+
+        <button
+          nbButton
+          ghost
+          shape="round"
+          status="warning"
+          nbTooltip="Edit dataset"
+          class="mb-2"
+          [disabled]="!canEdit"
+          (click)="editDataset()"
+        >
+          <nb-icon icon="pencil"></nb-icon>
+        </button>
+
+        <button
+          nbButton
+          ghost
+          shape="round"
+          status="danger"
+          nbTooltip="Delete dataset"
+          class="mb-2"
+          [disabled]="!canDelete"
+          (click)="confirmDeleteDataset()"
+        >
+          <nb-icon icon="trash"></nb-icon>
+        </button>
+      </div>
+    </div>
+  </nb-card-body>
+
+  <nb-card-body
+    *ngIf="displayQuestionsDetail"
+    class="background-basic-color-2 p-2 pt-1 inner-shade-top"
+  >
+    <div class="details-wrapper scrollbar-narrow">
+      <div
+        class="background-basic-color-1 rounded px-2 py-1 mt-1 font-size-small text-muted"
+        *ngFor="let question of dataset.questions"
+      >
+        {{ question.question }}
+      </div>
+    </div>
+  </nb-card-body>
+
+  <nb-card-body
+    *ngIf="displayRunsDetail"
+    class="background-basic-color-2 p-2 inner-shade-top"
+  >
+    <div
+      class="text-center text-muted"
+      *ngIf="!dataset.runs?.length"
+    >
+      No runs yet
+    </div>
+
+    <ng-container *ngIf="dataset.runs?.length">
+      <div class="runs-grid runs-grid-header px-2 mb-2 mr-2">
+        <div class="ellipsis">Start</div>
+        <div class="ellipsis">End</div>
+        <div class="ellipsis">Duration</div>
+        <div class="ellipsis">Questions</div>
+        <div class="ellipsis">Failed</div>
+        <div class="ellipsis">Completed</div>
+        <div class="ellipsis">Run State</div>
+        <div class="ellipsis"></div>
+      </div>
+
+      <div class="details-wrapper scrollbar-narrow">
+        <div
+          class="background-basic-color-1 rounded px-2 py-1 mt-1 font-size-small runs-grid"
+          *ngFor="let run of dataset.runs"
+        >
+          <div class="runs-grid-entry text-muted">
+            {{ run.startTime | date: 'y/MM/dd - HH:mm' }}
+          </div>
+          <div class="runs-grid-entry text-muted">
+            <ng-container *ngIf="run.endTime; else noEndTime">
+              {{ run.endTime | date: 'y/MM/dd - HH:mm' }}
+            </ng-container>
+            <ng-template #noEndTime>-</ng-template>
+          </div>
+          <div
+            class="runs-grid-entry"
+            [ngClass]="{
+              'text-muted': ![datasetRunState.QUEUED, datasetRunState.RUNNING].includes(run.state),
+              'text-info': run.state === datasetRunState.RUNNING,
+              'text-warning': run.state === datasetRunState.QUEUED
+            }"
+          >
+            {{ runDurations$[run.id] | async }}
+          </div>
+
+          <div class="runs-grid-entry text-muted">{{ run.stats.totalQuestions }}</div>
+          <div class="runs-grid-entry text-muted">{{ run.stats.failedQuestions }}</div>
+          <div class="runs-grid-entry text-muted">{{ run.stats.completedQuestions }}</div>
+
+          <div
+            class="runs-grid-entry"
+            [ngClass]="getStateColor(run.state)"
+          >
+            {{ run.state }}
+          </div>
+
+          <div>
+            <button
+              *ngIf="run.state === datasetRunState.COMPLETED && run !== getLatestRun()"
+              nbButton
+              size="tiny"
+              shape="round"
+              nbTooltip="Compare with latest run"
+              [routerLink]="['/quality/datasets/detail', dataset.id]"
+              [queryParams]="{ compareRunId: run.id }"
+            >
+              <nb-icon icon="plus-slash-minus"></nb-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  </nb-card-body>
+</nb-card>

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.scss
@@ -1,0 +1,61 @@
+// nb-card {
+//   transition: transform 0.2s ease, box-shadow 0.2s ease;
+// }
+
+// nb-card.hover-lift:hover {
+//   transform: translateY(-4px);
+//   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1) !important;
+// }
+
+.list-grid {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) minmax(3rem, 5rem) minmax(3rem, 4rem) minmax(5rem, 8.75rem) minmax(3rem, 5rem) 8.75rem;
+  gap: 0.5rem;
+  padding: var(--card-padding);
+  align-items: center;
+}
+
+.list-header {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.list-entry-name {
+  margin-bottom: 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-entry-desc {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.details-wrapper {
+  max-height: 20em;
+  overflow-y: auto;
+}
+
+.runs-grid {
+  display: grid;
+  grid-template-columns:
+    minmax(4rem, 8rem) minmax(4rem, 8rem) minmax(4rem, 1fr) minmax(2rem, 4rem) minmax(2rem, 3rem) minmax(2rem, 4rem) minmax(3rem, 5rem)
+    1.5rem;
+  gap: 0.5rem;
+}
+
+.runs-grid-header {
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.runs-grid-entry {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component.ts
@@ -1,0 +1,193 @@
+import { Component, Input, OnDestroy } from '@angular/core';
+import { Observable, Subject, interval } from 'rxjs';
+import { startWith, switchMap, takeUntil, takeWhile } from 'rxjs/operators';
+import { Dataset, DatasetRun, DatasetRunState } from '../../models';
+import { DatasetsService } from '../../services/datasets.service';
+import { DialogService } from '../../../../core-nlp/dialog.service';
+import { ChoiceDialogComponent } from '../../../../shared/components';
+import { DatasetCreateComponent } from '../../dataset-create/dataset-create.component';
+import { StateService } from '../../../../core-nlp/state.service';
+
+@Component({
+  selector: 'tock-datasets-board-entry',
+  templateUrl: './datasets-board-entry.component.html',
+  styleUrl: './datasets-board-entry.component.scss'
+})
+export class DatasetsBoardEntryComponent implements OnDestroy {
+  destroy$: Subject<void> = new Subject<void>();
+
+  displayQuestionsDetail: boolean = false;
+  displayRunsDetail: boolean = false;
+
+  datasetRunState = DatasetRunState;
+
+  runDurations$: Record<string, Observable<string>> = {};
+
+  private _pollingRunIds = new Set<string>();
+
+  @Input() set dataset(dataset: Dataset) {
+    this._dataset = dataset;
+
+    dataset.runs.forEach((run) => {
+      const isActive = run.state === DatasetRunState.QUEUED || run.state === DatasetRunState.RUNNING;
+      const existing$ = this.runDurations$[run.id];
+
+      if (!existing$ || (!isActive && run.endTime)) {
+        this.runDurations$ = {
+          ...this.runDurations$,
+          [run.id]: this.datasetsService.getRunDuration(run).pipe(takeUntil(this.destroy$))
+        };
+      }
+
+      if (isActive && !this._pollingRunIds.has(run.id)) {
+        this._startPolling(run);
+      }
+    });
+  }
+
+  get dataset(): Dataset {
+    return this._dataset;
+  }
+  private _dataset: Dataset;
+
+  constructor(private datasetsService: DatasetsService, private dialogService: DialogService, private stateService: StateService) {}
+
+  getLatestRun(): DatasetRun | null {
+    return this.datasetsService.getLatestRun(this.dataset);
+  }
+
+  // ── Action availability helpers ───────────────────────────────────────────
+
+  get latestRunState(): DatasetRunState | null {
+    return this.getLatestRun()?.state ?? null;
+  }
+
+  get hasActiveRun(): boolean {
+    return this.latestRunState === DatasetRunState.QUEUED || this.latestRunState === DatasetRunState.RUNNING;
+  }
+
+  get canPlay(): boolean {
+    return !this.hasActiveRun;
+  }
+
+  get canCancel(): boolean {
+    return this.hasActiveRun;
+  }
+
+  get canViewHistory(): boolean {
+    return !!this.dataset.runs.length;
+  }
+
+  get canEdit(): boolean {
+    return !this.hasActiveRun;
+  }
+
+  get canDelete(): boolean {
+    return !this.hasActiveRun;
+  }
+
+  runDataset(): void {
+    this.datasetsService
+      .createRun(this.dataset.id, { language: this.stateService.currentLocale })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        error: (err) => console.error('Failed to create run', err)
+      });
+  }
+
+  private _startPolling(run: DatasetRun): void {
+    this._pollingRunIds.add(run.id);
+
+    interval(5_000)
+      .pipe(
+        startWith(0),
+        switchMap(() => this.datasetsService.getRun(this.dataset.id, run.id)),
+        takeWhile((r) => r.state === DatasetRunState.QUEUED || r.state === DatasetRunState.RUNNING, true), // stops on COMPLETED or CANCELLED
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: (updated) => {
+          this.datasetsService.updateRunState(this.dataset.id, run.id, {
+            state: updated.state,
+            stats: updated.stats,
+            ...(updated.endTime ? { endTime: updated.endTime } : {})
+          });
+        },
+        complete: () => {
+          this._pollingRunIds.delete(run.id);
+        }
+      });
+  }
+
+  cancelRun(run: DatasetRun): void {
+    this.datasetsService
+      .cancelRun(this.dataset.id, run.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        error: (err) => console.error('Failed to cancel run', err)
+      });
+  }
+
+  confirmDeleteDataset(): void {
+    const action = 'permanently delete';
+    const dialogRef = this.dialogService.openDialog(ChoiceDialogComponent, {
+      context: {
+        title: 'Delete a dataset',
+        subtitle: `Are you sure you want to delete the "${this.dataset.name}" dataset and all its execution history?`,
+        modalStatus: 'danger',
+        actions: [
+          { actionName: 'cancel', buttonStatus: 'basic', ghost: true },
+          { actionName: action, buttonStatus: 'danger' }
+        ]
+      }
+    });
+    dialogRef.onClose.subscribe((result) => {
+      if (result === action) this.deleteDataset();
+    });
+  }
+
+  deleteDataset(): void {
+    this.datasetsService
+      .deleteDataset(this.dataset.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        error: (err) => console.error('Failed to delete dataset', err)
+      });
+  }
+
+  editDataset(): void {
+    this.dialogService.openDialog(DatasetCreateComponent, {
+      context: { dataset: this.dataset }
+    });
+  }
+
+  getStateColor(state: DatasetRunState): string {
+    switch (state) {
+      case DatasetRunState.QUEUED:
+        return 'text-warning';
+      case DatasetRunState.RUNNING:
+        return 'text-info';
+      case DatasetRunState.COMPLETED:
+        return 'text-success';
+      case DatasetRunState.CANCELLED:
+        return 'text-danger';
+      default:
+        return 'text-basic';
+    }
+  }
+
+  switchQuestionsDetail(): void {
+    this.displayQuestionsDetail = !this.displayQuestionsDetail;
+    if (this.displayQuestionsDetail) this.displayRunsDetail = false;
+  }
+
+  switchRunsDetail(): void {
+    this.displayRunsDetail = !this.displayRunsDetail;
+    if (this.displayRunsDetail) this.displayQuestionsDetail = false;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
@@ -1,0 +1,71 @@
+<!--
+  ~ Copyright (C) 2017/2025 SNCF Connect & Tech
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div class="d-flex align-items-center mb-2">
+  <h1 class="flex-grow-1 m-0">Datasets</h1>
+  <section class="grid-actions">
+    <button
+      nbButton
+      status="primary"
+      size="medium"
+      nbTooltip="Create new dataset"
+      class="d-flex align-items-center"
+      (click)="createDataset()"
+    >
+      <nb-icon
+        icon="plus-lg"
+        class="mr-2"
+      ></nb-icon>
+      <span>NEW DATASET</span>
+    </button>
+  </section>
+</div>
+
+<nb-card
+  *ngIf="loading"
+  [nbSpinner]="loading"
+  class="shadow-sm mt-2"
+>
+  <nb-card-body class="main-card-body p-4">&nbsp;</nb-card-body>
+</nb-card>
+
+<tock-no-data-found
+  *ngIf="configurations?.length === 0"
+  title="No bot configuration detected"
+></tock-no-data-found>
+
+<tock-no-data-found
+  *ngIf="!datasets?.length && !loading"
+  title="No dataset found"
+  message="Create your first dataset using the &#34;NEW DATASET&#34; button above."
+  class="mt-4"
+></tock-no-data-found>
+
+<div
+  *ngIf="!loading && datasets?.length"
+  class="list-grid list-header text-muted ellipsis"
+>
+  <div class="ellipsis">Dataset</div>
+  <div class="ellipsis pl-1">Questions</div>
+  <div class="ellipsis pl-1">Runs</div>
+  <div class="ellipsis">Last run state</div>
+  <div class="ellipsis">Duration</div>
+  <div class="ellipsis"></div>
+</div>
+
+<ng-container *ngFor="let dataset of datasets; trackBy: trackById">
+  <tock-datasets-board-entry [dataset]="dataset"></tock-datasets-board-entry>
+</ng-container>

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
@@ -19,6 +19,16 @@
   <section class="grid-actions">
     <button
       nbButton
+      ghost
+      shape="round"
+      nbTooltip="Import a dataset"
+      (click)="importDataset()"
+    >
+      <nb-icon icon="upload"></nb-icon>
+    </button>
+
+    <button
+      nbButton
       status="primary"
       size="medium"
       nbTooltip="Create new dataset"
@@ -35,7 +45,7 @@
 </div>
 
 <nb-card
-  *ngIf="loading"
+  *ngIf="loading && !datasets?.length"
   [nbSpinner]="loading"
   class="shadow-sm mt-2"
 >
@@ -66,6 +76,70 @@
   <div class="ellipsis"></div>
 </div>
 
-<ng-container *ngFor="let dataset of datasets; trackBy: trackById">
+<div
+  *ngFor="let dataset of datasets; trackBy: trackById"
+  [nbSpinner]="loading"
+>
   <tock-datasets-board-entry [dataset]="dataset"></tock-datasets-board-entry>
-</ng-container>
+</div>
+
+<ng-template #importModal>
+  <nb-card [nbSpinner]="loading">
+    <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+      Import Dataset
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Cancel"
+        (click)="closeImportModal()"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </nb-card-header>
+
+    <nb-card-body>
+      <form
+        [formGroup]="importForm"
+        (submit)="submitImportDataset()"
+      >
+        <tock-form-control
+          label="Dataset file"
+          name="importFile"
+          [required]="true"
+          [controls]="fileSource"
+          [showError]="isImportSubmitted"
+        >
+          <tock-file-upload
+            id="importFile"
+            formControlName="fileSource"
+            [autofocus]="true"
+            [fullWidth]="true"
+            [multiple]="false"
+            [fileTypeAccepted]="['json']"
+          ></tock-file-upload>
+        </tock-form-control>
+      </form>
+    </nb-card-body>
+
+    <nb-card-footer class="card-footer-actions">
+      <button
+        nbButton
+        ghost
+        size="small"
+        (click)="closeImportModal()"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        nbButton
+        status="primary"
+        size="small"
+        (click)="submitImportDataset()"
+      >
+        Import
+      </button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.scss
@@ -1,3 +1,11 @@
+.grid-actions {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: end;
+}
+
 .list-grid {
   display: grid;
   grid-template-columns: minmax(8rem, 1fr) minmax(3rem, 5rem) minmax(3rem, 4rem) minmax(5rem, 8.75rem) minmax(3rem, 5rem) 8.75rem;

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.scss
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.scss
@@ -1,0 +1,12 @@
+.list-grid {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) minmax(3rem, 5rem) minmax(3rem, 4rem) minmax(5rem, 8.75rem) minmax(3rem, 5rem) 8.75rem;
+  gap: 0.5rem;
+  padding: var(--card-padding);
+}
+
+.list-header {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+import { DialogService } from '../../../core-nlp/dialog.service';
+import { BotApplicationConfiguration } from '../../../core/model/configuration';
+import { BotConfigurationService } from '../../../core/bot-configuration.service';
+import { DatasetCreateComponent } from '../dataset-create/dataset-create.component';
+
+import { Dataset } from '../models';
+import { DatasetsService } from '../services/datasets.service';
+
+@Component({
+  selector: 'tock-datasets-board',
+  templateUrl: './datasets-board.component.html',
+  styleUrl: './datasets-board.component.scss'
+})
+export class DatasetsBoardComponent implements OnInit, OnDestroy {
+  destroy$: Subject<unknown> = new Subject();
+  loading: boolean = true;
+
+  configurations: BotApplicationConfiguration[];
+  datasets: Dataset[];
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    private dialogService: DialogService,
+    private datasetsService: DatasetsService
+  ) {}
+
+  ngOnInit(): void {
+    this.datasetsService.datasets$.pipe(takeUntil(this.destroy$)).subscribe((datasets) => {
+      this.datasets = datasets;
+    });
+
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((confs) => {
+      this.configurations = confs;
+      if (confs.length) this.fetchDatasets();
+    });
+  }
+
+  fetchDatasets(): void {
+    const { namespace, applicationId: botId } = this.configurations[0];
+
+    this.datasetsService
+      .getDatasets()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => (this.loading = false));
+  }
+
+  trackById(_index: number, dataset: Dataset): string {
+    return dataset.id;
+  }
+
+  createDataset(): void {
+    this.dialogService.openDialog(DatasetCreateComponent);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { Subject, takeUntil } from 'rxjs';
 import { DialogService } from '../../../core-nlp/dialog.service';
 import { BotApplicationConfiguration } from '../../../core/model/configuration';
@@ -7,6 +7,10 @@ import { DatasetCreateComponent } from '../dataset-create/dataset-create.compone
 
 import { Dataset } from '../models';
 import { DatasetsService } from '../services/datasets.service';
+import { NbDialogRef, NbDialogService, NbToastrService } from '@nebular/theme';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FileValidators } from '../../../shared/validators';
+import { readFileAsText } from '../../../shared/utils';
 
 @Component({
   selector: 'tock-datasets-board',
@@ -20,10 +24,14 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
   configurations: BotApplicationConfiguration[];
   datasets: Dataset[];
 
+  @ViewChild('importModal') importModal: TemplateRef<any>;
+
   constructor(
     private botConfiguration: BotConfigurationService,
     private dialogService: DialogService,
-    private datasetsService: DatasetsService
+    private datasetsService: DatasetsService,
+    private nbDialogService: NbDialogService,
+    private toastrService: NbToastrService
   ) {}
 
   ngOnInit(): void {
@@ -52,6 +60,102 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
 
   createDataset(): void {
     this.dialogService.openDialog(DatasetCreateComponent);
+  }
+
+  importModalRef: NbDialogRef<any>;
+
+  importDataset(): void {
+    this.isImportSubmitted = false;
+    this.importForm.reset();
+    this.importModalRef = this.nbDialogService.open(this.importModal);
+  }
+
+  closeImportModal(): void {
+    this.importModalRef.close();
+  }
+
+  importForm: FormGroup = new FormGroup({
+    fileSource: new FormControl<File[]>([], {
+      nonNullable: true,
+      validators: [Validators.required, FileValidators.mimeTypeSupported(['application/json'])]
+    })
+  });
+
+  isImportSubmitted: boolean = false;
+
+  get fileSource(): FormControl {
+    return this.importForm.get('fileSource') as FormControl;
+  }
+
+  get canSaveImport(): boolean {
+    return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
+  }
+
+  submitImportDataset(): void {
+    this.isImportSubmitted = true;
+    if (this.canSaveImport) {
+      this.loading = true;
+
+      const file = this.fileSource.value[0];
+
+      readFileAsText(file).then((fileContent) => {
+        try {
+          const importedData = JSON.parse(fileContent.data);
+
+          // JSON structure validation
+          if (
+            !importedData.name ||
+            !importedData.description ||
+            !Array.isArray(importedData.questions) ||
+            !importedData.questions.every((q: any) => typeof q.question === 'string' && typeof q.groundTruth === 'string')
+          ) {
+            this.toastrService.show(
+              `The file must contain a 'name', 'description', and an array of 'questions' with 'question' and 'groundTruth' fields.`,
+              'Invalid dataset format',
+              {
+                duration: 8000,
+                status: 'danger'
+              }
+            );
+            this.loading = false;
+            return;
+          }
+
+          const newDataset: Pick<Dataset, 'name' | 'description' | 'questions'> = {
+            name: importedData.name,
+            description: importedData.description,
+            questions: importedData.questions.map((q: { question: string; groundTruth: string }) => ({
+              question: q.question,
+              groundTruth: q.groundTruth
+            }))
+          };
+
+          this.datasetsService
+            .createDataset(newDataset)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe({
+              next: (createdDataset) => {
+                this.toastrService.show(`Dataset "${createdDataset.name}" imported successfully!`, 'Success', {
+                  duration: 4000,
+                  status: 'success'
+                });
+                this.closeImportModal();
+                this.loading = false;
+              },
+              error: (err) => {
+                this.toastrService.show(`Failed to import dataset: ${err.message || 'Unknown error'}`, 'Error', {
+                  duration: 6000,
+                  status: 'danger'
+                });
+                this.loading = false;
+              }
+            });
+        } catch (e) {
+          this.toastrService.show('The file is not a valid JSON.', 'Invalid JSON', { duration: 6000, status: 'danger' });
+          this.loading = false;
+        }
+      });
+    }
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
@@ -105,9 +105,11 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
           // JSON structure validation
           if (
             !importedData.name ||
-            !importedData.description ||
+            typeof importedData.description !== 'string' ||
             !Array.isArray(importedData.questions) ||
-            !importedData.questions.every((q: any) => typeof q.question === 'string' && typeof q.groundTruth === 'string')
+            !importedData.questions.every(
+              (q: any) => typeof q.question === 'string' && typeof q.groundTruth === 'string' && q.question.trim() !== ''
+            )
           ) {
             this.toastrService.show(
               `The file must contain a 'name', 'description', and an array of 'questions' with 'question' and 'groundTruth' fields.`,

--- a/bot/admin/web/src/app/quality/datatsets/doc-dataset-draft.md
+++ b/bot/admin/web/src/app/quality/datatsets/doc-dataset-draft.md
@@ -1,0 +1,307 @@
+## Rappel du besoin
+
+- un dataset a un nom, une description, une liste de questions et un historique de runs,
+- un run a un state, des dates, et un snapshot de settings,
+- la page de détail compare surtout un run A et un run B,
+- la comparaison se fait question par question,
+- le rendu compare surtout la réponse texte et les sources (footnotes),
+- côté front, `settingsSnapshot` n'est attendu que sur le détail dataset, pas sur la liste ni sur le polling de run.
+
+---
+
+## Connecteur de test
+
+- tout passe par la logique du connecteur de test,
+- chaque question est exécutée via l'équivalent interne de `POST /test/talk`,
+- le worker force :
+  - `sourceWithContent = true`,
+  - `debug = true`.
+
+---
+
+## Proposition de modèle
+
+## Dataset
+
+```json
+{
+  "id": "datasetId",
+  "namespace": "heymo-credit",
+  "botId": "heymo",
+  "name": "Résiliations & réclamations",
+  "description": "Questions de régression sur le domaine assurance",
+  "createdAt": "2026-03-06T10:00:00Z",
+  "createdBy": "RS483",
+  "updatedAt": "2026-03-06T10:00:00Z",
+  "updatedBy": "RS483",
+  "questions": [
+    {
+      "id": "questionId1",
+      "question": "Quels sont les délais légaux pour résilier un contrat d’assurance habitation ?",
+      "groundTruth": ""
+    }
+  ]
+}
+```
+
+Notes :
+
+- `groundTruth` non nullable côté API :
+  - `""` = pas de ground truth renseignée
+- validation back stricte :
+  - `name` obligatoire
+  - au moins 1 question,
+  - max `X` questions via variable d'env,
+  - question non vide
+- update/delete refusés si un run est déjà `QUEUED` ou `RUNNING` sur le dataset
+
+## DatasetRun
+
+Exemple à la création du run :
+
+```json
+{
+  "id": "runId",
+  "datasetId": "datasetId",
+  "state": "QUEUED",
+  "createdAt": "2026-03-06T10:15:00Z",
+  "startedBy": "RS483",
+  "startTime": "2026-03-06T10:15:00Z",
+  "endTime": null,
+  "settingsSnapshot": {
+    "...": "snapshot RagSettings"
+  },
+  "stats": {
+    "totalQuestions": 12,
+    "completedQuestions": 0,
+    "failedQuestions": 0
+  }
+}
+```
+
+- `settingsSnapshot` est absent des réponses de `GET /datasets` et `GET /runs/:runId` (polling), mais présent dans `GET /datasets/:datasetId`,
+- `settingsSnapshot` ne doit pas réutiliser tel quel le DTO RAG back existant :
+  - il faut persister une projection dédiée,
+  - sans secrets, en particulier sans `apiKey`,
+- pour exécuter `/test/talk`, le worker doit disposer de la `locale` et du `botApplicationConfigurationId`,
+- recommandation de contrat :
+  - la `locale` est envoyée explicitement par le front dans `POST /runs`,
+  - le serveur résout la configuration REST de test à partir du `botId`,
+  - le `botApplicationConfigurationId` reste interne au run,
+  - si la résolution de config est impossible ou ambiguë, le run est refusé
+
+## DatasetRunQuestionResult
+
+Modèle back, n'a pas vocation à être exposé tel quel au front.
+
+```json
+{
+  "id": "runQuestionResultId",
+  "runId": "runId",
+  "questionId": "questionId1",
+  "state": "PENDING",
+  "startedAt": null,
+  "endedAt": null,
+  "userIdModifier": "dataset_runId_questionId1",
+  "userActionId": null,
+  "dialogId": null,
+  "answerActionId": null,
+  "error": null
+}
+```
+
+Pourquoi stocker `dialogId` et `answerActionId` plutôt que l'action complète :
+
+- la vraie réponse bot reste stockée dans les dialogs / actions Tock,
+- le module datasets ne stocke ici que de quoi retrouver cette réponse plus tard,
+- le front attend `action = null` si le dialog a été purgé plus tard,
+- donc il vaut mieux relire l'`ActionReport` à la demande au moment du `GET /runs/:runId/actions`.
+
+## States
+
+### Run
+
+- `QUEUED`
+- `RUNNING`
+- `COMPLETED`
+- `CANCELLED`
+
+Un run fini avec erreurs partielles reste `COMPLETED`.
+Les erreurs vivent dans les résultats par question et dans `stats.failedQuestions`.
+
+### Question result
+
+- `PENDING`
+- `RUNNING`
+- `COMPLETED`
+- `FAILED`
+- `CANCELLED`
+
+---
+
+## Comportement d'exécution d'un run
+
+Quand l'user clique sur "Run dataset" :
+
+1. on charge le dataset,
+2. on vérifie qu'aucun run n'est déjà `QUEUED` ou `RUNNING`,
+3. on récupère la `locale` depuis la requête,
+4. on résout la config REST de test effective à partir du `botId`,
+5. si la résolution est impossible ou ambiguë, on refuse le lancement,
+6. on snapshote les settings RAG courants,
+7. on crée un `DatasetRun` en `QUEUED`,
+8. on précrée les `DatasetRunQuestionResult` en `PENDING`,
+9. le worker récupère le run,
+10. il passe le run en `RUNNING`,
+11. il exécute les questions une par une,
+12. il met à jour la progression après chaque question,
+13. à la fin il passe le run en `COMPLETED` ou `CANCELLED`.
+
+Point important :
+
+- en cas d'échec d'une question, le run continue,
+- le run ne passe pas en `FAILED`.
+
+---
+
+## Une question = une action
+
+- côté front et côté API de comparaison, une question correspond à une seule action résultat,
+- on ne veut pas exposer un dialog complet ni un historique de conversation,
+- côté back, l'implémentation peut malgré tout s'appuyer techniquement sur un dialog de test Tock pour produire cette action,
+- on génère un `userIdModifier` unique par tentative,
+- on exécute la question via la logique de `test/talk`,
+- on récupère `userActionId` dans la réponse,
+- puis on retrouve l'unique vraie réponse bot à rattacher à cette question.
+
+Exemple :
+
+```text
+dataset_{runId}_{questionId}
+```
+
+### Point clé côté back
+
+Le `userActionId` renvoyé par `/test/talk` n'est pas l'action bot à afficher dans la comparaison.
+
+C'est l'action utilisateur injectée dans le dialog.
+
+Il faut donc ensuite :
+
+1. retrouver le dialog créé pour ce test user,
+2. retrouver l'action utilisateur correspondante,
+3. prendre la première action bot pertinente après cette action,
+4. stocker son `actionId` dans `answerActionId`.
+
+Règle simple de sélection :
+
+- ignorer les actions debug,
+- prendre en priorité une réponse `SentenceWithFootnotes`,
+- sinon une `Sentence`,
+- sinon la première action bot non debug disponible.
+
+---
+
+## Worker
+
+Un composant de type `DatasetRunWorker` dans le back :
+
+- scrute les runs `QUEUED`,
+- en claim un de façon atomique,
+- le passe en `RUNNING`,
+- traite les questions une par une,
+- met à jour la progression au fil de l'eau,
+- termine le run.
+
+```text
+DatasetRun API -> save run QUEUED
+DatasetRunWorker -> pick next QUEUED run
+DatasetRunWorker -> set RUNNING
+DatasetRunWorker -> execute question 1..N
+DatasetRunWorker -> save question results
+DatasetRunWorker -> set COMPLETED / CANCELLED
+```
+
+### Fiabilité
+
+- stocker la progression après chaque question,
+- avoir un retry configurable par question,
+- prévoir un mécanisme de reprise simple pour éviter qu'un run reste bloqué si le worker meurt.
+
+---
+
+## Cancel
+
+### Si le run est `QUEUED`
+
+- il passe directement en `CANCELLED`,
+- `endTime` est renseigné,
+- il n'est jamais traité.
+
+### Si le run est `RUNNING`
+
+- l'API d'annulation doit renvoyer un run déjà `CANCELLED` avec `endTime` renseigné pour rester alignée avec le front,
+- le worker termine au plus la question en cours,
+- il ne lance pas la suivante.
+
+---
+
+## Stratégie d'échec
+
+### Sur une question
+
+- retry technique,
+- puis si échec final :
+  - `QuestionResult.state = FAILED`,
+  - `error` renseigné,
+  - on continue le run.
+
+### Sur le run
+
+- `run.state = COMPLETED` si le worker a fini son parcours,
+- `run.state = CANCELLED` si annulation,
+
+---
+
+## Exposition API des résultats
+
+Le endpoint `GET /bots/:botId/datasets/:datasetId/runs/:runId/actions` doit :
+
+- relire les `DatasetRunQuestionResult`,
+- pour chaque question :
+  - si `FAILED` -> `action = null`,
+  - si `COMPLETED` et action encore présente -> `action = ActionReport`,
+  - si `COMPLETED` mais dialog/action purgé -> `action = null`.
+
+À noter :
+
+- il ne faut pas "recalculer" rétroactivement les anciens runs si le dataset change,
+- si une question a été ajoutée après un ancien run, le front sait déjà gérer l'absence de résultat pour ce run historique.
+
+---
+
+## Guards back
+
+Le back doit check :
+
+- dataset vide,
+- dataset avec plus de `X` questions,
+- question vide,
+- 1 run actif max par dataset,
+- impossibilité de modifier ou supprimer un dataset pendant un run actif.
+- `POST /runs` sans `language`,
+- aucune configuration REST de test exploitable pour le `botId`,
+- plusieurs configurations REST candidates si la résolution serveur n'est pas univoque.
+
+---
+
+## Forcing côté worker
+
+Forcing côté worker :
+
+- `sourceWithContent = true`
+- `debug = true`
+
+Ces deux flags doivent être considérés comme des invariants d'exécution dataset.
+
+---

--- a/bot/admin/web/src/app/quality/datatsets/models.ts
+++ b/bot/admin/web/src/app/quality/datatsets/models.ts
@@ -1,0 +1,80 @@
+import { RagSettings } from '../../rag/rag-settings/models';
+
+export enum DatasetRunState {
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED'
+}
+
+export enum DatasetRunActionState {
+  COMPLETED = 'COMPLETED',
+  FAILED = 'FAILED'
+}
+
+export interface DatasetRunAction {
+  datasetId: string;
+  runId: string;
+  questionId: string;
+  state: DatasetRunActionState;
+  action: any | null; // ActionReport | null
+  retryCount: number;
+}
+
+export interface DatasetRunStats {
+  totalQuestions: number;
+  completedQuestions: number;
+  failedQuestions: number;
+}
+
+export interface DatasetRun {
+  id: string;
+  state: DatasetRunState;
+  startTime: string; // ISO 8601
+  endTime: string | null; // ISO 8601
+  settingsSnapshot?: Partial<RagSettings>;
+  startedBy: string;
+  stats: DatasetRunStats;
+}
+
+export interface DatasetQuestion {
+  id: string;
+  question: string;
+  groundTruth: string;
+}
+
+export interface Dataset {
+  id: string;
+  name: string;
+  description: string;
+  questions: DatasetQuestion[];
+  runs: DatasetRun[];
+  createdAt: string; // ISO 8601
+  createdBy: string;
+  updatedAt: string | null; // ISO 8601
+  updatedBy: string | null;
+  // Front-only flag — true once GET /datasets/:id has been called and settingsSnapshot
+  // fields are populated. Never sent to or expected from the backend.
+  _settingsLoaded?: boolean;
+}
+
+// Front-only — derived from DatasetRunAction.state + action nullability.
+// Never sent to or expected from the backend.
+export enum DatasetRunActionDisplayState {
+  SUCCESS = 'SUCCESS', // state COMPLETED + action présent
+  FAILED = 'FAILED', // state FAILED, pas de rapport disponible
+  PURGED = 'PURGED' // state COMPLETED + action null, dialogue purgé de la base
+}
+
+export interface SourceInfos {
+  title: string;
+  url?: string;
+  content: string;
+  _detail?: boolean; // Front-only flag to indicate if the source is shown in detail view. Never sent to or expected from the backend.
+}
+
+export interface SourcesDiffResult {
+  added: SourceInfos[];
+  removed: SourceInfos[];
+  modified: SourceInfos[];
+}

--- a/bot/admin/web/src/app/quality/datatsets/services/datasets.service.ts
+++ b/bot/admin/web/src/app/quality/datatsets/services/datasets.service.ts
@@ -1,0 +1,236 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, interval, Observable, of } from 'rxjs';
+import { map, startWith, tap } from 'rxjs/operators';
+import { Dataset, DatasetQuestion, DatasetRun, DatasetRunAction, DatasetRunState } from '../models';
+import { deepCopy } from '../../../shared/utils';
+import { StateService } from '../../../core-nlp/state.service';
+import { RestService } from '../../../core-nlp/rest/rest.service';
+
+@Injectable({ providedIn: 'root' })
+export class DatasetsService {
+  private datasetsSubject = new BehaviorSubject<Dataset[]>([]);
+
+  datasets$ = this.datasetsSubject.asObservable().pipe(
+    map((datasets) =>
+      [...datasets].sort((a, b) => {
+        const aMostRecent = a.runs.length > 0 ? Math.max(...a.runs.map((r) => new Date(r.startTime).getTime())) : 0;
+        const bMostRecent = b.runs.length > 0 ? Math.max(...b.runs.map((r) => new Date(r.startTime).getTime())) : 0;
+        return bMostRecent - aMostRecent;
+      })
+    )
+  );
+
+  get datasets(): Dataset[] {
+    return this.datasetsSubject.getValue();
+  }
+  private set datasets(value: Dataset[]) {
+    this.datasetsSubject.next(value);
+  }
+
+  constructor(private stateService: StateService, private rest: RestService) {}
+
+  // ---------------------------------------------------------------------------
+  // GET /bots/:botId/datasets
+  // ---------------------------------------------------------------------------
+  getDatasets(): Observable<Dataset[]> {
+    return this.rest.getArray<Dataset>(this.apiBase(), (res) => res as Dataset[]).pipe(tap((fetched) => this._mergeIntoStore(fetched)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /bots/:botId/datasets/:datasetId
+  // ---------------------------------------------------------------------------
+  getDataset(datasetId: string): Observable<Dataset> {
+    const cached = this.datasets.find((d) => d.id === datasetId);
+    if (cached?._settingsLoaded) {
+      return of(deepCopy(cached));
+    }
+
+    return this.rest
+      .get<Dataset>(`${this.apiBase()}/${datasetId}`, (res) => res as Dataset)
+      .pipe(tap((dataset) => this._upsertIntoStore({ ...dataset, _settingsLoaded: true })));
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /bots/:botId/datasets
+  // ---------------------------------------------------------------------------
+  createDataset(payload: { name: string; description: string; questions: Omit<DatasetQuestion, 'id'>[] }): Observable<Dataset> {
+    return this.rest
+      .post<typeof payload, Dataset>(this.apiBase(), payload, (res) => res as Dataset)
+      .pipe(tap((created) => (this.datasets = [{ ...created, _settingsLoaded: false }, ...this.datasets])));
+  }
+
+  // ---------------------------------------------------------------------------
+  // PUT /bots/:botId/datasets/:datasetId
+  // ---------------------------------------------------------------------------
+  updateDataset(
+    datasetId: string,
+    payload: { name: string; description: string; questions: (Omit<DatasetQuestion, 'id'> & { id?: string })[] }
+  ): Observable<Dataset> {
+    return this.rest
+      .put<typeof payload, Dataset>(`${this.apiBase()}/${datasetId}`, payload, (res) => res as Dataset)
+      .pipe(
+        tap((updated) => {
+          const index = this.datasets.findIndex((d) => d.id === datasetId);
+          if (index !== -1) {
+            const merged = { ...updated, runs: this.datasets[index].runs, _settingsLoaded: this.datasets[index]._settingsLoaded };
+            this.datasets = [...this.datasets.slice(0, index), merged, ...this.datasets.slice(index + 1)];
+          }
+        })
+      );
+  }
+
+  // ---------------------------------------------------------------------------
+  // DELETE /bots/:botId/datasets/:datasetId
+  // ---------------------------------------------------------------------------
+  deleteDataset(datasetId: string): Observable<boolean> {
+    return this.rest.delete<void>(`${this.apiBase()}/${datasetId}`).pipe(
+      tap(() => {
+        this.datasets = this.datasets.filter((d) => d.id !== datasetId);
+      })
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /bots/:botId/datasets/:datasetId/runs
+  // ---------------------------------------------------------------------------
+  createRun(datasetId: string, payload: { language: string }): Observable<DatasetRun> {
+    return this.rest
+      .post<typeof payload, DatasetRun>(`${this.apiBase()}/${datasetId}/runs`, payload, (res) => res as DatasetRun)
+      .pipe(
+        tap((run) => {
+          const dataset = this.datasets.find((d) => d.id === datasetId);
+          if (dataset) {
+            this._updateDatasetRuns(datasetId, [run, ...dataset.runs]);
+          }
+        })
+      );
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /bots/:botId/datasets/:datasetId/runs/:runId
+  // ---------------------------------------------------------------------------
+  getRun(datasetId: string, runId: string): Observable<DatasetRun> {
+    return this.rest.get<DatasetRun>(`${this.apiBase()}/${datasetId}/runs/${runId}`, (res) => res as DatasetRun);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /bots/:botId/datasets/:datasetId/runs/:runId/actions
+  // ---------------------------------------------------------------------------
+  getRunActions(datasetId: string, runId: string): Observable<DatasetRunAction[]> {
+    return this.rest.getArray<DatasetRunAction>(`${this.apiBase()}/${datasetId}/runs/${runId}/actions`, (res) => res as DatasetRunAction[]);
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /bots/:botId/datasets/:datasetId/runs/:runId/cancel
+  // ---------------------------------------------------------------------------
+  cancelRun(datasetId: string, runId: string): Observable<DatasetRun> {
+    return this.rest
+      .post<object, DatasetRun>(`${this.apiBase()}/${datasetId}/runs/${runId}/cancel`, {}, (res) => res as DatasetRun)
+      .pipe(
+        tap((cancelled) =>
+          this.updateRunState(datasetId, runId, { state: cancelled.state, endTime: cancelled.endTime, stats: cancelled.stats })
+        )
+      );
+  }
+
+  // ---------------------------------------------------------------------------
+  // PATCH run state
+  // ---------------------------------------------------------------------------
+  updateRunState(datasetId: string, runId: string, patch: Partial<Pick<DatasetRun, 'state' | 'endTime' | 'stats'>>): void {
+    const datasets = this.datasets;
+    const datasetIndex = datasets.findIndex((d) => d.id === datasetId);
+    if (datasetIndex === -1) return;
+
+    const dataset = datasets[datasetIndex];
+    const runIndex = dataset.runs.findIndex((r) => r.id === runId);
+    if (runIndex === -1) return;
+
+    const updatedRun: DatasetRun = { ...dataset.runs[runIndex], ...patch };
+    const updatedRuns = [...dataset.runs.slice(0, runIndex), updatedRun, ...dataset.runs.slice(runIndex + 1)];
+
+    // A run with COMPLETED status now has a settingsSnapshot on the server side
+    // that the store does not have — we invalidate to force a reload
+    // on the next opening of the detail view.
+    const settingsLoaded = patch.state === DatasetRunState.COMPLETED ? false : dataset._settingsLoaded;
+
+    const updatedDataset: Dataset = { ...dataset, runs: updatedRuns, _settingsLoaded: settingsLoaded };
+    this.datasets = [...datasets.slice(0, datasetIndex), updatedDataset, ...datasets.slice(datasetIndex + 1)];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Domain helpers
+  // ---------------------------------------------------------------------------
+  getLatestRun(dataset: Dataset): DatasetRun | null {
+    if (!dataset.runs?.length) return null;
+    return dataset.runs.reduce((latest, current) => (new Date(current.startTime) > new Date(latest.startTime) ? current : latest));
+  }
+
+  hasActiveRun(dataset: Dataset): boolean {
+    return dataset.runs.some((r) => r.state === DatasetRunState.QUEUED || r.state === DatasetRunState.RUNNING);
+  }
+
+  canProposeNewRun(dataset: Dataset): boolean {
+    return !this.hasActiveRun(dataset);
+  }
+
+  getRunDuration(run: DatasetRun): Observable<string> {
+    const start = new Date(run.startTime);
+    const end = run.endTime ? new Date(run.endTime) : null;
+
+    if (end) {
+      const durationMs = end.getTime() - start.getTime();
+      return durationMs <= 0 ? of('-') : of(this.formatDuration(durationMs));
+    }
+
+    if ([DatasetRunState.QUEUED, DatasetRunState.RUNNING].includes(run.state)) {
+      return interval(1000).pipe(
+        startWith(0),
+        map(() => this.formatDuration(new Date().getTime() - start.getTime()))
+      );
+    }
+
+    return of('-');
+  }
+
+  formatDuration(durationMs: number): string {
+    const days = Math.floor(durationMs / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((durationMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const minutes = Math.floor((durationMs % (1000 * 60 * 60)) / (1000 * 60));
+    const seconds = Math.floor((durationMs % (1000 * 60)) / 1000);
+    const time = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    return days > 0 ? `${days}d ${time}` : time;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+  private apiBase(): string {
+    return `/bots/${this.stateService.currentApplication.name}/datasets`;
+  }
+
+  private _mergeIntoStore(fetched: Dataset[]): void {
+    const existing = new Map(this.datasets.map((d) => [d.id, d]));
+    this.datasets = fetched.map((d) => {
+      const cached = existing.get(d.id);
+      return cached?._settingsLoaded ? cached : d;
+    });
+  }
+
+  private _upsertIntoStore(dataset: Dataset): void {
+    const index = this.datasets.findIndex((d) => d.id === dataset.id);
+    if (index === -1) {
+      this.datasets = [dataset, ...this.datasets];
+    } else {
+      this.datasets = [...this.datasets.slice(0, index), dataset, ...this.datasets.slice(index + 1)];
+    }
+  }
+
+  private _updateDatasetRuns(datasetId: string, runs: DatasetRun[]): void {
+    const datasets = this.datasets;
+    const index = datasets.findIndex((d) => d.id === datasetId);
+    if (index === -1) return;
+
+    const updatedDataset: Dataset = { ...datasets[index], runs, _settingsLoaded: datasets[index]._settingsLoaded };
+    this.datasets = [...datasets.slice(0, index), updatedDataset, ...datasets.slice(index + 1)];
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/services/markdown-diff.service.ts
+++ b/bot/admin/web/src/app/quality/datatsets/services/markdown-diff.service.ts
@@ -1,0 +1,89 @@
+/**
+ * MarkdownDiffService
+ *
+ * Dispatcher vers le Web Worker partagé.
+ * Un seul Worker est instancié pour toute l'application.
+ * Chaque appel à diff() retourne une Promise résolue quand le Worker répond.
+ * Les 20+ appels parallèles sont mis en file automatiquement par le Worker.
+ */
+import { Injectable, OnDestroy } from '@angular/core';
+
+export interface DiffResult {
+  textA: string;
+  textB: string;
+}
+
+interface PendingJob {
+  resolve: (result: DiffResult) => void;
+  reject: (err: Error) => void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class MarkdownDiffService implements OnDestroy {
+  private worker!: Worker;
+
+  // Map job id → pending Promise callbacks
+  private pending = new Map<string, PendingJob>();
+
+  // Monotonic counter for unique job IDs
+  private counter = 0;
+
+  constructor() {
+    this.initWorker();
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────────
+
+  /**
+   * Compute the diff asynchronously in the Web Worker.
+   * Returns a Promise that resolves with annotated Markdown for both sides.
+   *
+   * Safe to call 20+ times in parallel — the Worker queues jobs automatically.
+   */
+  diff(textA: string, textB: string): Promise<DiffResult> {
+    return new Promise<DiffResult>((resolve, reject) => {
+      const id = `diff-${++this.counter}`;
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage({ id, textA, textB });
+    });
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────────────────
+
+  ngOnDestroy(): void {
+    this.worker.terminate();
+    this.pending.forEach(({ reject }) => reject(new Error('MarkdownDiffService destroyed')));
+    this.pending.clear();
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────────
+
+  private initWorker(): void {
+    // Angular CLI registers the worker via the webWorker builder option.
+    // The URL syntax below is what Angular CLI needs to detect and bundle it.
+    this.worker = new Worker(new URL('./markdown-diff.worker', import.meta.url), { type: 'module' });
+
+    this.worker.addEventListener('message', ({ data }) => {
+      const job = this.pending.get(data.id);
+      if (!job) return;
+      this.pending.delete(data.id);
+
+      if (data.error) {
+        job.reject(new Error(data.error));
+      } else {
+        job.resolve({ textA: data.textA, textB: data.textB });
+      }
+    });
+
+    this.worker.addEventListener('error', (event) => {
+      // Worker-level crash: reject all pending jobs
+      const err = new Error(`Worker error: ${event.message}`);
+      this.pending.forEach(({ reject }) => reject(err));
+      this.pending.clear();
+
+      // Attempt to restart
+      console.error('[MarkdownDiffService] Worker crashed, restarting…', event);
+      this.initWorker();
+    });
+  }
+}

--- a/bot/admin/web/src/app/quality/datatsets/services/markdown-diff.worker.ts
+++ b/bot/admin/web/src/app/quality/datatsets/services/markdown-diff.worker.ts
@@ -1,0 +1,123 @@
+/**
+ * markdown-diff.worker.ts
+ *
+ * Web Worker — tout le calcul de diff se fait dans ce thread séparé.
+ *
+ * Protocol (structured-clone, strings uniquement) :
+ *   Request  (main → worker) : { id: string; textA: string; textB: string }
+ *   Response (worker → main) : { id: string; textA: string; textB: string }
+ *                            | { id: string; error: string }
+ */
+
+/// <reference lib="webworker" />
+
+const TOKEN_RE = new RegExp(
+  [
+    '`{3}[^\\n]*\\n[\\s\\S]*?`{3}',
+    '~{3}[^\\n]*\\n[\\s\\S]*?~{3}',
+    '`[^`\\n]+`',
+    '\\*{3}|_{3}',
+    '\\*{2}|_{2}',
+    '\\*|_',
+    '~~',
+    '!\\[.*?\\]\\(.*?\\)',
+    '\\[.*?\\]\\(.*?\\)',
+    '^#{1,6}\\s',
+    '&[a-zA-Z]+;|&#\\d+;',
+    '\\n',
+    -"[\\wÀ-ÿ'\u2019-]+",
+    +"[$\\wÀ-ÿ'\u2019-]+", // ← $ inclus pour $t, $route, $emit, etc.
+    '.'
+  ].join('|'),
+  'gm'
+);
+
+function tokenise(text: string): string[] {
+  return text.match(TOKEN_RE) ?? [];
+}
+
+type DiffOp = { type: 'equal' | 'insert' | 'delete'; tokens: string[] };
+
+function myersDiff(a: string[], b: string[]): DiffOp[] {
+  const m = a.length,
+    n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--)
+    for (let j = n - 1; j >= 0; j--) dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+
+  const ops: DiffOp[] = [];
+  let i = 0,
+    j = 0;
+  const push = (type: DiffOp['type'], token: string) => {
+    const last = ops[ops.length - 1];
+    last && last.type === type ? last.tokens.push(token) : ops.push({ type, tokens: [token] });
+  };
+  while (i < m || j < n) {
+    if (i < m && j < n && a[i] === b[j]) {
+      push('equal', a[i]);
+      i++;
+      j++;
+    } else if (j < n && (i >= m || dp[i][j + 1] >= dp[i + 1][j])) {
+      push('insert', b[j]);
+      j++;
+    } else {
+      push('delete', a[i]);
+      i++;
+    }
+  }
+  return ops;
+}
+
+const CODE_BLOCK_RE = /^(`{3}|~{3})/;
+
+function buildSide(ops: DiffOp[], side: 'delete' | 'insert'): string {
+  const cls = side === 'delete' ? 'added' : 'removed';
+  const flat: { token: string; changed: boolean }[] = [];
+  for (const op of ops) {
+    if (op.type === 'equal') for (const t of op.tokens) flat.push({ token: t, changed: false });
+    else if (op.type === side) for (const t of op.tokens) flat.push({ token: t, changed: true });
+  }
+
+  let out = '',
+    i = 0;
+  while (i < flat.length) {
+    const { token, changed } = flat[i];
+    if (CODE_BLOCK_RE.test(token)) {
+      out += token;
+      i++;
+      continue;
+    }
+    if (!changed) {
+      out += token;
+      i++;
+      continue;
+    }
+
+    let j = i;
+    while (j < flat.length && flat[j].changed && !CODE_BLOCK_RE.test(flat[j].token)) j++;
+
+    const run = flat.slice(i, j).map((f) => f.token);
+    let s = 0,
+      e = run.length;
+    while (s < e && /^\s+$/.test(run[s])) {
+      out += run[s++];
+    }
+    while (e > s && /^\s+$/.test(run[e - 1])) e--;
+
+    const inner = run.slice(s, e);
+    out += inner.length && inner.some((t) => !/^\s+$/.test(t)) ? `<span class="${cls}">${inner.join('')}</span>` : inner.join('');
+    for (let k = e; k < run.length; k++) out += run[k];
+    i = j;
+  }
+  return out;
+}
+
+addEventListener('message', ({ data }) => {
+  const { id, textA, textB } = data as { id: string; textA: string; textB: string };
+  try {
+    const ops = myersDiff(tokenise(textA), tokenise(textB));
+    postMessage({ id, textA: buildSide(ops, 'delete'), textB: buildSide(ops, 'insert') });
+  } catch (err) {
+    postMessage({ id, error: err instanceof Error ? err.message : String(err) });
+  }
+});

--- a/bot/admin/web/src/app/quality/datatsets/services/object-diff.service.ts
+++ b/bot/admin/web/src/app/quality/datatsets/services/object-diff.service.ts
@@ -1,0 +1,425 @@
+/**
+ * ObjectDiffService
+ *
+ * Compares two arbitrary JSON-serialisable objects and produces an HTML
+ * representation of each, styled like a JSON viewer, with diff highlights.
+ *
+ * Highlight classes (apply your own CSS):
+ *   .diff-added   — key/value present in A but not in B  (shown in pane A)
+ *   .diff-removed — key/value present in B but not in A  (shown in pane B)
+ *   .diff-changed — key exists in both but value differs  (shown in both panes)
+ *
+ * Rules
+ * ─────
+ * Objects  → recursive key-by-key diff.
+ *            • Key only in A  → entire subtree marked .diff-added   in A.
+ *            • Key only in B  → entire subtree marked .diff-removed in B.
+ *            • Key in both, same value  → no highlight.
+ *            • Key in both, different value:
+ *                - If both sides are objects/arrays → recurse.
+ *                - Otherwise → mark value .diff-changed in both panes.
+ *
+ * Arrays   → LCS-based item-by-item diff (same Myers algorithm as the
+ *            Markdown service).  Items matched by position after LCS.
+ *            • Item only in A → .diff-added in A.
+ *            • Item only in B → .diff-removed in B.
+ *            • Item in both but different → recurse if objects, else
+ *              .diff-changed on the scalar value.
+ *
+ * Primitives (string, number, boolean, null) → compared by value.
+ *
+ * Output
+ * ──────
+ * { htmlA: string, htmlB: string }
+ * Both strings are self-contained HTML fragments (no external dependencies)
+ * ready to be bound via [innerHTML] in Angular (use bypassSecurityTrustHtml).
+ */
+import { Injectable } from '@angular/core';
+
+export interface ObjectDiffResult {
+  htmlA: string;
+  htmlB: string;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+type DiffStatus = 'equal' | 'added' | 'removed' | 'changed';
+
+// Internal diff tree — one node per value, carrying status for each side.
+interface DiffNode {
+  /** Status as seen from pane A */
+  statusA: DiffStatus;
+  /** Status as seen from pane B */
+  statusB: DiffStatus;
+  /** Scalar value for A side (primitives) */
+  valueA?: JsonValue;
+  /** Scalar value for B side (primitives) */
+  valueB?: JsonValue;
+  /** For objects: ordered list of [key, childNode] */
+  objectEntries?: [string, DiffNode][];
+  /** For arrays: ordered list of child nodes */
+  arrayItems?: DiffNode[];
+  /** Node kind */
+  kind: 'primitive' | 'object' | 'array';
+}
+
+// ─── LCS for arrays ───────────────────────────────────────────────────────────
+
+function lcsIndices(a: JsonValue[], b: JsonValue[]): [number, number][] {
+  const m = a.length,
+    n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--)
+    for (let j = n - 1; j >= 0; j--) dp[i][j] = deepEqual(a[i], b[j]) ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+
+  const pairs: [number, number][] = [];
+  let i = 0,
+    j = 0;
+  while (i < m && j < n) {
+    if (deepEqual(a[i], b[j])) {
+      pairs.push([i, j]);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) i++;
+    else j++;
+  }
+  return pairs;
+}
+
+// ─── Deep equality ────────────────────────────────────────────────────────────
+
+function deepEqual(a: JsonValue, b: JsonValue): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ─── Core diff engine ─────────────────────────────────────────────────────────
+
+function diffValues(a: JsonValue, b: JsonValue): DiffNode {
+  // Both primitives (or one side is primitive)
+  if (!isObject(a) && !isArray(a) && !isObject(b) && !isArray(b)) {
+    const equal = deepEqual(a, b);
+    return {
+      kind: 'primitive',
+      statusA: equal ? 'equal' : 'changed',
+      statusB: equal ? 'equal' : 'changed',
+      valueA: a,
+      valueB: b
+    };
+  }
+
+  // Type mismatch (e.g. array vs object) → treat as changed scalars
+  if (isArray(a) !== isArray(b) || isObject(a) !== isObject(b)) {
+    return {
+      kind: 'primitive',
+      statusA: 'changed',
+      statusB: 'changed',
+      valueA: a,
+      valueB: b
+    };
+  }
+
+  // Both arrays
+  if (isArray(a) && isArray(b)) {
+    return diffArrays(a as JsonValue[], b as JsonValue[]);
+  }
+
+  // Both objects
+  if (isObject(a) && isObject(b)) {
+    return diffObjects(a as Record<string, JsonValue>, b as Record<string, JsonValue>);
+  }
+
+  // Fallback
+  return { kind: 'primitive', statusA: 'equal', statusB: 'equal', valueA: a, valueB: b };
+}
+
+function diffObjects(a: Record<string, JsonValue>, b: Record<string, JsonValue>): DiffNode {
+  // Preserve insertion order: keys from A first, then new keys from B.
+  const allKeys = [...new Set([...Object.keys(a), ...Object.keys(b)])];
+  const entries: [string, DiffNode][] = [];
+
+  for (const key of allKeys) {
+    const inA = Object.prototype.hasOwnProperty.call(a, key);
+    const inB = Object.prototype.hasOwnProperty.call(b, key);
+
+    if (inA && inB) {
+      entries.push([key, diffValues(a[key], b[key])]);
+    } else if (inA) {
+      entries.push([key, makeAdded(a[key])]);
+    } else {
+      entries.push([key, makeRemoved(b[key])]);
+    }
+  }
+
+  // Parent status: 'equal' only if all children are equal
+  const anyChanged = entries.some(([, n]) => n.statusA !== 'equal' || n.statusB !== 'equal');
+  return {
+    kind: 'object',
+    statusA: anyChanged ? 'changed' : 'equal',
+    statusB: anyChanged ? 'changed' : 'equal',
+    objectEntries: entries
+  };
+}
+
+function diffArrays(a: JsonValue[], b: JsonValue[]): DiffNode {
+  const matched = lcsIndices(a, b);
+  const matchedA = new Set(matched.map(([i]) => i));
+  const matchedB = new Set(matched.map(([, j]) => j));
+
+  // Build ordered item list by merging A and B sequences
+  const items: DiffNode[] = [];
+
+  // We'll walk through matched pairs and fill gaps
+  let prevAi = -1,
+    prevBj = -1;
+  for (const [ai, bj] of [...matched, [a.length, b.length]]) {
+    // Unmatched A items (deleted from B)
+    for (let i = prevAi + 1; i < ai; i++) {
+      if (!matchedA.has(i)) items.push(makeAdded(a[i]));
+    }
+    // Unmatched B items (inserted in B)
+    for (let j = prevBj + 1; j < bj; j++) {
+      if (!matchedB.has(j)) items.push(makeRemoved(b[j]));
+    }
+    // Matched pair
+    if (ai < a.length && bj < b.length) {
+      items.push(diffValues(a[ai], b[bj]));
+    }
+    prevAi = ai;
+    prevBj = bj;
+  }
+
+  const anyChanged = items.some((n) => n.statusA !== 'equal' || n.statusB !== 'equal');
+  return {
+    kind: 'array',
+    statusA: anyChanged ? 'changed' : 'equal',
+    statusB: anyChanged ? 'changed' : 'equal',
+    arrayItems: items
+  };
+}
+
+/** Wrap a value (and all its descendants) as existing only in A.
+ *  statusA='added'   → green in pane A.
+ *  statusB='removed' → hidden in pane B (node doesn't exist in B).
+ */
+function makeAdded(value: JsonValue): DiffNode {
+  return wrapEntire(value, 'added', 'removed');
+}
+
+/** Wrap a value (and all its descendants) as existing only in B.
+ *  statusA='removed' → hidden in pane A (node doesn't exist in A).
+ *  statusB='added'   → red in pane B.
+ */
+function makeRemoved(value: JsonValue): DiffNode {
+  return wrapEntire(value, 'removed', 'added');
+}
+
+function wrapEntire(value: JsonValue, statusA: DiffStatus, statusB: DiffStatus): DiffNode {
+  if (isArray(value)) {
+    return {
+      kind: 'array',
+      statusA,
+      statusB,
+      arrayItems: (value as JsonValue[]).map((v) => wrapEntire(v, statusA, statusB))
+    };
+  }
+  if (isObject(value)) {
+    return {
+      kind: 'object',
+      statusA,
+      statusB,
+      objectEntries: Object.entries(value as Record<string, JsonValue>).map(([k, v]) => [k, wrapEntire(v, statusA, statusB)])
+    };
+  }
+  return { kind: 'primitive', statusA, statusB, valueA: value, valueB: value };
+}
+
+// ─── HTML renderer ────────────────────────────────────────────────────────────
+//
+// Highlight rules (token-only — indentation is NEVER coloured):
+//
+// Pane A:
+//   • Key   added   (only in A)          → diff-added   on the key token
+//   • Key   changed (exists in B, differs) → diff-changed on the key token
+//   • Value added   (primitive, only in A) → diff-added   on the value token
+//   • Value changed (primitive, differs)   → diff-changed on the value token
+//   • "removed" nodes are hidden (they don't exist in A)
+//
+// Pane B:
+//   • Key   removed (only in B)          → diff-removed on the key token
+//   • Value removed (primitive, only in B)→ diff-removed on the value token
+//   • No yellow/green ever appear in B
+//   • "added" nodes are hidden (they don't exist in B)
+//
+// For object/array nodes that are added/removed en bloc, each descendant
+// key and primitive value inherits the added/removed status recursively
+// (already encoded in the DiffNode tree by wrapEntire).
+
+type Side = 'A' | 'B';
+const INDENT = 2; // spaces per depth level
+
+/**
+ * Returns the CSS class to apply to a KEY token on the given side.
+ *
+ *  A | added   → diff-added    (key only in A)
+ *  A | changed → diff-changed  (key in both, something inside differs)
+ *  B | added   → diff-removed  (key only in B — statusB='added' = B-only)
+ */
+function keyClass(status: DiffStatus, side: Side): string {
+  if (side === 'A') {
+    if (status === 'added') return 'diff-added';
+    if (status === 'changed') return 'diff-changed';
+  } else {
+    // statusB='added' means this node exists only in B → show red
+    if (status === 'added') return 'diff-removed';
+  }
+  return '';
+}
+
+/**
+ * Returns the CSS class to apply to a SCALAR VALUE token on the given side.
+ *
+ *  A | added   → diff-added
+ *  A | changed → diff-changed
+ *  B | added   → diff-removed  (B-only value)
+ */
+function valueClass(status: DiffStatus, side: Side): string {
+  if (side === 'A') {
+    if (status === 'added') return 'diff-added';
+    if (status === 'changed') return 'diff-changed';
+  } else {
+    if (status === 'added') return 'diff-removed';
+  }
+  return '';
+}
+
+function spanWrap(content: string, cls: string): string {
+  return cls ? `<span class="${cls}">${content}</span>` : content;
+}
+
+function renderNode(node: DiffNode, side: Side, depth: number): string | null {
+  const status = side === 'A' ? node.statusA : node.statusB;
+  const indent = ' '.repeat(depth * INDENT);
+  const indentChild = ' '.repeat((depth + 1) * INDENT);
+
+  // ── Visibility gate ─────────────────────────────────────────────────────────
+  // statusA='removed' → node only exists in B → omit from pane A
+  // statusB='removed' → node only exists in A → omit from pane B
+  if (side === 'A' && status === 'removed') return null;
+  if (side === 'B' && status === 'removed') return null;
+
+  // ── Primitive ────────────────────────────────────────────────────────────────
+  if (node.kind === 'primitive') {
+    const value = side === 'A' ? node.valueA : node.valueB;
+    const cls = valueClass(status, side);
+    return spanWrap(formatPrimitive(value), cls);
+  }
+
+  // ── Object ───────────────────────────────────────────────────────────────────
+  if (node.kind === 'object') {
+    const entries = node.objectEntries ?? [];
+    if (entries.length === 0) return '{}';
+
+    const lines: string[] = ['{'];
+
+    for (const [key, child] of entries) {
+      const childRendered = renderNode(child, side, depth + 1);
+      if (childRendered === null) continue; // hidden on this side
+
+      const childStatus = side === 'A' ? child.statusA : child.statusB;
+      const comma = ''; // commas added after the loop on visible items
+
+      const kCls = keyClass(childStatus, side);
+      const keyHtml = spanWrap(`"${escHtml(key)}"`, kCls);
+
+      lines.push(`${indentChild}${keyHtml}: ${childRendered}`);
+    }
+
+    // Add commas to all lines except the last entry line and the closing brace
+    const result = addTrailingCommas(lines);
+    result.push(`${indent}}`);
+    return result.join('\n');
+  }
+
+  // ── Array ────────────────────────────────────────────────────────────────────
+  if (node.kind === 'array') {
+    const items = node.arrayItems ?? [];
+    if (items.length === 0) return '[]';
+
+    const lines: string[] = ['['];
+
+    for (const child of items) {
+      const childRendered = renderNode(child, side, depth + 1);
+      if (childRendered === null) continue;
+
+      const childStatus = side === 'A' ? child.statusA : child.statusB;
+      const vCls = valueClass(childStatus, side);
+
+      // For array items that are primitives, the span is already applied by
+      // renderNode above.  For object/array items we don't add an extra span —
+      // individual tokens inside are already annotated recursively.
+      lines.push(`${indentChild}${childRendered}`);
+    }
+
+    const result = addTrailingCommas(lines);
+    result.push(`${indent}]`);
+    return result.join('\n');
+  }
+
+  return '';
+}
+
+/**
+ * Given a lines array starting with the opening bracket/brace line, adds a
+ * trailing comma to every entry line except the last one.
+ * Returns the lines WITHOUT the closing bracket (caller appends it).
+ */
+function addTrailingCommas(lines: string[]): string[] {
+  // lines[0] is the opening '{' or '[' — skip it.
+  // Lines[1..n] are entry lines — add comma to all but the last.
+  const entries = lines.slice(1);
+  return [lines[0], ...entries.map((line, i) => (i < entries.length - 1 ? line + ',' : line))];
+}
+
+function formatPrimitive(v: JsonValue | undefined): string {
+  if (v === null) return 'null';
+  if (typeof v === 'string') return `"${v}"`;
+  return String(v);
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isArray(v: JsonValue): boolean {
+  return Array.isArray(v);
+}
+function isObject(v: JsonValue): boolean {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// ─── Public service ───────────────────────────────────────────────────────────
+
+@Injectable({ providedIn: 'root' })
+export class ObjectDiffService {
+  /**
+   * Diff two JSON-serialisable objects.
+   * Returns two HTML strings (one per side) ready for [innerHTML] binding.
+   *
+   * Wrap with <pre> for monospaced display, e.g.:
+   *   <pre class="json-diff" [innerHTML]="result.htmlA"></pre>
+   */
+  diff(objA: unknown, objB: unknown): ObjectDiffResult {
+    const a = objA as JsonValue;
+    const b = objB as JsonValue;
+    const tree = diffValues(a, b);
+
+    return {
+      htmlA: renderNode(tree, 'A', 0) ?? '',
+      htmlB: renderNode(tree, 'B', 0) ?? ''
+    };
+  }
+}

--- a/bot/admin/web/src/app/quality/quality-routing.module.ts
+++ b/bot/admin/web/src/app/quality/quality-routing.module.ts
@@ -22,6 +22,8 @@ import { AuthGuard } from '../core-nlp/auth/auth.guard';
 import { SamplesBoardComponent } from './samples/samples-board/samples-board.component';
 import { QualityTabsComponent } from './quality-tabs.component';
 import { SampleDetailComponent } from './samples/sample-detail/sample-detail.component';
+import { DatasetsBoardComponent } from './datatsets/datasets-board/datasets-board.component';
+import { DatasetDetailComponent } from './datatsets/dataset-detail/dataset-detail.component';
 
 const routes: Routes = [
   {
@@ -47,6 +49,18 @@ const routes: Routes = [
       {
         path: 'samples/detail/:id',
         component: SampleDetailComponent
+      },
+      {
+        path: 'datasets',
+        component: DatasetsBoardComponent
+      },
+      {
+        path: 'datasets/datasets-board',
+        component: DatasetsBoardComponent
+      },
+      {
+        path: 'datasets/detail/:id',
+        component: DatasetDetailComponent
       }
     ]
   }

--- a/bot/admin/web/src/app/quality/quality.module.ts
+++ b/bot/admin/web/src/app/quality/quality.module.ts
@@ -43,9 +43,26 @@ import { QualityRoutingModule } from './quality-routing.module';
 import { SampleCreateComponent } from './samples/sample-create/sample-create.component';
 import { SampleDetailComponent } from './samples/sample-detail/sample-detail.component';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { DatasetsBoardComponent } from './datatsets/datasets-board/datasets-board.component';
+import { DatasetCreateComponent } from './datatsets/dataset-create/dataset-create.component';
+import { DatasetDetailComponent } from './datatsets/dataset-detail/dataset-detail.component';
+import { DatasetDetailSettingsDiffComponent } from './datatsets/dataset-detail/settings-diff/settings-diff.component';
+import { DatasetDetailEntryComponent } from './datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component';
+import { DatasetsBoardEntryComponent } from './datatsets/datasets-board/dataset-board-entry/datasets-board-entry.component';
 
 @NgModule({
-  declarations: [QualityTabsComponent, SamplesBoardComponent, SampleCreateComponent, SampleDetailComponent],
+  declarations: [
+    QualityTabsComponent,
+    SamplesBoardComponent,
+    SampleCreateComponent,
+    SampleDetailComponent,
+    DatasetsBoardComponent,
+    DatasetsBoardEntryComponent,
+    DatasetCreateComponent,
+    DatasetDetailComponent,
+    DatasetDetailSettingsDiffComponent,
+    DatasetDetailEntryComponent
+  ],
   imports: [
     ReactiveFormsModule,
     CommonModule,

--- a/bot/admin/web/src/app/quality/samples/samples-board/samples-board.component.scss
+++ b/bot/admin/web/src/app/quality/samples/samples-board/samples-board.component.scss
@@ -1,8 +1,14 @@
 .list-grid {
   display: grid;
   grid-template-columns:
-    minmax(130px, 1fr) minmax(60px, 110px) minmax(40px, 100px) minmax(60px, 80px) minmax(60px, 80px) minmax(40px, 130px) minmax(40px, 130px)
-    minmax(20px, 80px);
+    minmax(8rem, 1fr)
+    minmax(2.5rem, 6.875rem)
+    minmax(2.5rem, 6.25rem)
+    minmax(2rem, 5rem)
+    minmax(2rem, 5rem)
+    minmax(3.5rem, 8.125rem)
+    minmax(3.5rem, 8.125rem)
+    minmax(1.25rem, 4.5rem);
   gap: 0.5rem;
   padding: var(--card-padding);
 }

--- a/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.html
+++ b/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.html
@@ -1,22 +1,28 @@
-<!--
-  ~ Copyright (C) 2017/2025 SNCF Connect & Tech
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <div
-  [ngClass]="{ scrolled: scrolled }"
+  [ngClass]="{ scrolled: scrolled, hidden: hidden }"
   class="sticky"
 >
-  <ng-content></ng-content>
+  <div class="content-wrapper">
+    <div class="content">
+      <ng-content></ng-content>
+    </div>
+  </div>
+
+  <button
+    *ngIf="hideable"
+    nbButton
+    size="tiny"
+    class="reduce"
+    (click)="swapDisplay()"
+    [nbTooltip]="hidden ? 'Expand this menu' : 'Reduce this menu'"
+  >
+    <i
+      *ngIf="!hidden"
+      class="bi bi-chevron-up"
+    ></i>
+    <i
+      *ngIf="hidden"
+      class="bi bi-chevron-down"
+    ></i>
+  </button>
 </div>

--- a/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.scss
+++ b/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.scss
@@ -19,13 +19,26 @@
   top: 5em;
   z-index: 2;
   background: var(--layout-background-color);
+  transition: all 0.1s ease-in;
 
   &.scrolled {
     margin: -1em;
     padding: 0.5em 0.5em 0.5em 1em;
 
     box-shadow: 0px 8px 12px -12px #000000b3;
-    transition: all 0.1s ease-in;
+  }
+
+  .reduce {
+    display: none;
+
+    cursor: pointer;
+
+    position: absolute;
+
+    bottom: 0em;
+
+    left: -1.6em;
+    padding: 0.5em 0.75em;
   }
 
   ::ng-deep {
@@ -35,9 +48,47 @@
   }
 
   &.scrolled {
+    min-height: 1.75em;
+
+    .reduce {
+      display: block;
+    }
+
     ::ng-deep {
       .sticky-menu-scrolled-info {
         display: block;
+      }
+    }
+
+    .content-wrapper {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows 0.25s ease-in-out;
+      overflow: hidden;
+
+      .content {
+        min-height: 0;
+        overflow: hidden;
+      }
+    }
+
+    &.hidden {
+      height: 1.75em;
+
+      .content-wrapper {
+        grid-template-rows: 0fr;
+      }
+    }
+  }
+}
+
+.nb-theme-dark {
+  :host {
+    .sticky {
+      .reduce {
+        background-color: var(--layout-background-color) !important;
+        border-color: var(--border-basic-color-4);
+        color: var(--card-text-color);
       }
     }
   }

--- a/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.ts
+++ b/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.ts
@@ -1,21 +1,6 @@
-/*
- * Copyright (C) 2017/2025 SNCF Connect & Tech
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import { DOCUMENT } from '@angular/common';
-import { Component, HostListener, Inject, Input, OnInit } from '@angular/core';
+import { Component, HostListener, Inject, Input, OnInit, ViewChild } from '@angular/core';
+import { NbTooltipDirective } from '@nebular/theme';
 
 @Component({
   selector: 'tock-sticky-menu',
@@ -24,8 +9,12 @@ import { Component, HostListener, Inject, Input, OnInit } from '@angular/core';
 })
 export class StickyMenuComponent implements OnInit {
   @Input() offset: number = 230;
+  @Input() hideable: boolean = false;
+
+  @ViewChild(NbTooltipDirective) tooltip: NbTooltipDirective;
 
   scrolled: boolean = false;
+  hidden: boolean = false;
   prevScrollVal: number;
 
   constructor(@Inject(DOCUMENT) private document: Document) {}
@@ -38,9 +27,14 @@ export class StickyMenuComponent implements OnInit {
   onPageScroll(): void {
     const verticalOffset = this.document.documentElement.scrollTop || this.document.body.scrollTop || 0;
 
-    if (verticalOffset === 0 && this.prevScrollVal > this.offset) return; // deal with <nb-select> reseting page scroll when opening select
+    if (verticalOffset === 0 && this.prevScrollVal > this.offset) return;
 
     this.scrolled = verticalOffset > this.offset ? true : false;
     this.prevScrollVal = verticalOffset;
+  }
+
+  swapDisplay() {
+    this.hidden = !this.hidden;
+    this.tooltip?.hide();
   }
 }

--- a/bot/admin/web/src/app/shared/utils/markup.utils.ts
+++ b/bot/admin/web/src/app/shared/utils/markup.utils.ts
@@ -178,8 +178,12 @@ export const katexInlineExtension: TokenizerExtension & RendererExtension = {
   },
 
   tokenizer(src: string): katexInlineToken | undefined {
-    // 1) $...$
-    const rule1 = /^\$([^$]+?)\$/;
+    // Matches $...$ inline math only when:
+    // - not preceded by a digit (avoids currency like $20)
+    // - no whitespace immediately after opening $ or before closing $
+    // - content is non-empty and does not itself contain $
+    // This avoids false positives on prices, variable names like $t, $route, etc.
+    const rule1 = /^\$(?!\s)([^$\n]+?)(?<!\s)\$(?!\d)/;
     const match1 = rule1.exec(src);
     if (match1) {
       const token: katexInlineToken = {
@@ -232,6 +236,28 @@ export const markedParser = new Marked({
     postprocess: (html) => DOMPurify.sanitize(html)
   },
   extensions: [katexBlockExtension, katexInlineExtension],
+  breaks: true,
+  gfm: true
+});
+
+export const markedParserForDiff = new Marked({
+  async: false,
+  ...markedHighlight({
+    emptyLangClass: 'hljs',
+    langPrefix: 'hljs language-',
+    highlight(code, lang, info) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    }
+  }),
+  hooks: {
+    postprocess: (html) =>
+      DOMPurify.sanitize(html, {
+        // Allow spans with class 'added' or 'removed' for diff highlighting, but no other classes or tags to minimize XSS risks
+        ADD_TAGS: ['span'],
+        ADD_ATTR: ['class']
+      })
+  },
   breaks: true,
   gfm: true
 });

--- a/bot/admin/web/src/app/theme/components/header/header.component.html
+++ b/bot/admin/web/src/app/theme/components/header/header.component.html
@@ -28,22 +28,24 @@
     </div>
   </div>
 
-  <div class="d-flex align-items-center gap-1">
+  <div class="header-tools">
     <div class="d-flex gap-1 align-items-center mode-switch">
-      <nb-icon
-        nbTooltip="Light Mode"
-        icon="brightness-high"
-      ></nb-icon>
-      <nb-toggle
-        [ngModel]="isDarkTheme()"
-        (change)="switchTheme()"
-        class="darkmode-toggle nb-toggle-reset-label-margin"
-        nbTooltip="Switch mode"
-      ></nb-toggle>
-      <nb-icon
-        nbTooltip="Dark Mode"
-        icon="brightness-low"
-      ></nb-icon>
+      <button
+        nbButton
+        ghost
+        size="medium"
+        (click)="switchTheme()"
+        [nbTooltip]="isDarkTheme() ? 'Use light mode' : 'Use dark mode'"
+      >
+        <nb-icon
+          *ngIf="isDarkTheme()"
+          icon="brightness-high"
+        ></nb-icon>
+        <nb-icon
+          *ngIf="!isDarkTheme()"
+          icon="moon"
+        ></nb-icon>
+      </button>
     </div>
 
     <nb-form-field *ngIf="state.currentApplication">
@@ -55,7 +57,7 @@
         (selectedChange)="changeApplication($event)"
         [ngModel]="currentApplicationName"
         nbTooltip="Select current application"
-        class="mb-0 min-width-5 max-width-15em"
+        class="mb-0"
       >
         <nb-option
           *ngFor="let app of state.applications"
@@ -74,7 +76,7 @@
         (selectedChange)="changeNamespace($event)"
         [selected]="currentNamespaceName"
         nbTooltip="Select current namespace"
-        class="mb-0 min-width-5 max-width-15em"
+        class="mb-0"
       >
         <nb-option
           *ngFor="let namespace of state.namespaces"
@@ -93,7 +95,7 @@
         (selectedChange)="changeLocale($event)"
         [ngModel]="state.currentLocale"
         nbTooltip="Select current locale"
-        class="mb-0 min-width-5 max-width-15em"
+        class="mb-0"
       >
         <nb-option
           *ngFor="let l of state.currentApplication.supportedLocales"

--- a/bot/admin/web/src/app/theme/components/header/header.component.scss
+++ b/bot/admin/web/src/app/theme/components/header/header.component.scss
@@ -32,15 +32,22 @@
   }
 
   @include media-breakpoint-down(sm) {
-    .logo-txt,
-    .mode-switch {
+    .logo-txt {
       display: none !important;
     }
   }
 
-  @include media-breakpoint-down(is) {
-    nb-select {
-      display: none;
+  .header-tools {
+    display: grid;
+    gap: 0.5rem;
+    padding: var(--card-padding);
+
+    // Default grid: without the optional logout button (6 columns)
+    grid-template-columns: 2.5em minmax(7em, auto) minmax(7em, auto) minmax(5em, auto) 2.5em 2.5em;
+
+    // If a 7th child is present (logout button), add the extra column
+    &:has(> :nth-child(7)) {
+      grid-template-columns: 2.5em minmax(7em, auto) minmax(7em, auto) minmax(5em, auto) 2.5em 2.5em 2.5em;
     }
   }
 }

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -149,6 +149,10 @@
   text-overflow: ellipsis;
 }
 
+.white-space-pre-line {
+  white-space: pre-line;
+}
+
 nb-select.appearance-outline .select-button {
   min-width: auto !important;
 }
@@ -317,6 +321,9 @@ nb-menu {
 
 .max-width-15em {
   max-width: 15em !important;
+}
+.max-width-20em {
+  max-width: 20em !important;
 }
 
 .min-height-90vh {

--- a/bot/engine/src/main/kotlin/admin/dataset/Dataset.kt
+++ b/bot/engine/src/main/kotlin/admin/dataset/Dataset.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.dataset
+
+import ai.tock.shared.Dice
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
+import java.time.Instant
+
+data class DatasetQuestion(
+    val id: String = Dice.newId(),
+    val question: String,
+    val groundTruth: String? = null,
+)
+
+data class Dataset(
+    val _id: Id<Dataset> = newId(),
+    val namespace: String,
+    val botId: String,
+    val name: String,
+    val description: String,
+    val questions: List<DatasetQuestion>,
+    val createdAt: Instant,
+    val createdBy: String,
+    val updatedAt: Instant? = null,
+    val updatedBy: String? = null,
+)

--- a/bot/engine/src/main/kotlin/admin/dataset/DatasetDAO.kt
+++ b/bot/engine/src/main/kotlin/admin/dataset/DatasetDAO.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.dataset
+
+import org.litote.kmongo.Id
+
+interface DatasetDAO {
+    fun save(dataset: Dataset): Dataset
+
+    fun getDatasetById(id: Id<Dataset>): Dataset?
+
+    fun getDatasetsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): List<Dataset>
+
+    fun delete(id: Id<Dataset>)
+
+    fun deleteByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    )
+}

--- a/bot/engine/src/main/kotlin/admin/dataset/DatasetRun.kt
+++ b/bot/engine/src/main/kotlin/admin/dataset/DatasetRun.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.dataset
+
+import ai.tock.bot.admin.bot.BotApplicationConfiguration
+import ai.tock.bot.engine.action.Action
+import ai.tock.bot.engine.dialog.Dialog
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
+import java.time.Instant
+import java.util.Locale
+
+enum class DatasetRunState {
+    QUEUED,
+    RUNNING,
+    COMPLETED,
+    CANCELLED,
+}
+
+enum class DatasetRunQuestionResultState {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    FAILED,
+    CANCELLED,
+}
+
+data class DatasetRun(
+    val _id: Id<DatasetRun> = newId(),
+    val namespace: String,
+    val botId: String,
+    val datasetId: Id<Dataset>,
+    val state: DatasetRunState,
+    val startTime: Instant,
+    val endTime: Instant? = null,
+    val startedBy: String,
+    val language: Locale? = null,
+    val botApplicationConfigurationId: Id<BotApplicationConfiguration>? = null,
+    val settingsSnapshot: Map<String, Any?> = emptyMap(),
+)
+
+data class DatasetRunQuestionResult(
+    val _id: Id<DatasetRunQuestionResult> = newId(),
+    val namespace: String,
+    val botId: String,
+    val datasetId: Id<Dataset>,
+    val runId: Id<DatasetRun>,
+    val questionId: String,
+    val state: DatasetRunQuestionResultState = DatasetRunQuestionResultState.PENDING,
+    val startedAt: Instant? = null,
+    val endedAt: Instant? = null,
+    val userIdModifier: String,
+    val userActionId: String? = null,
+    val dialogId: Id<Dialog>? = null,
+    val answerActionId: Id<Action>? = null,
+    val retryCount: Int = 0,
+    val error: String? = null,
+)

--- a/bot/engine/src/main/kotlin/admin/dataset/DatasetRunDAO.kt
+++ b/bot/engine/src/main/kotlin/admin/dataset/DatasetRunDAO.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.dataset
+
+import org.litote.kmongo.Id
+
+interface DatasetRunDAO {
+    fun saveRun(run: DatasetRun): DatasetRun
+
+    fun claimNextQueuedRun(): DatasetRun?
+
+    fun getRunById(id: Id<DatasetRun>): DatasetRun?
+
+    fun getRunsByDatasetId(datasetId: Id<Dataset>): List<DatasetRun>
+
+    fun getActiveRunsByDatasetId(datasetId: Id<Dataset>): List<DatasetRun>
+
+    fun deleteRun(id: Id<DatasetRun>)
+
+    fun deleteRunsByDatasetId(datasetId: Id<Dataset>)
+
+    fun deleteRunsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    )
+
+    fun saveQuestionResult(result: DatasetRunQuestionResult): DatasetRunQuestionResult
+
+    fun saveQuestionResults(results: List<DatasetRunQuestionResult>)
+
+    fun getQuestionResultsByRunId(runId: Id<DatasetRun>): List<DatasetRunQuestionResult>
+
+    fun deleteQuestionResultsByRunId(runId: Id<DatasetRun>)
+
+    fun deleteQuestionResultsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    )
+}

--- a/bot/storage-mongo/src/main/kotlin/DatasetMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/DatasetMongoDAO.kt
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.mongo
+
+import ai.tock.bot.admin.dataset.Dataset
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetRun
+import ai.tock.bot.admin.dataset.DatasetRunDAO
+import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
+import ai.tock.bot.admin.dataset.DatasetRunState
+import ai.tock.shared.ensureIndex
+import ai.tock.shared.ensureUniqueIndex
+import ai.tock.shared.error
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Sorts.ascending
+import com.mongodb.client.model.Updates.set
+import mu.KotlinLogging
+import org.litote.kmongo.Id
+import org.litote.kmongo.ascendingSort
+import org.litote.kmongo.deleteMany
+import org.litote.kmongo.deleteOneById
+import org.litote.kmongo.descendingSort
+import org.litote.kmongo.eq
+import org.litote.kmongo.find
+import org.litote.kmongo.findOneById
+import org.litote.kmongo.getCollection
+import org.litote.kmongo.`in`
+import org.litote.kmongo.save
+
+internal object DatasetMongoDAO : DatasetDAO, DatasetRunDAO {
+    private val logger = KotlinLogging.logger {}
+
+    private val datasetCol = MongoBotConfiguration.database.getCollection<Dataset>("dataset")
+    private val datasetRunCol = MongoBotConfiguration.database.getCollection<DatasetRun>("dataset_run")
+    private val datasetRunQuestionResultCol =
+        MongoBotConfiguration.database.getCollection<DatasetRunQuestionResult>("dataset_run_question_result")
+
+    init {
+        try {
+            datasetCol.ensureIndex(Dataset::namespace, Dataset::botId)
+            datasetCol.ensureIndex(Dataset::namespace, Dataset::botId, Dataset::name)
+
+            datasetRunCol.ensureIndex(DatasetRun::namespace, DatasetRun::botId)
+            datasetRunCol.ensureIndex(DatasetRun::datasetId)
+            datasetRunCol.ensureIndex(DatasetRun::datasetId, DatasetRun::state)
+            datasetRunCol.ensureIndex(DatasetRun::datasetId, DatasetRun::startTime)
+
+            datasetRunQuestionResultCol.ensureIndex(DatasetRunQuestionResult::namespace, DatasetRunQuestionResult::botId)
+            datasetRunQuestionResultCol.ensureIndex(DatasetRunQuestionResult::datasetId, DatasetRunQuestionResult::runId)
+            datasetRunQuestionResultCol.ensureUniqueIndex(
+                DatasetRunQuestionResult::runId,
+                DatasetRunQuestionResult::questionId,
+            )
+        } catch (e: Exception) {
+            logger.error(e)
+        }
+    }
+
+    override fun save(dataset: Dataset): Dataset {
+        datasetCol.save(dataset)
+        return dataset
+    }
+
+    override fun getDatasetById(id: Id<Dataset>): Dataset? {
+        return datasetCol.findOneById(id)
+    }
+
+    override fun getDatasetsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): List<Dataset> {
+        return datasetCol.find(
+            Dataset::namespace eq namespace,
+            Dataset::botId eq botId,
+        ).ascendingSort(Dataset::name).toList()
+    }
+
+    override fun delete(id: Id<Dataset>) {
+        datasetCol.deleteOneById(id)
+        deleteRunsByDatasetId(id)
+    }
+
+    override fun deleteByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ) {
+        datasetCol.deleteMany(
+            Dataset::namespace eq namespace,
+            Dataset::botId eq botId,
+        )
+        deleteRunsByNamespaceAndBotId(namespace, botId)
+    }
+
+    override fun saveRun(run: DatasetRun): DatasetRun {
+        datasetRunCol.save(run)
+        return run
+    }
+
+    override fun claimNextQueuedRun(): DatasetRun? {
+        return datasetRunCol.findOneAndUpdate(
+            DatasetRun::state eq DatasetRunState.QUEUED,
+            set(DatasetRun::state.name, DatasetRunState.RUNNING),
+            FindOneAndUpdateOptions()
+                .sort(ascending(DatasetRun::startTime.name))
+                .returnDocument(ReturnDocument.AFTER),
+        )
+    }
+
+    override fun getRunById(id: Id<DatasetRun>): DatasetRun? {
+        return datasetRunCol.findOneById(id)
+    }
+
+    override fun getRunsByDatasetId(datasetId: Id<Dataset>): List<DatasetRun> {
+        return datasetRunCol.find(DatasetRun::datasetId eq datasetId)
+            .descendingSort(DatasetRun::startTime)
+            .toList()
+    }
+
+    override fun getActiveRunsByDatasetId(datasetId: Id<Dataset>): List<DatasetRun> {
+        return datasetRunCol.find(
+            DatasetRun::datasetId eq datasetId,
+            DatasetRun::state `in` listOf(DatasetRunState.QUEUED, DatasetRunState.RUNNING),
+        ).toList()
+    }
+
+    override fun deleteRun(id: Id<DatasetRun>) {
+        datasetRunCol.deleteOneById(id)
+        deleteQuestionResultsByRunId(id)
+    }
+
+    override fun deleteRunsByDatasetId(datasetId: Id<Dataset>) {
+        val runIds = datasetRunCol.find(DatasetRun::datasetId eq datasetId).toList().map { it._id }
+        datasetRunCol.deleteMany(DatasetRun::datasetId eq datasetId)
+        if (runIds.isNotEmpty()) {
+            datasetRunQuestionResultCol.deleteMany(DatasetRunQuestionResult::runId `in` runIds)
+        }
+    }
+
+    override fun deleteRunsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ) {
+        val runIds =
+            datasetRunCol.find(
+                DatasetRun::namespace eq namespace,
+                DatasetRun::botId eq botId,
+            ).toList().map { it._id }
+
+        datasetRunCol.deleteMany(
+            DatasetRun::namespace eq namespace,
+            DatasetRun::botId eq botId,
+        )
+
+        if (runIds.isNotEmpty()) {
+            datasetRunQuestionResultCol.deleteMany(DatasetRunQuestionResult::runId `in` runIds)
+        }
+    }
+
+    override fun saveQuestionResult(result: DatasetRunQuestionResult): DatasetRunQuestionResult {
+        datasetRunQuestionResultCol.save(result)
+        return result
+    }
+
+    override fun saveQuestionResults(results: List<DatasetRunQuestionResult>) {
+        if (results.isEmpty()) {
+            return
+        }
+        results.forEach { datasetRunQuestionResultCol.save(it) }
+    }
+
+    override fun getQuestionResultsByRunId(runId: Id<DatasetRun>): List<DatasetRunQuestionResult> {
+        return datasetRunQuestionResultCol.find(DatasetRunQuestionResult::runId eq runId).toList()
+    }
+
+    override fun deleteQuestionResultsByRunId(runId: Id<DatasetRun>) {
+        datasetRunQuestionResultCol.deleteMany(DatasetRunQuestionResult::runId eq runId)
+    }
+
+    override fun deleteQuestionResultsByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ) {
+        datasetRunQuestionResultCol.deleteMany(
+            DatasetRunQuestionResult::namespace eq namespace,
+            DatasetRunQuestionResult::botId eq botId,
+        )
+    }
+}

--- a/bot/storage-mongo/src/main/kotlin/Ioc.kt
+++ b/bot/storage-mongo/src/main/kotlin/Ioc.kt
@@ -22,6 +22,8 @@ import ai.tock.bot.admin.bot.observability.BotObservabilityConfigurationDAO
 import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
 import ai.tock.bot.admin.bot.sentencegeneration.BotSentenceGenerationConfigurationDAO
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
+import ai.tock.bot.admin.dataset.DatasetDAO
+import ai.tock.bot.admin.dataset.DatasetRunDAO
 import ai.tock.bot.admin.dialog.DialogReportDAO
 import ai.tock.bot.admin.evaluation.EvaluationDAO
 import ai.tock.bot.admin.evaluation.EvaluationSampleDAO
@@ -67,6 +69,8 @@ val botMongoModule =
         bind<BotDocumentCompressorConfigurationDAO>() with provider { BotDocumentCompressorConfigurationMongoDAO }
         bind<BotVectorStoreConfigurationDAO>() with provider { BotVectorStoreConfigurationMongoDAO }
         bind<BotSentenceGenerationConfigurationDAO>() with provider { BotSentenceGenerationConfigurationMongoDAO }
+        bind<DatasetDAO>() with provider { DatasetMongoDAO }
+        bind<DatasetRunDAO>() with provider { DatasetMongoDAO }
         bind<StoryDefinitionConfigurationDAO>() with provider { StoryDefinitionConfigurationMongoDAO }
         bind<I18nDAO>() with provider { I18nMongoDAO }
         bind<UserTimelineDAO>() with provider { UserTimelineMongoDAO }


### PR DESCRIPTION
## Overview

This PR introduces a **dataset evaluation** feature that lets teams measure the quality of  answers over time. Users can define datasets of questions with ground truths, trigger evaluation runs against the bot, and compare the outputs of two runs side by side to detect regressions or improvements.

Resolves #2031 

## Backend

- New `DatasetRunWorker` with a periodic poll loop — claims queued runs atomically, processes each question sequentially, and supports configurable retries (`tock_dataset_run_worker_max_retries`). Drains the full queue within a single worker slot before releasing.
- `DatasetRunProcessor` handles run lifecycle: marks questions as `RUNNING` → `COMPLETED` / `FAILED`, persists a `userActionId` on success, and honours mid-run `CANCELLED` signals checked at each question boundary.
- A `DatasetQuestionExecutor` interface (+ `DefaultDatasetQuestionExecutor`) wraps `TestTalkService.talk()` with debug and source-with-content enabled, and isolates each retry to a new conversation via a suffixed `userIdModifier`.
- REST DTOs in `Requests.kt` / `Responses.kt`: create/update/run/cancel requests with validation (blank name, empty question list, configurable max questions via `tock_datasets_max_questions`), and typed response objects including a `settingsSnapshot` serialised as `Map<String, Any?>` (with Api key removed for security reasons).

## Frontend

- **Dataset board** — lists datasets sorted by most recent run, with inline run status, quick-launch and cancel actions.
- **Dataset detail view** (`DatasetDetailComponent`) — side-by-side run comparison (Run A vs Run B). Supports deep-linking to a specific comparison via the `compareRunId` query param. Scrollable run selectors with arrow controls, bot-switch guard that redirects to the board.
- **Entry component** (`DatasetDetailEntryComponent`) — per-question card showing both answers with markdown diff highlighting. Displays source diff badges (added / modified / removed) computed from stable content hashes (djb2). Detects answer-type transitions between runs (e.g. `RAG → INTENT`). Supports foldable cards and a "show more / less" height limiter.
- **Settings diff dialog** — compares prompts and RAG settings between the two selected runs, with per-field diff indicators on the run header tags.
- `DatasetsService` manages a local store (`BehaviorSubject`) with lazy `settingsSnapshot` loading, optimistic run-state patching, and cache invalidation on run completion.

## Configuration

| Property | Default | Description |
|---|---|---|
| `tock_datasets_max_questions` | `200` | Max questions per dataset |
| `tock_dataset_run_worker_poll_interval_ms` | `2000` | Worker poll interval (ms) |
| `tock_dataset_run_worker_max_retries` | `0` | Per-question retry budget |

## Testing notes

- Create a dataset, trigger a run, wait for completion, then open the detail view.
- Trigger a second run with different RAG settings to verify comparison mode, diff badges, and settings diff dialog.
- Cancel a run mid-execution to verify the worker honours the cancellation signal.
- Switch bot while on the detail view — should redirect to the dataset board.

## Misc Frontend Improvements
- Improved the app header display to show the full list of NS and Bot options selected from the dropdown menus
- Replaced the toggle switch with a single button for light/dark mode to save space
- Improved the regular expression used to detect LaTeX when displaying responses