### PR TITLE
[Tock Studio] Improvements to dataset creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "js/ts.tsdk.path": "bot/admin/web/node_modules/typescript/lib"
+}

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
@@ -1,16 +1,33 @@
 <nb-card class="mb-2">
-  <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
-    <div class="pt-1">{{ isEditMode ? 'Edit dataset' : 'New dataset' }}</div>
+  <nb-card-header>
+    <div class="d-flex justify-content-between align-items-start gap-1">
+      <div class="pt-1">{{ isEditMode ? 'Edit dataset' : 'New dataset' }}</div>
 
-    <button
-      type="button"
-      nbButton
-      shape="round"
-      nbTooltip="Close"
-      (click)="dialogRef.close()"
+      <button
+        type="button"
+        nbButton
+        shape="round"
+        nbTooltip="Close"
+        (click)="dialogRef.close()"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </div>
+
+    <nb-alert
+      *ngIf="isSubmitted && !form.valid"
+      status="danger"
+      class="mb-3"
     >
-      <nb-icon icon="x-lg"></nb-icon>
-    </button>
+      <ul class="mb-0 ps-3 font-color-white">
+        <li *ngIf="form.controls.name.invalid">The dataset name is invalid.</li>
+        <li *ngIf="form.controls.description.invalid">The dataset description is invalid.</li>
+        <li *ngIf="questions.invalid">
+          {{ invalidQuestionCount }} question{{ invalidQuestionCount > 1 ? 's are' : ' is' }} invalid. Please ensure all questions are
+          filled out and do not exceed the character limit.
+        </li>
+      </ul>
+    </nb-alert>
   </nb-card-header>
 
   <nb-card-body>
@@ -110,7 +127,15 @@
                   placeholder="Ground truth (optional)"
                   rows="2"
                   class="mt-1 scrollbar-narrow"
+                  [status]="isSubmitted && questionGroup.controls.groundTruth.invalid ? 'danger' : 'basic'"
                 ></textarea>
+
+                <small
+                  *ngIf="isSubmitted && questionGroup.controls.groundTruth.errors?.maxlength"
+                  class="text-danger"
+                >
+                  Ground truth exceeds the {{ questionGroup.controls.groundTruth.errors.maxlength.requiredLength }} character limit.
+                </small>
               </div>
             </div>
           </tock-form-control>
@@ -132,6 +157,10 @@
       [disabled]="isLoading"
       (click)="exportDataset()"
     >
+      <nb-icon
+        icon="download"
+        class="mr-2"
+      ></nb-icon>
       EXPORT DATASET
     </button>
 

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
@@ -48,8 +48,8 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
   }
 
   form = new FormGroup<DatasetForm>({
-    name: new FormControl('', [Validators.required, Validators.minLength(5), Validators.maxLength(100)]),
-    description: new FormControl('', [Validators.maxLength(750)]),
+    name: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.minLength(5), Validators.maxLength(100)] }),
+    description: new FormControl('', { nonNullable: true, validators: [Validators.maxLength(750)] }),
     questions: new FormArray<FormGroup<QuestionForm>>([], [atLeastOneFilledQuestion])
   });
 
@@ -64,7 +64,7 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    if (this.isEditMode) {
+    if (this.isEditMode && this.dataset) {
       this._populateForm(this.dataset);
     } else {
       this._appendEmptyQuestion();
@@ -80,8 +80,14 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
     dataset.questions.forEach((q) => {
       this.questions.push(
         new FormGroup<QuestionForm>({
-          question: new FormControl(q.question, [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]),
-          groundTruth: new FormControl(q.groundTruth ?? '', [Validators.maxLength(groundtruth_maxLength)])
+          question: new FormControl(q.question, {
+            nonNullable: true,
+            validators: [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]
+          }),
+          groundTruth: new FormControl(q.groundTruth ?? '', {
+            nonNullable: true,
+            validators: [Validators.maxLength(groundtruth_maxLength)]
+          })
         })
       );
     });
@@ -120,8 +126,11 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
   private _appendEmptyQuestion(): void {
     this.questions.push(
       new FormGroup<QuestionForm>({
-        question: new FormControl('', [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]),
-        groundTruth: new FormControl('', [Validators.maxLength(groundtruth_maxLength)])
+        question: new FormControl('', {
+          nonNullable: true,
+          validators: [Validators.minLength(question_minLength), Validators.maxLength(question_maxLength)]
+        }),
+        groundTruth: new FormControl('', { nonNullable: true, validators: [Validators.maxLength(groundtruth_maxLength)] })
       })
     );
   }
@@ -145,11 +154,48 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
       }));
   }
 
+  get invalidQuestionCount(): number {
+    return this.questions.controls.filter((g, i) => !this.isLastEntry(i) && (g.controls.question.invalid || g.controls.groundTruth.invalid))
+      .length;
+  }
+
+  private _scrollToFirstInvalidField(): void {
+    setTimeout(() => {
+      if (this.form.controls.name.invalid) {
+        const nameInput = document.querySelector('[formControlName="name"]') as HTMLElement;
+        nameInput?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        nameInput?.focus();
+        return;
+      }
+
+      if (this.form.controls.description.invalid) {
+        const descInput = document.querySelector('[formControlName="description"]') as HTMLElement;
+        descInput?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        descInput?.focus();
+        return;
+      }
+
+      const invalidIndex = this.questions.controls.findIndex(
+        (g, i) => !this.isLastEntry(i) && (g.controls.question.invalid || g.controls.groundTruth.invalid)
+      );
+
+      if (invalidIndex !== -1) {
+        const inputs = this.questionInputs.toArray();
+        const el = inputs[invalidIndex]?.nativeElement;
+        el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el?.focus();
+      }
+    }, 50);
+  }
+
   submit(): void {
     this.isSubmitted = true;
     this.questions.updateValueAndValidity();
 
-    if (!this.form.valid) return;
+    if (!this.form.valid) {
+      this._scrollToFirstInvalidField();
+      return;
+    }
 
     this.isLoading = true;
 


### PR DESCRIPTION
## Summary
Improve form validation feedback in the dataset create/edit dialog.

## Changes
- Auto-scroll to the first invalid field on failed submission (name, description, questions)
- Add `danger` status and error message on ground truth textareas when they exceed the character limit
- Fix `invalidQuestionCount` getter to account for invalid ground truth fields, not just question fields

## Why
Previously, validation errors were silent for fields outside the visible scroll area, leaving the user with no indication of what was blocking submission. Ground truth fields also had no visual feedback on error.