### PR TITLE
[DERCBOT-1869] Added sources without URL formating option for Google Chat Connector

### DIFF
--- a/bot/connector-google-chat/README.md
+++ b/bot/connector-google-chat/README.md
@@ -53,6 +53,7 @@ Authentication Audience → Project Number
 | **Service account credential json content** | `{"type": "service_account", ...}` |
 | **Service account to impersonate** (optional) | `bot-sa@project.iam.gserviceaccount.com` |
 | **Use condensed footnotes** | `1` = condensed, `0` = detailed |
+| **Display sources without URL** | `1` = displayed, `0` = hidden |
 
 ---
 

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
@@ -45,6 +45,7 @@ class GoogleChatConnector(
     private val chatService: HangoutsChat,
     private val authorisationHandler: GoogleChatAuthorisationHandler,
     private val useCondensedFootnotes: Boolean,
+    private val displaySourcesWithoutUrl: Boolean,
     private val introMessage: String? = null,
     private val useThread: Boolean = false,
 ) : ConnectorBase(GoogleChatConnectorProvider.connectorType) {
@@ -118,7 +119,7 @@ class GoogleChatConnector(
         if (event !is Action) return
 
         val message =
-            GoogleChatMessageConverter.toMessageOut(event, useCondensedFootnotes)
+            GoogleChatMessageConverter.toMessageOut(event, useCondensedFootnotes, displaySourcesWithoutUrl)
                 ?: return
 
         callback as GoogleChatConnectorCallback

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
@@ -43,6 +43,7 @@ private const val SERVICE_CREDENTIAL_PATH_PARAMETER = "serviceCredentialPath"
 private const val SERVICE_CREDENTIAL_CONTENT_PARAMETER = "serviceCredentialContent"
 private const val AUTH_AUDIENCE_PARAMETER = "authenticationAudience"
 private const val CONDENSED_FOOTNOTES_PARAMETER = "useCondensedFootnotes"
+private const val DISPLAY_SOURCES_WITHOUT_URL_PARAMETER = "displaySourcesWithoutUrl"
 private const val GSA_TO_IMPERSONATE_PARAMETER = "gsaToImpersonate"
 private const val INTRO_MESSAGE_PARAMETER = "introMessage"
 private const val USE_THREAD_PARAMETER = "useThread"
@@ -83,6 +84,8 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
 
             val useCondensedFootnotes =
                 connectorConfiguration.parameters[CONDENSED_FOOTNOTES_PARAMETER] == "1"
+            val displaySourcesWithoutUrl =
+                connectorConfiguration.parameters[DISPLAY_SOURCES_WITHOUT_URL_PARAMETER] != "0"
 
             val chatService =
                 HangoutsChat
@@ -111,6 +114,7 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 chatService,
                 authorisationHandler,
                 useCondensedFootnotes,
+                displaySourcesWithoutUrl,
                 introMessage,
                 useThread,
             )
@@ -197,6 +201,11 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 ConnectorTypeConfigurationField(
                     "Use condensed footnotes (true = 1, false = 0)",
                     CONDENSED_FOOTNOTES_PARAMETER,
+                    false,
+                ),
+                ConnectorTypeConfigurationField(
+                    "Display sources without URL (true = 1, false = 0)",
+                    DISPLAY_SOURCES_WITHOUT_URL_PARAMETER,
                     false,
                 ),
                 ConnectorTypeConfigurationField(

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatFootnoteFormatter.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatFootnoteFormatter.kt
@@ -30,9 +30,17 @@ object GoogleChatFootnoteFormatter {
         text: CharSequence,
         footnotes: List<Footnote>,
         condensed: Boolean = false,
+        displaySourcesWithoutUrl: Boolean = true,
     ): String {
-        if (footnotes.isEmpty()) return text.toString()
-        return if (condensed) formatCondensed(text, footnotes) else formatDetailed(text, footnotes)
+        val filteredFootnotes =
+            if (displaySourcesWithoutUrl) {
+                footnotes
+            } else {
+                footnotes.filter { !it.url.isNullOrBlank() }
+            }
+
+        if (filteredFootnotes.isEmpty()) return text.toString()
+        return if (condensed) formatCondensed(text, filteredFootnotes) else formatDetailed(text, filteredFootnotes)
     }
 
     private fun formatDetailed(

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatMessageConverter.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatMessageConverter.kt
@@ -26,6 +26,7 @@ internal object GoogleChatMessageConverter {
     fun toMessageOut(
         action: Action,
         condensedFootnotes: Boolean = false,
+        displaySourcesWithoutUrl: Boolean = true,
     ): GoogleChatConnectorMessage? =
         when (action) {
             is SendSentence -> {
@@ -33,7 +34,7 @@ internal object GoogleChatMessageConverter {
             }
 
             is SendSentenceWithFootnotes -> {
-                sendSentenceWithFootnotes(action, condensedFootnotes)
+                sendSentenceWithFootnotes(action, condensedFootnotes, displaySourcesWithoutUrl)
             }
 
             else -> {
@@ -48,19 +49,21 @@ internal object GoogleChatMessageConverter {
         } else {
             action.stringText
                 ?.takeUnless { it.isBlank() }
-                ?.let { GoogleChatMarkdown.toGoogleChat(it.toString()) }
+                ?.let(GoogleChatMarkdown::toGoogleChat)
                 ?.let(::GoogleChatConnectorTextMessageOut)
         }
 
     private fun sendSentenceWithFootnotes(
         action: SendSentenceWithFootnotes,
         condensedFootnotes: Boolean,
+        displaySourcesWithoutUrl: Boolean,
     ): GoogleChatConnectorMessage {
         val formatted =
             GoogleChatFootnoteFormatter.format(
                 action.text,
                 action.footnotes,
                 condensed = condensedFootnotes,
+                displaySourcesWithoutUrl = displaySourcesWithoutUrl,
             )
         val parsed = GoogleChatMarkdown.toGoogleChat(formatted)
         return GoogleChatConnectorTextMessageOut(parsed)

--- a/bot/connector-google-chat/src/test/kotlin/GoogleChatFootnoteFormatterTest.kt
+++ b/bot/connector-google-chat/src/test/kotlin/GoogleChatFootnoteFormatterTest.kt
@@ -55,6 +55,71 @@ class GoogleChatFootnoteFormatterTest {
         assertEquals(expectedResult, result)
     }
 
+    @Test
+    fun `format hides sources without url when option is disabled in detailed mode`() {
+        val result =
+            GoogleChatFootnoteFormatter.format(
+                text = "Here's some info",
+                footnotes =
+                    listOf(
+                        Footnote("id1", "Google", "https://google.com", null, null),
+                        Footnote("id2", "Just text", null, null, null),
+                    ),
+                condensed = false,
+                displaySourcesWithoutUrl = false,
+            )
+
+        assertEquals(
+            """
+            Here's some info
+
+            *Source :*
+            <https://google.com|Google>
+            """.trimIndent(),
+            result,
+        )
+    }
+
+    @Test
+    fun `format hides sources without url when option is disabled in condensed mode`() {
+        val result =
+            GoogleChatFootnoteFormatter.format(
+                text = "Sources below",
+                footnotes =
+                    listOf(
+                        Footnote("id1", "Tock", "https://tock.ai", null, null),
+                        Footnote("id2", "Offline doc", null, null, null),
+                    ),
+                condensed = true,
+                displaySourcesWithoutUrl = false,
+            )
+
+        assertEquals(
+            """
+            Sources below
+
+            *Source:* [[1]](https://tock.ai)
+            """.trimIndent(),
+            result,
+        )
+    }
+
+    @Test
+    fun `format returns original text when all sources are without url and option is disabled`() {
+        val result =
+            GoogleChatFootnoteFormatter.format(
+                text = "Sources below",
+                footnotes =
+                    listOf(
+                        Footnote("id1", "Offline doc", null, null, null),
+                    ),
+                condensed = true,
+                displaySourcesWithoutUrl = false,
+            )
+
+        assertEquals("Sources below", result)
+    }
+
     companion object {
         @JvmStatic
         fun detailedFormatTestCases(): Stream<Arguments> =


### PR DESCRIPTION
[DERCBOT-1869](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1869)

Added a new Google Chat connector setting to optionally hide sources without URLs from footnote rendering