### PR TITLE
[DERCBOT-1876] Fix dataset RAG technical failures and Mongo snapshot append

### DIFF
--- a/bot/admin/server/src/main/kotlin/model/dataset/Responses.kt
+++ b/bot/admin/server/src/main/kotlin/model/dataset/Responses.kt
@@ -69,4 +69,6 @@ data class DatasetRunActionDTO(
     @JsonInclude(JsonInclude.Include.ALWAYS)
     val action: ActionReport?,
     val retryCount: Int,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val error: String? = null,
 )

--- a/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
@@ -25,6 +25,7 @@ import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
 import ai.tock.bot.admin.dataset.DatasetRunState
 import ai.tock.bot.admin.test.TestTalkService
 import ai.tock.bot.admin.test.model.BotDialogResponse
+import ai.tock.bot.connector.rest.client.model.ClientDebug
 import ai.tock.bot.engine.message.Sentence
 import ai.tock.shared.Executor
 import ai.tock.shared.injector
@@ -41,6 +42,8 @@ private const val DATASET_RUN_WORKER_POLL_INTERVAL_PROPERTY = "tock_dataset_run_
 private const val DATASET_RUN_WORKER_MAX_RETRIES_PROPERTY = "tock_dataset_run_worker_max_retries"
 private const val DEFAULT_DATASET_RUN_WORKER_POLL_INTERVAL_MS = 2000L
 private const val DEFAULT_DATASET_RUN_WORKER_MAX_RETRIES = 0
+private const val RAG_DEBUG_MESSAGE_TEXT = "RAG"
+private const val RAG_TECHNICAL_ERROR_STATUS = "technical_error"
 private val MIN_TIMER_DELAY: Duration = Duration.ofMillis(1)
 
 fun interface DatasetQuestionExecutor {
@@ -144,10 +147,11 @@ class DatasetRunProcessor(
             val outcome =
                 runCatching {
                     questionExecutor.execute(run, currentResult, question)
-                }
+            }
 
             val response = outcome.getOrNull()
-            if (response?.userActionId != null) {
+            val retryableFailureMessage = response?.toRetryableFailureMessage()
+            if (response?.userActionId != null && retryableFailureMessage == null) {
                 return datasetRunDAO.saveQuestionResult(
                     currentResult.copy(
                         state = DatasetRunQuestionResultState.COMPLETED,
@@ -158,12 +162,13 @@ class DatasetRunProcessor(
                 )
             }
 
-            val errorMessage = outcome.exceptionOrNull()?.message ?: response.toFailureMessage()
+            val errorMessage = outcome.exceptionOrNull()?.message ?: retryableFailureMessage ?: response.toFailureMessage()
             if (currentResult.retryCount >= maxRetries) {
                 return datasetRunDAO.saveQuestionResult(
                     currentResult.copy(
                         state = DatasetRunQuestionResultState.FAILED,
                         endedAt = now(),
+                        userActionId = response?.userActionId ?: currentResult.userActionId,
                         error = errorMessage,
                     ),
                 )
@@ -173,6 +178,7 @@ class DatasetRunProcessor(
                 datasetRunDAO.saveQuestionResult(
                     currentResult.copy(
                         retryCount = currentResult.retryCount + 1,
+                        userActionId = response?.userActionId ?: currentResult.userActionId,
                         error = errorMessage,
                     ),
                 )
@@ -187,6 +193,35 @@ class DatasetRunProcessor(
     private fun BotDialogResponse?.toFailureMessage(): String =
         this?.messages?.takeIf { it.isNotEmpty() }?.joinToString(separator = " | ") { it.toString() }
             ?: "Talk execution did not return a userActionId"
+
+    private fun BotDialogResponse.toRetryableFailureMessage(): String? =
+        messages
+            .asSequence()
+            .filterIsInstance<ClientDebug>()
+            .mapNotNull { it.toRAGTechnicalFailure() }
+            .firstOrNull()
+
+    private fun ClientDebug.toRAGTechnicalFailure(): String? {
+        if (text != RAG_DEBUG_MESSAGE_TEXT) {
+            return null
+        }
+
+        val dataMap = data.asMap() ?: return null
+        val answerMap = dataMap["answer"].asMap()
+        val status = answerMap?.stringValue("status")
+        val errorMessage = dataMap["error"].asMap()?.stringValue("errorMessage")
+
+        if (status != RAG_TECHNICAL_ERROR_STATUS && errorMessage == null) {
+            return null
+        }
+
+        val answerMessage = answerMap?.stringValue("answer")
+        return "RAG execution failed: ${errorMessage ?: answerMessage ?: status ?: "unknown error"}"
+    }
+
+    private fun Any?.asMap(): Map<*, *>? = this as? Map<*, *>
+
+    private fun Map<*, *>.stringValue(key: String): String? = this[key] as? String
 
     private fun now(): Instant = Instant.now(clock)
 }

--- a/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
@@ -147,7 +147,7 @@ class DatasetRunProcessor(
             val outcome =
                 runCatching {
                     questionExecutor.execute(run, currentResult, question)
-            }
+                }
 
             val response = outcome.getOrNull()
             val retryableFailureMessage = response?.toRetryableFailureMessage()

--- a/bot/admin/server/src/main/kotlin/service/DatasetService.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetService.kt
@@ -264,6 +264,7 @@ object DatasetService {
                 state = resolvedAction.state,
                 action = resolvedAction.action,
                 retryCount = questionResult.retryCount,
+                error = resolvedAction.error,
             )
         }
     }
@@ -302,7 +303,11 @@ object DatasetService {
     ): ResolvedRunAction =
         when (questionResult.state) {
             DatasetRunQuestionResultState.COMPLETED -> resolveCompletedRunAction(run, questionResult, cachedDialog)
-            else -> ResolvedRunAction(DatasetRunActionState.FAILED, null)
+            else -> ResolvedRunAction(
+                DatasetRunActionState.FAILED,
+                null,
+                questionResult.error ?: "Dataset question execution failed before producing an answer.",
+            )
         }
 
     private fun resolveCompletedRunAction(
@@ -321,7 +326,11 @@ object DatasetService {
                 return ResolvedRunAction(DatasetRunActionState.COMPLETED, null)
             }
 
-            return ResolvedRunAction(DatasetRunActionState.FAILED, null)
+            return ResolvedRunAction(
+                DatasetRunActionState.FAILED,
+                null,
+                unresolvedActionMessage(questionResult, dialog.id.toString()),
+            )
         }
 
         val searchedDialog =
@@ -334,9 +343,19 @@ object DatasetService {
         return if (searchedAction != null) {
             ResolvedRunAction(DatasetRunActionState.COMPLETED, searchedAction)
         } else {
-            ResolvedRunAction(DatasetRunActionState.FAILED, null)
+            ResolvedRunAction(
+                DatasetRunActionState.FAILED,
+                null,
+                unresolvedActionMessage(questionResult, searchedDialog.id.toString()),
+            )
         }
     }
+
+    private fun unresolvedActionMessage(
+        questionResult: DatasetRunQuestionResult,
+        dialogId: String,
+    ): String =
+        "Unable to resolve a bot answer for userActionId ${questionResult.userActionId} in dialog $dialogId."
 
     private fun resolveActionFromDialog(
         dialog: DialogReport,
@@ -536,6 +555,7 @@ object DatasetService {
 private data class ResolvedRunAction(
     val state: DatasetRunActionState,
     val action: ActionReport?,
+    val error: String? = null,
 )
 
 sealed class DatasetError(message: String) : RuntimeException(message) {

--- a/bot/admin/server/src/main/kotlin/service/DatasetService.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetService.kt
@@ -303,11 +303,12 @@ object DatasetService {
     ): ResolvedRunAction =
         when (questionResult.state) {
             DatasetRunQuestionResultState.COMPLETED -> resolveCompletedRunAction(run, questionResult, cachedDialog)
-            else -> ResolvedRunAction(
-                DatasetRunActionState.FAILED,
-                null,
-                questionResult.error ?: "Dataset question execution failed before producing an answer.",
-            )
+            else ->
+                ResolvedRunAction(
+                    DatasetRunActionState.FAILED,
+                    null,
+                    questionResult.error ?: "Dataset question execution failed before producing an answer.",
+                )
         }
 
     private fun resolveCompletedRunAction(
@@ -354,8 +355,7 @@ object DatasetService {
     private fun unresolvedActionMessage(
         questionResult: DatasetRunQuestionResult,
         dialogId: String,
-    ): String =
-        "Unable to resolve a bot answer for userActionId ${questionResult.userActionId} in dialog $dialogId."
+    ): String = "Unable to resolve a bot answer for userActionId ${questionResult.userActionId} in dialog $dialogId."
 
     private fun resolveActionFromDialog(
         dialog: DialogReport,

--- a/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
@@ -25,6 +25,7 @@ import ai.tock.bot.admin.dataset.DatasetRunQuestionResult
 import ai.tock.bot.admin.dataset.DatasetRunQuestionResultState
 import ai.tock.bot.admin.dataset.DatasetRunState
 import ai.tock.bot.admin.test.model.BotDialogResponse
+import ai.tock.bot.connector.rest.client.model.ClientDebug
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -87,6 +88,57 @@ class DatasetRunProcessorTest {
         assertEquals(2, completedResults.size)
         assertEquals("user-action-${firstQuestion.id}", completedResults[firstQuestion.id]?.userActionId)
         assertEquals("user-action-${secondQuestion.id}", completedResults[secondQuestion.id]?.userActionId)
+    }
+
+    @Test
+    fun `processNextQueuedRun retries RAG technical errors even when a user action id is returned`() {
+        val dataset = newDataset(questionCount = 1)
+        val run = newRun(dataset)
+        val question = dataset.questions.first()
+        val questionResult = newQuestionResult(run, dataset, question.id)
+        val savedQuestionResults = mutableListOf<DatasetRunQuestionResult>()
+        val savedRuns = mutableListOf<DatasetRun>()
+
+        every { datasetRunDAO.claimNextQueuedRun() } returns run
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(questionResult)
+        every { datasetRunDAO.getRunById(any()) } returns run.copy(state = DatasetRunState.RUNNING)
+        every { datasetRunDAO.saveQuestionResult(any()) } answers {
+            firstArg<DatasetRunQuestionResult>().also { savedQuestionResults.add(it) }
+        }
+        every { datasetRunDAO.saveRun(any()) } answers {
+            firstArg<DatasetRun>().also { savedRuns.add(it) }
+        }
+
+        val processor =
+            DatasetRunProcessor(
+                datasetDAO = datasetDAO,
+                datasetRunDAO = datasetRunDAO,
+                questionExecutor =
+                    DatasetQuestionExecutor { _, result, _ ->
+                        if (result.retryCount == 0) {
+                            BotDialogResponse(
+                                listOf(ragTechnicalError("timeout")),
+                                userActionId = "failed-user-action",
+                            )
+                        } else {
+                            BotDialogResponse(emptyList(), userActionId = "successful-user-action")
+                        }
+                    },
+                maxRetries = 1,
+                clock = fixedClock,
+            )
+
+        val processed = processor.processNextQueuedRun()
+
+        assertTrue(processed)
+        assertEquals(DatasetRunState.COMPLETED, savedRuns.last().state)
+
+        val completedResult = savedQuestionResults.last()
+        assertEquals(DatasetRunQuestionResultState.COMPLETED, completedResult.state)
+        assertEquals(1, completedResult.retryCount)
+        assertEquals("successful-user-action", completedResult.userActionId)
+        assertEquals(null, completedResult.error)
     }
 
     @Test
@@ -195,5 +247,19 @@ class DatasetRunProcessorTest {
             runId = run._id,
             questionId = questionId,
             userIdModifier = "dataset_${run._id}_$questionId",
+        )
+
+    private fun ragTechnicalError(errorMessage: String): ClientDebug =
+        ClientDebug(
+            text = "RAG",
+            data =
+                mapOf(
+                    "error" to mapOf("errorMessage" to errorMessage),
+                    "answer" to
+                        mapOf(
+                            "status" to "technical_error",
+                            "answer" to "Technical error :( sorry!",
+                        ),
+                ),
         )
 }

--- a/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
@@ -421,6 +421,7 @@ class DatasetServiceTest : AbstractTest() {
                 state = DatasetRunQuestionResultState.FAILED,
                 userIdModifier = "dataset_${run._id}_${dataset.questions.first().id}",
                 retryCount = 2,
+                error = "RAG execution failed: timeout",
             )
         val cancelledQuestionResult =
             DatasetRunQuestionResult(
@@ -449,6 +450,7 @@ class DatasetServiceTest : AbstractTest() {
         assertEquals(2, result.size)
         assertTrue(result.all { it.state == DatasetRunActionState.FAILED && it.action == null })
         assertEquals(2, result.first().retryCount)
+        assertEquals("RAG execution failed: timeout", result.first().error)
         verify(exactly = 0) { dialogReportDAO.search(any()) }
     }
 

--- a/bot/admin/web/src/app/quality/datatsets/api-contract-datasets.md
+++ b/bot/admin/web/src/app/quality/datatsets/api-contract-datasets.md
@@ -67,6 +67,7 @@ interface DatasetRunAction {
   //   - state = COMPLETED → le dialogue associé a été purgé de la base, afficher un avertissement
   action: ActionReport | null;
   retryCount: number;
+  error?: string | null;
 }
 ```
 

--- a/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-detail/dataset-detail-entry/dataset-detail-entry.component.html
@@ -191,7 +191,7 @@
               *ngSwitchCase="DatasetRunActionDisplayState.FAILED"
               class="text-danger text-center"
             >
-              This action failed during run and produced no output.
+              {{ currentAction?.error || 'This action failed during run and produced no output.' }}
             </div>
             <div
               *ngSwitchCase="DatasetRunActionDisplayState.PURGED"
@@ -225,7 +225,7 @@
               *ngSwitchCase="DatasetRunActionDisplayState.FAILED"
               class="text-danger text-center"
             >
-              This action failed during run and produced no output.
+              {{ comparisonAction?.error || 'This action failed during run and produced no output.' }}
             </div>
             <div
               *ngSwitchCase="DatasetRunActionDisplayState.PURGED"

--- a/bot/admin/web/src/app/quality/datatsets/models.ts
+++ b/bot/admin/web/src/app/quality/datatsets/models.ts
@@ -19,6 +19,7 @@ export interface DatasetRunAction {
   state: DatasetRunActionState;
   action: any | null; // ActionReport | null
   retryCount: number;
+  error?: string | null;
 }
 
 export interface DatasetRunStats {

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -104,10 +104,10 @@ import org.litote.kmongo.and
 import org.litote.kmongo.ascending
 import org.litote.kmongo.avg
 import org.litote.kmongo.bson
+import org.litote.kmongo.combine
 import org.litote.kmongo.contains
 import org.litote.kmongo.coroutine.aggregate
 import org.litote.kmongo.coroutine.coroutine
-import org.litote.kmongo.combine
 import org.litote.kmongo.descending
 import org.litote.kmongo.div
 import org.litote.kmongo.eq
@@ -412,9 +412,10 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     internal suspend fun loadConnectorMessage(
         actionId: Id<Action>,
         dialogId: Id<Dialog>,
-    ): List<ConnectorMessage> {
-        return try {
-            connectorMessageCol.findOneById(ConnectorMessageColId(actionId, dialogId))
+    ): List<ConnectorMessage> =
+        try {
+            connectorMessageCol
+                .findOneById(ConnectorMessageColId(actionId, dialogId))
                 ?.messages
                 ?.mapNotNull { it?.value as? ConnectorMessage }
                 ?: emptyList()
@@ -422,14 +423,14 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
             logger.error(e)
             emptyList()
         }
-    }
 
-    internal suspend fun loadConnectorMessages(ids: List<ConnectorMessageColId>): Map<ConnectorMessageColId, List<ConnectorMessage>> {
-        return try {
+    internal suspend fun loadConnectorMessages(ids: List<ConnectorMessageColId>): Map<ConnectorMessageColId, List<ConnectorMessage>> =
+        try {
             if (ids.isEmpty()) {
                 emptyMap()
             } else {
-                connectorMessageCol.find(ConnectorMessageCol::_id `in` ids)
+                connectorMessageCol
+                    .find(ConnectorMessageCol::_id `in` ids)
                     .toList()
                     .associate { m -> m._id to m.messages.mapNotNull { it?.value as? ConnectorMessage } }
             }
@@ -437,7 +438,6 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
             logger.error(e)
             emptyMap()
         }
-    }
 
     private suspend fun saveNlpStats(
         actionId: Id<Action>,
@@ -456,20 +456,19 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     internal suspend fun loadNlpStats(
         actionId: Id<Action>,
         dialogId: Id<Dialog>,
-    ): NlpCallStats? {
-        return try {
+    ): NlpCallStats? =
+        try {
             nlpStatsCol.findOneById(NlpStatsColId(actionId, dialogId))?.stats
         } catch (e: Exception) {
             logger.error(e)
             null
         }
-    }
 
     override fun getNlpCallStats(
         actionId: Id<Action>,
         namespace: String,
-    ): NlpCallStats? {
-        return runBlocking {
+    ): NlpCallStats? =
+        runBlocking {
             try {
                 nlpStatsCol.findOne(NlpStatsCol_._id.actionId eq actionId, AppNamespace eq namespace)?.stats
             } catch (e: Exception) {
@@ -477,23 +476,21 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 null
             }
         }
-    }
 
     override fun getNlpStats(
         dialogIds: List<Id<Dialog>>,
         namespace: String,
-    ): List<NlpStats> {
-        return runBlocking {
-            nlpStatsCol.find(
-                and(
-                    NlpStatsCol::appNamespace eq namespace,
-                    NlpStatsCol::_id / NlpStatsColId::dialogId `in` dialogIds,
-                ),
-            )
-                .toList()
+    ): List<NlpStats> =
+        runBlocking {
+            nlpStatsCol
+                .find(
+                    and(
+                        NlpStatsCol::appNamespace eq namespace,
+                        NlpStatsCol::_id / NlpStatsColId::dialogId `in` dialogIds,
+                    ),
+                ).toList()
                 .map { it.toNlpStats() }
         }
-    }
 
     override suspend fun loadWithLastValidDialog(
         namespace: String,
@@ -512,7 +509,8 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
 
             // copy state
             val priorTimelineId = timelineId(priorUserId.id, namespace)
-            userTimelineCol.findOneById(priorTimelineId)
+            userTimelineCol
+                .findOneById(priorTimelineId)
                 ?.apply {
                     toUserTimeline().userState.flags.forEach {
                         timeline.userState.flags.putIfAbsent(it.key, it.value)
@@ -568,59 +566,59 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     override suspend fun loadByTemporaryIdsWithoutDialogs(
         namespace: String,
         temporaryIds: List<String>,
-    ): List<UserTimeline> {
-        return userTimelineCol.find(TemporaryIds `in` (temporaryIds), Namespace eq namespace)
-            .toList().map { it.toUserTimeline() }
-    }
+    ): List<UserTimeline> =
+        userTimelineCol
+            .find(TemporaryIds `in` (temporaryIds), Namespace eq namespace)
+            .toList()
+            .map { it.toUserTimeline() }
 
     private suspend fun loadLastValidGroupDialogCol(
         namespace: String,
         groupId: String,
-    ): DialogCol? {
-        return dialogCol.aggregate<DialogCol>(
-            match(
-                Namespace eq namespace,
-                GroupId eq groupId,
-                LastUpdateDate gt now().minusSeconds(dialogMaxValidityInSeconds),
-            ),
-            sort(
-                descending(LastUpdateDate),
-            ),
-            limit(1),
-        ).first()
-    }
+    ): DialogCol? =
+        dialogCol
+            .aggregate<DialogCol>(
+                match(
+                    Namespace eq namespace,
+                    GroupId eq groupId,
+                    LastUpdateDate gt now().minusSeconds(dialogMaxValidityInSeconds),
+                ),
+                sort(
+                    descending(LastUpdateDate),
+                ),
+                limit(1),
+            ).first()
 
     private suspend fun loadLastValidDialogCol(
         namespace: String,
         userId: PlayerId,
-    ): DialogCol? {
-        return dialogCol.aggregate<DialogCol>(
-            match(
-                PlayerIds.id eq userId.id,
-                Namespace eq namespace,
-                LastUpdateDate gt now().minusSeconds(dialogMaxValidityInSeconds),
-            ),
-            sort(
-                descending(LastUpdateDate),
-            ),
-            limit(1),
-        ).first()
-    }
+    ): DialogCol? =
+        dialogCol
+            .aggregate<DialogCol>(
+                match(
+                    PlayerIds.id eq userId.id,
+                    Namespace eq namespace,
+                    LastUpdateDate gt now().minusSeconds(dialogMaxValidityInSeconds),
+                ),
+                sort(
+                    descending(LastUpdateDate),
+                ),
+                limit(1),
+            ).first()
 
     private suspend fun loadLastValidDialog(
         namespace: String,
         userId: PlayerId,
         groupId: String? = null,
         storyDefinitionProvider: (String) -> StoryDefinition,
-    ): Dialog? {
-        return try {
+    ): Dialog? =
+        try {
             (groupId?.let { loadLastValidGroupDialogCol(namespace, it) } ?: loadLastValidDialogCol(namespace, userId))
                 ?.toDialog(storyDefinitionProvider)
         } catch (e: Exception) {
             logger.error(e)
             null
         }
-    }
 
     override fun search(query: UserReportQuery): UserReportQueryResult =
         runBlocking {
@@ -643,14 +641,16 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                             if (flags.isEmpty()) {
                                 null
                             } else {
-                                flags.flatMap {
-                                    "userState.flags.${it.key}".let { key ->
-                                        listOfNotNull(
-                                            if (it.value == null) null else "{'$key.value':${it.value!!.json}}",
-                                            "{$or:[{'$key.expirationDate':{$gt:${now().json}}},{'$key.expirationDate':{$type:10}}]}",
-                                        )
-                                    }
-                                }.joinToString(",", "{$and:[", "]}").bson
+                                flags
+                                    .flatMap {
+                                        "userState.flags.${it.key}".let { key ->
+                                            listOfNotNull(
+                                                if (it.value == null) null else "{'$key.value':${it.value!!.json}}",
+                                                "{$or:[{'$key.expirationDate':{$gt:${now().json}}},{'$key.expirationDate':{$type:10}}]}",
+                                            )
+                                        }
+                                    }.joinToString(",", "{$and:[", "]}")
+                                    .bson
                             },
                             if (query.displayTests) null else UserTimelineCol_.UserPreferences.test eq false,
                         )
@@ -660,7 +660,8 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                     logger.debug { "count: $count" }
                     if (count > start) {
                         val list =
-                            c.find(filter)
+                            c
+                                .find(filter)
                                 .skip(start.toInt())
                                 .limit(size)
                                 .descendingSort(LastUpdateDate)
@@ -690,7 +691,8 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                         )
                     logger.debug { "user analytics search query: $filter" }
                     val c = userTimelineCol.withReadPreference(secondaryPreferred())
-                    c.find(filter)
+                    c
+                        .find(filter)
                         .ascendingSort(LastUserActionDate)
                         .toList()
                         .map { it.toUserAnalytics() }
@@ -708,13 +710,14 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                     if (dialogId != null) {
                         // When a single dialog is requested, only the applicationId filter is applied
                         val dialog =
-                            dialogCol.findOne(
-                                and(
-                                    DialogCol::_id eq dialogId!!.toId(),
-                                    DialogCol::applicationIds `in` applicationsIds,
-                                    DialogCol::namespace eq namespace,
-                                ),
-                            )?.toDialogReport(query.evaluableActionsOnly)
+                            dialogCol
+                                .findOne(
+                                    and(
+                                        DialogCol::_id eq dialogId!!.toId(),
+                                        DialogCol::applicationIds `in` applicationsIds,
+                                        DialogCol::namespace eq namespace,
+                                    ),
+                                )?.toDialogReport(query.evaluableActionsOnly)
 
                         dialog?.let(::listOf).orEmpty().let {
                             DialogReportQueryResult(1, 0, 1, it)
@@ -722,12 +725,22 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                     } else {
                         val dialogIds =
                             when {
-                                !query.dialogIds.isNullOrEmpty() -> query.dialogIds!!.map { it.toId<Dialog>() }.toSet()
-                                query.text.isNullOrBlank() -> emptySet()
+                                !query.dialogIds.isNullOrEmpty() -> {
+                                    query.dialogIds!!.map { it.toId<Dialog>() }.toSet()
+                                }
+
+                                query.text.isNullOrBlank() -> {
+                                    emptySet()
+                                }
+
                                 query.exactMatch -> {
-                                    dialogTextCol.find(Text eq textKey(query.text!!.trim())).toList().map { it.dialogId }
+                                    dialogTextCol
+                                        .find(Text eq textKey(query.text!!.trim()))
+                                        .toList()
+                                        .map { it.dialogId }
                                         .toSet()
                                 }
+
                                 else -> {
                                     dialogTextCol
                                         .find(Text.regex(textKey(query.text!!.trim()), "i"))
@@ -785,12 +798,14 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                             val list =
                                 if (query.random) {
                                     if (count > 0) {
-                                        c.aggregate<DialogCol>(
-                                            listOf(
-                                                match(filter),
-                                                sample(size.coerceAtLeast(1)),
-                                            ),
-                                        ).toList().map { it.toDialogReport(query.evaluableActionsOnly) }
+                                        c
+                                            .aggregate<DialogCol>(
+                                                listOf(
+                                                    match(filter),
+                                                    sample(size.coerceAtLeast(1)),
+                                                ),
+                                            ).toList()
+                                            .map { it.toDialogReport(query.evaluableActionsOnly) }
                                     } else {
                                         emptyList()
                                     }
@@ -814,9 +829,12 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                                             }
 
                                             // If no filter is specified, we keep default filtering
-                                            else -> descending(LastUpdateDate)
+                                            else -> {
+                                                descending(LastUpdateDate)
+                                            }
                                         }
-                                    c.find(filter)
+                                    c
+                                        .find(filter)
                                         .skip(start.toInt())
                                         .limit(size)
                                         .sort(sortBson)
@@ -849,13 +867,12 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 .distinct(
                     Stories.actions.state.intent as KProperty1<DialogCol, String>,
                     and(DialogCol_.ApplicationIds `in` applicationsIds.filter { it.isNotEmpty() }),
-                )
-                .toList()
+                ).toList()
                 .filterNotNullTo(mutableSetOf())
         }
 
-    override fun findBotDialogStats(query: DialogReportQuery): RatingReportQueryResult? {
-        return runBlocking {
+    override fun findBotDialogStats(query: DialogReportQuery): RatingReportQueryResult? =
+        runBlocking {
             val applicationsIds = getApplicationIds(query.namespace, query.nlpModel)
             val matchConditions =
                 and(
@@ -881,21 +898,20 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 null
             }
         }
-    }
 
-    override fun getDialog(id: Id<Dialog>): DialogReport? {
-        return runBlocking {
+    override fun getDialog(id: Id<Dialog>): DialogReport? =
+        runBlocking {
             dialogCol.findOneById(id)?.toDialogReport()
         }
-    }
 
-    override fun findByDialogByIds(ids: Set<Id<Dialog>>): Set<DialogReport> {
-        return runBlocking {
-            dialogCol.find(_id `in` ids).toList()
+    override fun findByDialogByIds(ids: Set<Id<Dialog>>): Set<DialogReport> =
+        runBlocking {
+            dialogCol
+                .find(_id `in` ids)
+                .toList()
                 .mapNotNull { it.toDialogReport() }
                 .toSet()
         }
-    }
 
     override suspend fun getClientDialogs(
         namespace: String,
@@ -918,12 +934,11 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
         namespace: String,
         from: Instant,
         storyDefinitionProvider: (String) -> StoryDefinition,
-    ): List<Dialog> {
-        return dialogCol
+    ): List<Dialog> =
+        dialogCol
             .find(and(LastUpdateDate gt from, Namespace eq namespace))
             .toList()
             .map { it.toDialog(storyDefinitionProvider) }
-    }
 
     private suspend fun addSnapshot(dialog: Dialog): SnapshotCol {
         val snapshot = Snapshot(dialog)
@@ -939,40 +954,40 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     }
 
     private suspend fun addArchivedValues(dialog: Dialog) {
-        dialog.state.entityValues.values.filter { it.hasBeanUpdatedInBus }
+        dialog.state.entityValues.values
+            .filter { it.hasBeanUpdatedInBus }
             .forEach {
                 logger.debug { "save archived values for $it" }
                 archivedEntityValuesCol.save(ArchivedEntityValuesCol(it.previousValues, it.stateValueId))
             }
     }
 
-    override suspend fun getSnapshots(dialogId: Id<Dialog>): List<Snapshot> {
-        return try {
+    override suspend fun getSnapshots(dialogId: Id<Dialog>): List<Snapshot> =
+        try {
             snapshotCol.findOneById(dialogId)?.snapshots ?: emptyList()
         } catch (e: Exception) {
             logger.error(e)
             emptyList()
         }
-    }
 
     override suspend fun getLastStoryId(
         namespace: String,
         playerId: PlayerId,
-    ): String? {
-        return try {
+    ): String? =
+        try {
             loadLastValidDialogCol(namespace, playerId)?.stories?.lastOrNull()?.storyDefinitionId
         } catch (e: Exception) {
             logger.error(e)
             null
         }
-    }
 
     override fun findAnnotation(
         dialogId: String,
         actionId: String,
     ): BotAnnotation? =
         runBlocking {
-            dialogCol.findOneById(dialogId)
+            dialogCol
+                .findOneById(dialogId)
                 ?.stories
                 ?.firstNotNullOfOrNull { story -> story.actions.find { it.id.toString() == actionId }?.annotation }
         }
@@ -983,12 +998,15 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
         annotation: BotAnnotation,
     ) {
         runBlocking {
-            dialogCol.findOneById(dialogId)?.takeIf { dialog ->
-                dialog.stories.any { story ->
-                    story.actions.find { it.id.toString() == actionId }
-                        ?.also { it.annotation = annotation } != null
-                }
-            }?.let { dialogCol.save(it) }
+            dialogCol
+                .findOneById(dialogId)
+                ?.takeIf { dialog ->
+                    dialog.stories.any { story ->
+                        story.actions
+                            .find { it.id.toString() == actionId }
+                            ?.also { it.annotation = annotation } != null
+                    }
+                }?.let { dialogCol.save(it) }
                 ?: logger.warn("Action with ID $actionId not found in dialog $dialogId")
         }
     }
@@ -998,7 +1016,8 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
         actionId: String,
     ): Boolean =
         runBlocking {
-            dialogCol.findOneById(dialogId)
+            dialogCol
+                .findOneById(dialogId)
                 ?.stories
                 ?.any { story -> story.actions.any { it.id.toString() == actionId && it.annotation != null } }
                 ?: false
@@ -1011,13 +1030,14 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     ) {
         runBlocking {
             dialogCol.findOneById(dialogId)?.let { dialog ->
-                dialog.stories.firstNotNullOfOrNull { story ->
-                    story.actions.find { it.id.toString() == actionId }?.annotation
-                }?.apply {
-                    events.add(event)
-                    lastUpdateDate = Instant.now()
-                    dialogCol.save(dialog)
-                } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
+                dialog.stories
+                    .firstNotNullOfOrNull { story ->
+                        story.actions.find { it.id.toString() == actionId }?.annotation
+                    }?.apply {
+                        events.add(event)
+                        lastUpdateDate = Instant.now()
+                        dialogCol.save(dialog)
+                    } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
             } ?: logger.warn("Dialog with ID $dialogId not found")
         }
     }
@@ -1028,10 +1048,15 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
         eventId: String,
     ): BotAnnotationEvent? =
         runBlocking {
-            dialogCol.findOneById(dialogId)
+            dialogCol
+                .findOneById(dialogId)
                 ?.stories
                 ?.firstNotNullOfOrNull { story ->
-                    story.actions.find { it.id.toString() == actionId }?.annotation?.events?.find { it.eventId.toString() == eventId }
+                    story.actions
+                        .find { it.id.toString() == actionId }
+                        ?.annotation
+                        ?.events
+                        ?.find { it.eventId.toString() == eventId }
                 }
         }
 
@@ -1043,16 +1068,18 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     ) {
         runBlocking {
             dialogCol.findOneById(dialogId)?.let { dialog ->
-                dialog.stories.firstNotNullOfOrNull { story ->
-                    story.actions.find { it.id.toString() == actionId }?.annotation
-                }?.let { annotation ->
-                    annotation.events.indexOfFirst { it.eventId.toString() == eventId }
-                        .takeIf { it != -1 }
-                        ?.let { index ->
-                            annotation.events[index] = updatedEvent
-                            dialogCol.save(dialog)
-                        } ?: logger.warn("Event $eventId not found")
-                } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
+                dialog.stories
+                    .firstNotNullOfOrNull { story ->
+                        story.actions.find { it.id.toString() == actionId }?.annotation
+                    }?.let { annotation ->
+                        annotation.events
+                            .indexOfFirst { it.eventId.toString() == eventId }
+                            .takeIf { it != -1 }
+                            ?.let { index ->
+                                annotation.events[index] = updatedEvent
+                                dialogCol.save(dialog)
+                            } ?: logger.warn("Event $eventId not found")
+                    } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
             } ?: logger.warn("Dialog with ID $dialogId not found")
         }
     }
@@ -1064,15 +1091,16 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     ) {
         runBlocking {
             dialogCol.findOneById(dialogId)?.let { dialog ->
-                dialog.stories.firstNotNullOfOrNull { story ->
-                    story.actions.find { it.id.toString() == actionId }?.annotation
-                }?.let { annotation ->
-                    if (annotation.events.removeIf { it.eventId.toString() == eventId && it.type == BotAnnotationEventType.COMMENT }) {
-                        dialogCol.save(dialog)
-                    } else {
-                        logger.warn("Event $eventId not found or not a comment in annotation for action $actionId")
-                    }
-                } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
+                dialog.stories
+                    .firstNotNullOfOrNull { story ->
+                        story.actions.find { it.id.toString() == actionId }?.annotation
+                    }?.let { annotation ->
+                        if (annotation.events.removeIf { it.eventId.toString() == eventId && it.type == BotAnnotationEventType.COMMENT }) {
+                            dialogCol.save(dialog)
+                        } else {
+                            logger.warn("Event $eventId not found or not a comment in annotation for action $actionId")
+                        }
+                    } ?: logger.warn("Action $actionId or annotation not found in dialog $dialogId")
             } ?: logger.warn("Dialog with ID $dialogId not found")
         }
     }
@@ -1083,8 +1111,10 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     ): List<ArchivedEntityValue> {
         logger.debug { "load archived values for $stateValueId" }
         return try {
-            archivedEntityValuesCol.findOneById(stateValueId)
-                ?.values?.map { it.toArchivedEntityValue(oldActionsMap) }
+            archivedEntityValuesCol
+                .findOneById(stateValueId)
+                ?.values
+                ?.map { it.toArchivedEntityValue(oldActionsMap) }
                 ?: emptyList()
         } catch (e: Exception) {
             logger.error(e)
@@ -1156,8 +1186,14 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
         }
 
         when (intentType) {
-            IntentTypeEnum.UNKNOWN -> filters += eq("stories.actions.state.intent", "unknown")
-            IntentTypeEnum.KNOWN -> filters += not(eq("stories.actions.state.intent", "unknown"))
+            IntentTypeEnum.UNKNOWN -> {
+                filters += eq("stories.actions.state.intent", "unknown")
+            }
+
+            IntentTypeEnum.KNOWN -> {
+                filters += not(eq("stories.actions.state.intent", "unknown"))
+            }
+
             else -> {}
         }
 

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -107,6 +107,7 @@ import org.litote.kmongo.bson
 import org.litote.kmongo.contains
 import org.litote.kmongo.coroutine.aggregate
 import org.litote.kmongo.coroutine.coroutine
+import org.litote.kmongo.combine
 import org.litote.kmongo.descending
 import org.litote.kmongo.div
 import org.litote.kmongo.eq
@@ -123,6 +124,7 @@ import org.litote.kmongo.match
 import org.litote.kmongo.not
 import org.litote.kmongo.orderBy
 import org.litote.kmongo.pull
+import org.litote.kmongo.push
 import org.litote.kmongo.regex
 import org.litote.kmongo.replaceUpsert
 import org.litote.kmongo.setValue
@@ -925,16 +927,15 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
 
     private suspend fun addSnapshot(dialog: Dialog): SnapshotCol {
         val snapshot = Snapshot(dialog)
-        val existingSnapshot = snapshotCol.findOneById(dialog.id)
-        return if (existingSnapshot == null) {
-            SnapshotCol(dialog.id, listOf(snapshot))
-                .also { snapshotCol.insertOne(it) }
-        } else {
-            existingSnapshot.copy(
-                snapshots = existingSnapshot.snapshots + snapshot,
-                lastUpdateDate = now(),
-            ).also { snapshotCol.save(it) }
-        }
+        snapshotCol.updateOneById(
+            dialog.id,
+            combine(
+                push(SnapshotCol::snapshots, snapshot),
+                setValue(SnapshotCol::lastUpdateDate, now()),
+            ),
+            upsert(),
+        )
+        return snapshotCol.findOneById(dialog.id) ?: SnapshotCol(dialog.id, listOf(snapshot))
     }
 
     private suspend fun addArchivedValues(dialog: Dialog) {

--- a/bot/storage-mongo/src/test/kotlin/UserTimelineMongoDAOTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/UserTimelineMongoDAOTest.kt
@@ -114,6 +114,85 @@ internal class UserTimelineMongoDAOTest : AbstractTest() {
         }
 
     @Test
+    fun `save appends dialog snapshots without overwriting previous snapshots`() =
+        runBlocking {
+            val namespace = "test_dialog_snapshot_append"
+            val applicationId = "test_app_dialog_snapshot_append"
+            val userId = PlayerId("user_dialog_snapshot_append", PlayerType.user)
+            val botPlayerId = PlayerId("bot_dialog_snapshot_append", PlayerType.bot)
+            val storyDef =
+                StoryDefinitionBase(
+                    "test_story_dialog_snapshot_append",
+                    object : SimpleStoryHandlerBase() {
+                        override fun action(bus: BotBus) {}
+                    },
+                )
+
+            val firstAction =
+                SendSentence(
+                    botPlayerId,
+                    applicationId,
+                    userId,
+                    "first",
+                    mutableListOf(),
+                    newId(),
+                    ZonedDateTime.parse("2025-12-01T10:00:00Z").toInstant(),
+                    EventState(),
+                    ActionMetadata(),
+                )
+            val secondAction =
+                SendSentence(
+                    botPlayerId,
+                    applicationId,
+                    userId,
+                    "second",
+                    mutableListOf(),
+                    newId(),
+                    ZonedDateTime.parse("2025-12-01T10:00:01Z").toInstant(),
+                    EventState(),
+                    ActionMetadata(),
+                )
+
+            val dialogId = newId<Dialog>()
+            val fullDialog =
+                Dialog(
+                    playerIds = setOf(userId, botPlayerId),
+                    id = dialogId,
+                    stories =
+                        mutableListOf(
+                            Story(
+                                storyDef,
+                                Intent("test"),
+                                actions = mutableListOf(firstAction, secondAction),
+                            ),
+                        ),
+                )
+            val staleDialog =
+                Dialog(
+                    playerIds = setOf(userId, botPlayerId),
+                    id = dialogId,
+                    stories =
+                        mutableListOf(
+                            Story(
+                                storyDef,
+                                Intent("test"),
+                                actions = mutableListOf(firstAction),
+                            ),
+                        ),
+                )
+
+            UserTimelineMongoDAO.save(UserTimeline(userId, dialogs = mutableListOf(fullDialog)), namespace)
+            delay(200)
+            UserTimelineMongoDAO.save(UserTimeline(userId, dialogs = mutableListOf(staleDialog)), namespace)
+            delay(200)
+
+            val snapshots = UserTimelineMongoDAO.getSnapshots(dialogId)
+
+            assertEquals(2, snapshots.size)
+            assertTrue(snapshots.all { it.storyDefinitionId == storyDef.id })
+        }
+
+    @Test
     fun `dialogActivity filters should handle all null and non-null date combinations`() =
         runBlocking {
             val namespace = "test_activity_filter_all_cases"


### PR DESCRIPTION
Ticket : [DERCBOT-1876](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1876)

### Goal
Fix dataset runs that were marked as successful even when the RAG call returned a technical error.

### Details
- Detect RAG technical errors from debug messages returned by Bot API
- Retry the dataset question when this technical error is detected, instead of marking it as completed because a userActionId exists
- Store the final error on failed dataset questions and expose it in the actions endpoint
- Display the backend error message in the dataset run UI
- Append Mongo dialog snapshots atomically to avoid overwriting existing snapshots