### PR TITLE
[DERCBOT-1146] Fix footnoted messages in test plan execution

### DIFF
--- a/bot/admin/test/core/src/main/kotlin/ClientMessageConverter.kt
+++ b/bot/admin/test/core/src/main/kotlin/ClientMessageConverter.kt
@@ -21,13 +21,16 @@ import ai.tock.bot.connector.rest.client.model.ClientAttachment
 import ai.tock.bot.connector.rest.client.model.ClientAttachmentType
 import ai.tock.bot.connector.rest.client.model.ClientChoice
 import ai.tock.bot.connector.rest.client.model.ClientConnectorType
+import ai.tock.bot.connector.rest.client.model.ClientFootnote
 import ai.tock.bot.connector.rest.client.model.ClientGenericElement
 import ai.tock.bot.connector.rest.client.model.ClientGenericMessage
 import ai.tock.bot.connector.rest.client.model.ClientLocation
 import ai.tock.bot.connector.rest.client.model.ClientMessage
 import ai.tock.bot.connector.rest.client.model.ClientSentence
+import ai.tock.bot.connector.rest.client.model.ClientSentenceWithFootnotes
 import ai.tock.bot.connector.rest.client.model.ClientUserInterfaceType
 import ai.tock.bot.connector.rest.client.model.ClientUserLocation
+import ai.tock.bot.engine.action.Footnote
 import ai.tock.bot.engine.action.SendAttachment
 import ai.tock.bot.engine.message.Attachment
 import ai.tock.bot.engine.message.Choice
@@ -36,6 +39,7 @@ import ai.tock.bot.engine.message.GenericMessage
 import ai.tock.bot.engine.message.Location
 import ai.tock.bot.engine.message.Message
 import ai.tock.bot.engine.message.Sentence
+import ai.tock.bot.engine.message.SentenceWithFootnotes
 import ai.tock.bot.engine.user.UserLocation
 import ai.tock.translator.UserInterfaceType
 
@@ -55,9 +59,14 @@ fun UserInterfaceType.toClientUserInterfaceType(): ClientUserInterfaceType = Cli
 
 fun ClientUserInterfaceType.toUserInterfaceType(): UserInterfaceType = UserInterfaceType.valueOf(name)
 
+fun Footnote.toClientFootnote(): ClientFootnote = ClientFootnote(identifier.toString(), title.toString(), url, content, score, metadata)
+
+fun ClientFootnote.toFootnote(): Footnote = Footnote(identifier, title, url, content, score, metadata)
+
 fun Message.toClientMessage(): ClientMessage =
     when (this) {
         is Sentence -> ClientSentence(text, messages.map { it.toClientSentenceElement() }.toMutableList())
+        is SentenceWithFootnotes -> ClientSentenceWithFootnotes(text, footnotes.map { it.toClientFootnote() })
         is Choice -> ClientChoice(intentName, parameters)
         is Attachment -> ClientAttachment(url, type.toClientAttachmentType())
         is Location -> toClientLocation()
@@ -67,6 +76,7 @@ fun Message.toClientMessage(): ClientMessage =
 fun ClientMessage.toMessage(): Message =
     when (this) {
         is ClientSentence -> Sentence(text, messages.map { it.toSentenceElement() }.toMutableList())
+        is ClientSentenceWithFootnotes -> SentenceWithFootnotes(text, footnotes.map { it.toFootnote() })
         is ClientChoice -> Choice(intentName, parameters)
         is ClientAttachment -> Attachment(url, type.toAttachmentType())
         is ClientLocation -> toLocation()

--- a/bot/admin/test/core/src/main/kotlin/TestPlanService.kt
+++ b/bot/admin/test/core/src/main/kotlin/TestPlanService.kt
@@ -25,6 +25,7 @@ import ai.tock.bot.connector.rest.client.model.ClientGenericMessage
 import ai.tock.bot.connector.rest.client.model.ClientMessage
 import ai.tock.bot.connector.rest.client.model.ClientMessageRequest
 import ai.tock.bot.connector.rest.client.model.ClientSentence
+import ai.tock.bot.connector.rest.client.model.ClientSentenceWithFootnotes
 import ai.tock.bot.engine.dialog.Dialog
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.PlayerType
@@ -221,8 +222,7 @@ object TestPlanService {
                         // go over the bot answer to remove emoticons
                         botMessages = body
                             ?.messages
-                            ?.map { it as ClientSentence }
-                            ?.map { it.copy(text = it.text?.cleanSurrogateChars()) }
+                            ?.map { it.cleanSurrogateChars() }
                             ?.toMutableList() ?: mutableListOf()
                         logger.debug { "ANSWER without surrogate -- : $botMessages" }
                     } else {
@@ -255,6 +255,7 @@ object TestPlanService {
                             dialogReportId = dialog.id,
                             error = true,
                             errorActionId = testStepMessages.id,
+                            returnedMessage = botMessage.toMessage(),
                             errorMessage = "Error : $errorMessage - during steps comparison : $givenAnswer / expected : $expectedAnswer",
                             indexOfStepError = testStepIndex,
                         )
@@ -308,18 +309,34 @@ object TestPlanService {
      * @return true if messages are the same, false otherwise.
      */
     fun ClientMessage.checkEquality(expectedMessage: ClientMessage): String? {
-        if (expectedMessage !is ClientSentence || this !is ClientSentence) {
+        if (!isSentenceMessage() || !expectedMessage.isSentenceMessage()) {
             return if (expectedMessage == this) null else "Messages differs : \"$this\" / expected \"$expectedMessage\""
         }
 
-        if (text?.cleanSurrogateChars()?.trim() != expectedMessage.text?.cleanSurrogateChars()?.trim()) {
-            return "Text differs : \"${this.text}\" / expected \"${expectedMessage.text}\""
+        if (text()?.cleanSurrogateChars()?.trim() != expectedMessage.text()?.cleanSurrogateChars()?.trim()) {
+            return "Text differs : \"${this.text()}\" / expected \"${expectedMessage.text()}\""
         }
 
-        return messages
-            .zip(expectedMessage.messages)
-            .mapNotNull { (subMessage, expectedSubMessage) -> subMessage.partiallyEquals(expectedSubMessage) }
-            .firstOrNull()
+        if (javaClass != expectedMessage.javaClass) {
+            return "Message type differs : \"${javaClass.simpleName}\" / expected \"${expectedMessage.javaClass.simpleName}\""
+        }
+
+        if (this is ClientSentence && expectedMessage is ClientSentence) {
+            return messages
+                .zip(expectedMessage.messages)
+                .mapNotNull { (subMessage, expectedSubMessage) -> subMessage.partiallyEquals(expectedSubMessage) }
+                .firstOrNull()
+        }
+
+        if (this is ClientSentenceWithFootnotes && expectedMessage is ClientSentenceWithFootnotes) {
+            return if (footnotes == expectedMessage.footnotes) {
+                null
+            } else {
+                "Footnotes differs : \"$footnotes\" / expected \"${expectedMessage.footnotes}\""
+            }
+        }
+
+        return null
     }
 }
 
@@ -364,5 +381,21 @@ private fun ClientChoice.partiallyEquals(expected: ClientChoice): String? {
 }
 
 private fun Map<String, String>.cleanTexts() = mapValues { (_, v) -> v.cleanSurrogateChars().replace(Regex("<[^>]*>"), "") }
+
+private fun ClientMessage.cleanSurrogateChars(): ClientMessage =
+    when (this) {
+        is ClientSentence -> copy(text = text?.cleanSurrogateChars())
+        is ClientSentenceWithFootnotes -> copy(text = text.cleanSurrogateChars())
+        else -> this
+    }
+
+private fun ClientMessage.isSentenceMessage(): Boolean = this is ClientSentence || this is ClientSentenceWithFootnotes
+
+private fun ClientMessage.text(): String? =
+    when (this) {
+        is ClientSentence -> text
+        is ClientSentenceWithFootnotes -> text
+        else -> null
+    }
 
 private fun String.cleanSurrogateChars(): String = filterNot { it.isSurrogate() }

--- a/bot/admin/test/core/src/test/kotlin/ClientMessageConverterTest.kt
+++ b/bot/admin/test/core/src/test/kotlin/ClientMessageConverterTest.kt
@@ -18,8 +18,12 @@ package ai.tock.bot.admin.test
 
 import ai.tock.bot.connector.rest.client.model.ClientAttachment
 import ai.tock.bot.connector.rest.client.model.ClientAttachmentType
+import ai.tock.bot.connector.rest.client.model.ClientFootnote
+import ai.tock.bot.connector.rest.client.model.ClientSentenceWithFootnotes
+import ai.tock.bot.engine.action.Footnote
 import ai.tock.bot.engine.action.SendAttachment
 import ai.tock.bot.engine.message.Attachment
+import ai.tock.bot.engine.message.SentenceWithFootnotes
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -35,5 +39,23 @@ class ClientMessageConverterTest {
             ClientAttachment("a", ClientAttachmentType.file),
             a.toClientMessage(),
         )
+    }
+
+    @Test
+    fun sentenceWithFootnotes_mustBeConvertedBothWays() {
+        val message =
+            SentenceWithFootnotes(
+                "Hello",
+                listOf(Footnote("1", "Source", "https://example.com", "content", 0.8f, mapOf("doc" to "a"))),
+            )
+
+        val clientMessage =
+            ClientSentenceWithFootnotes(
+                "Hello",
+                listOf(ClientFootnote("1", "Source", "https://example.com", "content", 0.8f, mapOf("doc" to "a"))),
+            )
+
+        assertEquals(clientMessage, message.toClientMessage())
+        assertEquals(message, clientMessage.toMessage())
     }
 }

--- a/bot/admin/test/core/src/test/kotlin/TestPlanServiceTest.kt
+++ b/bot/admin/test/core/src/test/kotlin/TestPlanServiceTest.kt
@@ -17,11 +17,14 @@
 import ai.tock.bot.admin.test.TestPlanService.checkEquality
 import ai.tock.bot.connector.rest.client.model.ClientChoice
 import ai.tock.bot.connector.rest.client.model.ClientConnectorType
+import ai.tock.bot.connector.rest.client.model.ClientFootnote
 import ai.tock.bot.connector.rest.client.model.ClientGenericMessage
 import ai.tock.bot.connector.rest.client.model.ClientSentence
+import ai.tock.bot.connector.rest.client.model.ClientSentenceWithFootnotes
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertEquals
 import kotlin.test.expect
 
 internal class TestPlanServiceTest {
@@ -102,5 +105,44 @@ internal class TestPlanServiceTest {
                 ),
             )
         }
+    }
+
+    @Test
+    fun `should be deepEquals for sentence with footnotes`() {
+        val footnotes = listOf(ClientFootnote("1", "Source", "https://example.com", "content", 0.8f, mapOf("doc" to "a")))
+
+        expect(null) {
+            ClientSentenceWithFootnotes("Hello", footnotes)
+                .checkEquality(ClientSentenceWithFootnotes("Hello", footnotes))
+        }
+    }
+
+    @Test
+    fun `should not be deepEquals if footnotes differ`() {
+        assertEquals(
+            "Footnotes differs : \"[ClientFootnote(identifier=1, title=Source, url=https://example.com, content=content, score=0.8, metadata={doc=a})]\" / expected \"[ClientFootnote(identifier=2, title=Other source, url=https://example.com/2, content=other content, score=0.5, metadata={doc=b})]\"",
+            ClientSentenceWithFootnotes(
+                "Hello",
+                listOf(ClientFootnote("1", "Source", "https://example.com", "content", 0.8f, mapOf("doc" to "a"))),
+            ).checkEquality(
+                ClientSentenceWithFootnotes(
+                    "Hello",
+                    listOf(ClientFootnote("2", "Other source", "https://example.com/2", "other content", 0.5f, mapOf("doc" to "b"))),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `should not be deepEquals if expected message contains footnotes but answer does not`() {
+        assertEquals(
+            "Message type differs : \"ClientSentence\" / expected \"ClientSentenceWithFootnotes\"",
+            ClientSentence("Hello").checkEquality(
+                ClientSentenceWithFootnotes(
+                    "Hello",
+                    listOf(ClientFootnote("1", "Source", "https://example.com", "content", 0.8f)),
+                ),
+            ),
+        )
     }
 }

--- a/bot/admin/test/core/src/test/kotlin/TestPlanServiceTest.kt
+++ b/bot/admin/test/core/src/test/kotlin/TestPlanServiceTest.kt
@@ -120,7 +120,10 @@ internal class TestPlanServiceTest {
     @Test
     fun `should not be deepEquals if footnotes differ`() {
         assertEquals(
-            "Footnotes differs : \"[ClientFootnote(identifier=1, title=Source, url=https://example.com, content=content, score=0.8, metadata={doc=a})]\" / expected \"[ClientFootnote(identifier=2, title=Other source, url=https://example.com/2, content=other content, score=0.5, metadata={doc=b})]\"",
+            "Footnotes differs : " +
+                "\"[ClientFootnote(identifier=1, title=Source, url=https://example.com, content=content, score=0.8, metadata={doc=a})]\" " +
+                "/ expected " +
+                "\"[ClientFootnote(identifier=2, title=Other source, url=https://example.com/2, content=other content, score=0.5, metadata={doc=b})]\"",
             ClientSentenceWithFootnotes(
                 "Hello",
                 listOf(ClientFootnote("1", "Source", "https://example.com", "content", 0.8f, mapOf("doc" to "a"))),


### PR DESCRIPTION
Ticket : [DERCBOT-1146](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1146)

### Goal

Fix test plan execution when backend responses contain footnotes.

### Details

- Added support for footnoted messages in test plan backend conversion/comparison
- Removed the unsafe cast causing execution errors with messagesWithFootnotes
- Returned the last bot message on comparison failure so the existing frontend block can display it