### PR TITLE
[DERCBOT-1822] Fix 'number of messages' chart in custom metrics

### DIFF
--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -47,6 +47,7 @@ import ai.tock.bot.admin.bot.sentencegeneration.BotSentenceGenerationConfigurati
 import ai.tock.bot.admin.bot.vectorstore.BotVectorStoreConfigurationDAO
 import ai.tock.bot.admin.dataset.DatasetDAO
 import ai.tock.bot.admin.dialog.ApplicationDialogFlowData
+import ai.tock.bot.admin.dialog.CountByDateResult
 import ai.tock.bot.admin.dialog.CountResult
 import ai.tock.bot.admin.dialog.DialogReport
 import ai.tock.bot.admin.dialog.DialogReportDAO
@@ -619,10 +620,20 @@ object BotAdminService {
         return grouped
     }
 
+    private fun groupCountByDateByAppConfigType(results: List<CountByDateResult>): Map<String, List<CountByDateResult>> {
+        val grouped: Map<String, List<CountByDateResult>> =
+            results.groupBy { stat ->
+                // At the moment, we rely on the `test-` prefix to distinguish test configurations
+                if (stat.applicationId.startsWith("test-")) APP_CONFIG_TEST_TYPE else APP_CONFIG_PROD_TYPE
+            }
+        return grouped
+    }
+
     fun getDialogStats(query: DialogStatsQuery): DialogStatsGroupResponse {
         val stats = dialogReportDAO.calculateDialogStats(query)
 
         val allUserActionsGroup = groupByAppConfigType(stats.allUserActions)
+        val allUserActionsByDateGroup = groupCountByDateByAppConfigType(stats.allUserActionsByDate)
         val allUserActionsExceptRagGroup = groupByAppConfigType(stats.allUserActionsExceptRag)
         val allUserRagActionsGroup = groupByAppConfigType(stats.allUserRagActions)
         val knownIntentUserActionsGroup = groupByAppConfigType(stats.knownIntentUserActions)
@@ -634,6 +645,7 @@ object BotAdminService {
         fun buildResult(env: String) =
             DialogStatsQueryResult(
                 allUserActions = allUserActionsGroup[env] ?: emptyList(),
+                allUserActionsByDate = allUserActionsByDateGroup[env] ?: emptyList(),
                 allUserActionsExceptRag = allUserActionsExceptRagGroup[env] ?: emptyList(),
                 allUserRagActions = allUserRagActionsGroup[env] ?: emptyList(),
                 knownIntentUserActions = knownIntentUserActionsGroup[env] ?: emptyList(),

--- a/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.html
+++ b/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.html
@@ -89,7 +89,7 @@
           ghost
           status="info"
           nbTooltip="Display metrics for the last 3 days"
-          (click)="setTimeRange(timeRanges.day)"
+          (click)="setTimeRange(timeRanges.threeDays)"
         >
           3d
         </button>

--- a/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.spec.ts
+++ b/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.spec.ts
@@ -28,21 +28,20 @@ import {
   NbDialogService
 } from '@nebular/theme';
 import { of } from 'rxjs';
-import { AnalyticsService } from '../../analytics/analytics.service';
-import { UserAnalyticsQueryResult } from '../../analytics/users/users';
 import { AnswerConfigurationType } from '../../bot/model/story';
 import { RestService } from '../../core-nlp/rest/rest.service';
 import { StateService } from '../../core-nlp/state.service';
 import { BotConfigurationService } from '../../core/bot-configuration.service';
 
 import { TestSharedModule } from '../../shared/test-shared.module';
-import { IndicatorDefinition, MetricResult, StorySummary } from '../models';
+import { IndicatorDefinition, IndicatorType, MetricResult, StorySummary } from '../models';
 import { MetricsBoardComponent, StoriesFilter } from './metrics-board.component';
 
 const indicator1: IndicatorDefinition = {
   name: 'test',
   label: 'test label',
   description: 'test desc',
+  type: IndicatorType.CUSTOM,
   dimensions: ['test'],
   values: [{ name: 'oui', label: 'oui label' }]
 };
@@ -50,15 +49,9 @@ const indicator2: IndicatorDefinition = {
   name: 'otherTest',
   label: 'Other Test',
   description: 'Other Test desc',
+  type: IndicatorType.CUSTOM,
   dimensions: ['test', 'Other test dim'],
   values: []
-};
-
-const messagesStats: UserAnalyticsQueryResult = {
-  dates: [new Date('2023-04-15'), new Date('2023-04-16'), new Date('2023-04-17')],
-  usersData: [[0, 0], [5], [12]],
-  connectorsType: [],
-  intents: []
 };
 
 const storiesSummaries: StorySummary[] = [
@@ -136,6 +129,51 @@ const dimensionMetrics: MetricResult[] = [
   }
 ];
 
+const emptyDialogStats = {
+  allUserActions: [],
+  allUserActionsByDate: [],
+  allUserActionsExceptRag: [],
+  allUserRagActions: [],
+  knownIntentUserActions: [],
+  unknownIntentUserActions: [],
+  unknownIntentUserActionsExceptRag: [],
+  allFeedbackUp: [],
+  allFeedbackDown: []
+};
+
+const dialogStats = {
+  test: {
+    ...emptyDialogStats,
+    allUserActionsByDate: [
+      {
+        applicationId: 'test-test',
+        date: '2023-04-17',
+        total: 3
+      }
+    ]
+  },
+  prod: {
+    ...emptyDialogStats,
+    allUserActionsByDate: [
+      {
+        applicationId: 'test',
+        date: '2023-04-15',
+        total: 0
+      },
+      {
+        applicationId: 'test',
+        date: '2023-04-16',
+        total: 5
+      },
+      {
+        applicationId: 'test',
+        date: '2023-04-17',
+        total: 12
+      }
+    ]
+  }
+};
+
 describe('MetricsBoardComponent', () => {
   let component: MetricsBoardComponent;
   let fixture: ComponentFixture<MetricsBoardComponent>;
@@ -168,10 +206,6 @@ describe('MetricsBoardComponent', () => {
           useValue: { currentApplication: { name: 'TestApp', namespace: 'TestNamespace' }, currentLocale: 'fr' }
         },
         {
-          provide: AnalyticsService,
-          useValue: { messagesAnalytics: () => of(messagesStats) }
-        },
-        {
           provide: BotConfigurationService,
           useValue: { configurations: of([{}]) }
         },
@@ -180,14 +214,17 @@ describe('MetricsBoardComponent', () => {
           useValue: {
             get: () => of([indicator1, indicator2]),
             post: (url, payload) => {
+              if (url === '/dialogs/stats') {
+                return of(dialogStats);
+              }
               if (url === '/bot/story/search/summary') {
                 return of(storiesSummaries);
               }
               if (url === '/bot/TestApp/metrics') {
-                if (payload.groupBy[0] === 'TRACKED_STORY_ID') {
-                  return of(storiesHits);
+                if (payload.groupBy.includes('TRACKED_STORY_ID')) {
+                  return of({ test: [], prod: storiesHits });
                 }
-                return of(dimensionMetrics);
+                return of({ test: [], prod: dimensionMetrics });
               }
             }
           }
@@ -272,7 +309,12 @@ describe('MetricsBoardComponent', () => {
   });
 
   it('should init messages stats chart', () => {
-    expect(component.messagesChartOptions.series[0].data).toEqual([0, 5, 12]);
+    expect(component.messagesChartOptions.series[0].data).toEqual([0, 0, 0, 0, 0, 5, 12]);
+  });
+
+  it('should refresh messages stats chart when display tests changes', () => {
+    component.onToggleDisplayTests();
+    expect(component.messagesChartOptions.series[0].data).toEqual([0, 0, 0, 0, 0, 5, 15]);
   });
 
   it('should retrieve indicators by name', () => {
@@ -280,6 +322,7 @@ describe('MetricsBoardComponent', () => {
       name: 'test',
       label: 'test label',
       description: 'test desc',
+      type: IndicatorType.CUSTOM,
       dimensions: ['test'],
       values: [
         {
@@ -299,6 +342,7 @@ describe('MetricsBoardComponent', () => {
         name: 'otherTest',
         label: 'Other Test',
         description: 'Other Test desc',
+        type: IndicatorType.CUSTOM,
         dimensions: ['test', 'Other test dim'],
         values: []
       }

--- a/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.ts
+++ b/bot/admin/web/src/app/metrics/metrics-board/metrics-board.component.ts
@@ -18,10 +18,6 @@ import { Component, effect, OnDestroy, OnInit, signal } from '@angular/core';
 import { NbCalendarRange, NbDateService, NbDialogService, NbToastrService } from '@nebular/theme';
 import type { EChartsOption } from 'echarts';
 import { forkJoin, Observable, Subject, take, takeUntil } from 'rxjs';
-import { environment } from '../../../environments/environment';
-import { AnalyticsService } from '../../analytics/analytics.service';
-import { DialogFlowRequest } from '../../analytics/flow/flow';
-import { UserAnalyticsQueryResult } from '../../analytics/users/users';
 import { AnswerConfigurationType } from '../../bot/model/story';
 import { RestService } from '../../core-nlp/rest/rest.service';
 import { StateService } from '../../core-nlp/state.service';
@@ -40,13 +36,19 @@ import {
 } from '../models';
 import { MetricsByStoriesComponent } from './metrics-by-stories/metrics-by-stories.component';
 import { StoriesHitsComponent } from './stories-hits/stories-hits.component';
-import { RagAnswerStatusLabels, roundMinutesToNextTen, snakeCaseToDisplayLabel, toISOStringWithoutOffset } from '../../shared/utils';
-import { DialogStats as DialogStats, DialogStatsQueryResult, DialogStatsGroupResult, DialogCounts } from 'src/app/shared/model/dialog-data';
+import { RagAnswerStatusLabels, roundMinutesToNextTen, snakeCaseToDisplayLabel } from '../../shared/utils';
+import {
+  CountByDateResult,
+  DialogStats as DialogStats,
+  DialogStatsQueryResult,
+  DialogStatsGroupResult,
+  DialogCounts
+} from 'src/app/shared/model/dialog-data';
 import { BotSharedService } from '../../shared/bot-shared.service';
 import { MetricsIndicatorDetailsComponent } from './metrics-indicator-details/metrics-indicator-details.component';
 
 export enum TimeRanges {
-  day = 1,
+  threeDays = 3,
   week = 7,
   month = 31,
   quarter = 92,
@@ -77,7 +79,7 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
 
   timeRanges = TimeRanges;
   range = signal<NbCalendarRange<Date>>({
-    start: this.dateService.setSeconds(this.dateService.addDay(this.dateService.today(), -this.timeRanges.week), 0),
+    start: this.dateService.setSeconds(this.dateService.addDay(this.dateService.today(), -(this.timeRanges.week - 1)), 0),
     end: roundMinutesToNextTen(this.dateService.today())
   });
 
@@ -90,6 +92,7 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
   storiesHits: MetricGroupResult;
   storiesFilterType = StoriesFilterType;
   lastLoadedDimensionMetrics: MetricGroupResult;
+  lastLoadedDialogStats: DialogStatsGroupResult;
 
   indicatorType = IndicatorType;
 
@@ -98,7 +101,6 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
   constructor(
     private stateService: StateService,
     private dateService: NbDateService<Date>,
-    private analyticsService: AnalyticsService,
     private botConfiguration: BotConfigurationService,
     private rest: RestService,
     private nbDialogService: NbDialogService,
@@ -175,7 +177,7 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
 
   setTimeRange(timeRange: TimeRanges): void {
     this.range.set({
-      start: this.dateService.addDay(this.dateService.today(), -timeRange),
+      start: this.dateService.addDay(this.dateService.today(), -(timeRange - 1)),
       end: roundMinutesToNextTen(this.dateService.today())
     });
   }
@@ -195,6 +197,9 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
 
     // refresh current dimension metrics with or without test data according to the new displayTests value
     this.initCurrentDimensionMetricsChart(this.accumulateDimensionMetrics(this.getMergedMetricsData(this.lastLoadedDimensionMetrics)));
+
+    // refresh messages metrics with or without test data according to the new displayTests value
+    this.initMessagesChart(this.getMergedMessagesData(this.lastLoadedDialogStats));
   }
 
   private loadIndicatorsAndStories(): void {
@@ -323,7 +328,6 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
     this.loading = true;
 
     const loaders = [
-      this.getMessagesSearchQuery().pipe(take(1)),
       this.getStoriesHitsQuery().pipe(take(1)),
       this.getCurrentDimensionMetricsQuery().pipe(take(1)),
       this.getRagDimensionMetricsQuery().pipe(take(1)),
@@ -331,18 +335,18 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
     ];
 
     forkJoin(loaders).subscribe(
-      ([messages, storiesHits, dimensionMetrics, ragStats, dialogStats]: [
-        UserAnalyticsQueryResult,
+      ([storiesHits, dimensionMetrics, ragStats, dialogStats]: [
         MetricGroupResult,
         MetricGroupResult,
         MetricGroupResult,
         DialogStatsGroupResult
       ]) => {
-        this.initMessagesChart(messages);
         this.storiesHits = storiesHits;
         this.storiesMetrics = this.accumulateStoryMetrics(this.getMergedMetricsData(this.storiesHits));
         this.ragStats = this.accumulateRagStats(ragStats);
+        this.lastLoadedDialogStats = dialogStats;
         this.dialogStats = this.accumulateDialogStats(dialogStats);
+        this.initMessagesChart(this.getMergedMessagesData(this.lastLoadedDialogStats));
         this.initStoriesHitsChart();
         this.lastLoadedDimensionMetrics = dimensionMetrics;
         this.initCurrentDimensionMetricsChart(this.accumulateDimensionMetrics(this.getMergedMetricsData(this.lastLoadedDimensionMetrics)));
@@ -358,6 +362,13 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
     return set.prod;
   }
 
+  private getMergedMessagesData(set: DialogStatsGroupResult): CountByDateResult[] {
+    if (this.displayTests) {
+      return [...set.prod.allUserActionsByDate, ...set.test.allUserActionsByDate];
+    }
+    return set.prod.allUserActionsByDate;
+  }
+
   private loadCurrentDimensionMetrics(): void {
     this.loading = true;
 
@@ -368,22 +379,6 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
         this.initCurrentDimensionMetricsChart(this.accumulateDimensionMetrics(this.getMergedMetricsData(this.lastLoadedDimensionMetrics)));
         this.loading = false;
       });
-  }
-
-  private getMessagesSearchQuery(): Observable<UserAnalyticsQueryResult> {
-    return this.analyticsService.messagesAnalytics(
-      new DialogFlowRequest(
-        this.stateService.currentApplication.namespace,
-        this.stateService.currentApplication.name,
-        this.stateService.currentLocale,
-        this.stateService.currentApplication.name,
-        undefined,
-        undefined,
-        toISOStringWithoutOffset(this.range().start),
-        toISOStringWithoutOffset(this.range().end),
-        !environment.production // In dev, we ask for test messages to dispose of some usable content
-      )
-    );
   }
 
   private getStoriesHitsQuery(): Observable<MetricGroupResult> {
@@ -399,11 +394,13 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
     return this.rest.post(url, query);
   }
 
-  private messagesStatsData: UserAnalyticsQueryResult;
+  private messagesStatsData: CountByDateResult[];
   messagesChartOptions: EChartsOption;
 
-  private initMessagesChart(rawStats: UserAnalyticsQueryResult): void {
+  private initMessagesChart(rawStats: CountByDateResult[]): void {
     this.messagesStatsData = rawStats;
+    const countsByDate = this.accumulateMessagesByDate(rawStats);
+    const dates = this.getDatesBetween(this.range().start, this.range().end);
 
     this.messagesChartOptions = {
       tooltip: {
@@ -414,7 +411,7 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
         }
       },
       xAxis: {
-        data: rawStats.dates as any
+        data: dates as any
       },
       yAxis: {
         type: 'value'
@@ -424,10 +421,39 @@ export class MetricsBoardComponent implements OnInit, OnDestroy {
           type: 'line',
           smooth: true,
           areaStyle: {},
-          data: rawStats.usersData.map((val) => val[0])
+          data: dates.map((date) => countsByDate[date] ?? 0)
         }
       ]
     };
+  }
+
+  private accumulateMessagesByDate(items: CountByDateResult[]): Record<string, number> {
+    const resultMap: Record<string, number> = {};
+
+    items.forEach((item) => {
+      resultMap[item.date] = (resultMap[item.date] ?? 0) + item.total;
+    });
+
+    return resultMap;
+  }
+
+  private getDatesBetween(startDate: Date, endDate: Date): string[] {
+    const dates: string[] = [];
+    const date = new Date(startDate);
+    const end = new Date(endDate);
+
+    while (date <= end) {
+      dates.push(this.formatDate(date));
+      date.setDate(date.getDate() + 1);
+    }
+
+    return dates;
+  }
+
+  private formatDate(date: Date): string {
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${date.getFullYear()}-${month}-${day}`;
   }
 
   private storiesMetrics: MetricResult[];

--- a/bot/admin/web/src/app/shared/model/dialog-data.ts
+++ b/bot/admin/web/src/app/shared/model/dialog-data.ts
@@ -466,6 +466,7 @@ export interface DialogStatsGroupResult {
 
 export interface DialogStatsQueryResult {
   allUserActions: CountResult[];
+  allUserActionsByDate: CountByDateResult[];
   allUserActionsExceptRag: CountResult[];
   allUserRagActions: CountResult[];
   knownIntentUserActions: CountResult[];
@@ -477,6 +478,12 @@ export interface DialogStatsQueryResult {
 
 export interface CountResult {
   _id: string; // applicationName
+  total: number;
+}
+
+export interface CountByDateResult {
+  applicationId: string;
+  date: string;
   total: number;
 }
 

--- a/bot/engine/src/main/kotlin/admin/dialog/DialogStatsQueryResult.kt
+++ b/bot/engine/src/main/kotlin/admin/dialog/DialogStatsQueryResult.kt
@@ -31,6 +31,18 @@ data class CountResult(
 )
 
 /**
+ * The count result by date.
+ * @param applicationId the id of the bot configuration
+ * @param date the day of the user actions, formatted as YYYY-MM-DD.
+ * @param total the number of user actions aggregated for the given [applicationId] and [date].
+ */
+data class CountByDateResult(
+    val applicationId: String,
+    val date: String,
+    val total: Long,
+)
+
+/**
  * Set of calculated statistics
  *
  * @param allUserActions : All user actions, including GenAI RAG interactions.
@@ -42,6 +54,7 @@ data class CountResult(
  */
 data class DialogStatsQueryResult(
     val allUserActions: List<CountResult> = emptyList(),
+    val allUserActionsByDate: List<CountByDateResult> = emptyList(),
     val allUserActionsExceptRag: List<CountResult> = emptyList(),
     val allUserRagActions: List<CountResult> = emptyList(),
     val knownIntentUserActions: List<CountResult> = emptyList(),

--- a/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/UserTimelineMongoDAO.kt
@@ -20,6 +20,7 @@ import ai.tock.bot.admin.annotation.BotAnnotation
 import ai.tock.bot.admin.annotation.BotAnnotationEvent
 import ai.tock.bot.admin.annotation.BotAnnotationEventType
 import ai.tock.bot.admin.annotation.BotAnnotationState
+import ai.tock.bot.admin.dialog.CountByDateResult
 import ai.tock.bot.admin.dialog.CountResult
 import ai.tock.bot.admin.dialog.DialogRating
 import ai.tock.bot.admin.dialog.DialogReport
@@ -92,6 +93,7 @@ import com.mongodb.client.model.Filters.lte
 import com.mongodb.client.model.IndexOptions
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import org.bson.Document
 import org.bson.conversions.Bson
 import org.litote.kmongo.Id
 import org.litote.kmongo.MongoOperator.and
@@ -123,6 +125,7 @@ import org.litote.kmongo.lte
 import org.litote.kmongo.match
 import org.litote.kmongo.not
 import org.litote.kmongo.orderBy
+import org.litote.kmongo.project
 import org.litote.kmongo.pull
 import org.litote.kmongo.push
 import org.litote.kmongo.regex
@@ -1156,25 +1159,28 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
     }
 
     /**
-     * Counts user actions within dialogs for a given namespace and set of applications.
+     * Builds the MongoDB filters used to count user actions.
      *
-     * @param namespace the namespace
-     * @param applicationIds the set of application configuration.
-     * @param fromDate optional start date (inclusive).
-     * @param toDate optional end date (inclusive).
-     * @param intentType the type of intents to count.
-     * @param includeGenAIRag whether to include GenAI RAG user actions in the count.
+     * This method centralizes all common filtering logic:
+     * - filters only user actions
+     * - applies optional date range filtering
+     * - excludes GenAI RAG stories when requested
+     * - filters by intent type (KNOWN / UNKNOWN / all)
      *
-     * @return Counts grouped by applicationId
+     * @param fromDate optional start date (inclusive)
+     * @param toDate optional end date (inclusive)
+     * @param intentType filter on intent classification
+     * @param includeGenAIRag whether GenAI RAG actions should be included
+     *
+     * @return list of MongoDB Bson filters to apply in aggregation pipelines
      */
-    fun countUserActions(
-        namespace: String,
-        applicationIds: Set<String>,
-        fromDate: ZonedDateTime? = null,
-        toDate: ZonedDateTime? = null,
+
+    private fun buildUserActionFilters(
+        fromDate: ZonedDateTime?,
+        toDate: ZonedDateTime?,
         intentType: IntentTypeEnum,
         includeGenAIRag: Boolean,
-    ): List<CountResult> {
+    ): List<Bson> {
         val filters =
             mutableListOf<Bson>(
                 eq("stories.actions.playerId.type", "user"),
@@ -1197,7 +1203,86 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
             else -> {}
         }
 
-        return runBlocking { buildAndExecuteCountPipeline(namespace, applicationIds, filters) }
+        return filters
+    }
+
+    /**
+     * Counts user actions grouped by applicationId and day.
+     *
+     * Each action is aggregated per application and per calendar day
+     * (based on action timestamp truncated to day precision in Europe/Paris timezone).
+     *
+     * @param namespace the namespace
+     * @param applicationIds the set of application configurations to include
+     * @param fromDate optional start date (inclusive)
+     * @param toDate optional end date (inclusive)
+     * @param intentType filter on intent classification (KNOWN / UNKNOWN / all)
+     * @param includeGenAIRag whether to include GenAI RAG user actions
+     *
+     * @return counts grouped by applicationId and date (yyyy-MM-dd)
+     */
+    fun countUserActionsByDate(
+        namespace: String,
+        applicationIds: Set<String>,
+        fromDate: ZonedDateTime? = null,
+        toDate: ZonedDateTime? = null,
+        intentType: IntentTypeEnum,
+        includeGenAIRag: Boolean,
+    ): List<CountByDateResult> {
+        val filters =
+            buildUserActionFilters(
+                fromDate = fromDate,
+                toDate = toDate,
+                intentType = intentType,
+                includeGenAIRag = includeGenAIRag,
+            )
+
+        return runBlocking {
+            buildAndExecuteCountByDatePipeline(
+                namespace,
+                applicationIds,
+                filters,
+            )
+        }
+    }
+
+    /**
+     * Counts user actions within dialogs for a given namespace and set of applications.
+     *
+     * Aggregation is performed per applicationId without date grouping.
+     *
+     * @param namespace the namespace
+     * @param applicationIds the set of application configurations
+     * @param fromDate optional start date (inclusive)
+     * @param toDate optional end date (inclusive)
+     * @param intentType filter on intent classification (KNOWN / UNKNOWN / all)
+     * @param includeGenAIRag whether to include GenAI RAG user actions in the count
+     *
+     * @return counts grouped by applicationId
+     */
+    fun countUserActions(
+        namespace: String,
+        applicationIds: Set<String>,
+        fromDate: ZonedDateTime? = null,
+        toDate: ZonedDateTime? = null,
+        intentType: IntentTypeEnum,
+        includeGenAIRag: Boolean,
+    ): List<CountResult> {
+        val filters =
+            buildUserActionFilters(
+                fromDate = fromDate,
+                toDate = toDate,
+                intentType = intentType,
+                includeGenAIRag = includeGenAIRag,
+            )
+
+        return runBlocking {
+            buildAndExecuteCountPipeline(
+                namespace,
+                applicationIds,
+                filters,
+            )
+        }
     }
 
     /**
@@ -1256,6 +1341,61 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 result.find { it.applicationId == appId } ?: CountResult(appId, 0)
             }
         return resultByAppId
+    }
+
+    private fun buildCountByDatePipeline(
+        namespace: String,
+        applicationIds: Set<String>,
+        filters: List<Bson>,
+    ): List<Bson> =
+        listOf(
+            match(
+                and(
+                    DialogCol::namespace eq namespace,
+                    DialogCol::applicationIds `in` applicationIds,
+                ),
+            ),
+            unwind("\$stories"),
+            unwind("\$stories.actions"),
+            match(and(filters)),
+            group(
+                Document(
+                    "applicationId",
+                    "\$stories.actions.applicationId",
+                ).append(
+                    "date",
+                    Document(
+                        "\$dateTrunc",
+                        Document("date", "\$stories.actions.date")
+                            .append("unit", "day")
+                            .append("timezone", "Europe/Paris"),
+                    ),
+                ),
+                sum("total", 1L),
+            ),
+            project(
+                Document()
+                    .append("applicationId", "\$_id.applicationId")
+                    .append(
+                        "date",
+                        Document(
+                            "\$dateToString",
+                            Document("format", "%Y-%m-%d")
+                                .append("date", "\$_id.date")
+                                .append("timezone", "Europe/Paris"),
+                        ),
+                    )
+                    .append("total", "\$total"),
+            ),
+        )
+
+    private suspend fun buildAndExecuteCountByDatePipeline(
+        namespace: String,
+        applicationIds: Set<String>,
+        filters: List<Bson>,
+    ): List<CountByDateResult> {
+        val pipeline = buildCountByDatePipeline(namespace, applicationIds, filters)
+        return dialogCol.aggregate<CountByDateResult>(pipeline).toList()
     }
 
     private fun applyDateFilters(
@@ -1336,9 +1476,9 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 nlpModel = query.applicationName,
             ).map { it.applicationId }.toSet()
 
-        // Get all user actions, including GenAI RAG interactions.
-        val allUserActions =
-            countUserActions(
+        // Get all user actions, including GenAI RAG interactions (by applicationId and date).
+        val allUserActionsByDate =
+            countUserActionsByDate(
                 namespace = query.namespace,
                 applicationIds = applicationIds,
                 fromDate = query.from,
@@ -1346,6 +1486,8 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
                 intentType = IntentTypeEnum.ALL,
                 includeGenAIRag = true,
             )
+
+        val allUserActions = allUserActionsByDate.toCountResults()
 
         // Get all user actions, excluding GenAI RAG interactions.
         val allUserActionsExceptRag =
@@ -1420,6 +1562,7 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
 
         return DialogStatsQueryResult(
             allUserActions = allUserActions,
+            allUserActionsByDate = allUserActionsByDate,
             allUserActionsExceptRag = allUserActionsExceptRag,
             allUserRagActions = allUserRagActions,
             knownIntentUserActions = allUserActionsOnlyKnownIntent,
@@ -1429,4 +1572,13 @@ internal object UserTimelineMongoDAO : UserTimelineDAO, UserReportDAO, DialogRep
             allFeedbackDown = allFeedbackDown,
         )
     }
+
+    fun List<CountByDateResult>.toCountResults(): List<CountResult> =
+        groupBy { it.applicationId }
+            .map { (applicationId, results) ->
+                CountResult(
+                    applicationId = applicationId,
+                    total = results.sumOf { it.total },
+                )
+            }
 }


### PR DESCRIPTION
Ticket : [DERCBOT-1822](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1822)

### Goal
Fix the “Number of user messages” chart in Custom Metrics so it counts real user messages, instead of relying on flow transition stats that can overcount messages.

### Details
- Count user messages from dialog user actions, which is the same source of truth used by dialog stats
- Add a dedicated endpoint for user messages by date: `/dialogs/stats/messages-by-date`
- Keep the chart response compatible with the existing Custom Metrics chart format
- Preserve date range filtering and daily aggregation
- Exclude test configurations from the chart in REC/PROD

### Why
The previous chart used flow transition stats. In some cases, especially with RAG dialogs, a single user message can create multiple flow transition stat entries, which makes the chart display more messages than actually exist.
Counting dialog user actions directly avoids this overcount and aligns the chart with the “Total user messages” stats.