### PR TITLE
[DEERCBOT-1904] Manage business glossary, excluded topics, and covered topics

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       # Checkout the repository at the pushed commit
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       # Setup Python
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
@@ -54,7 +54,7 @@ jobs:
 
       # Upload the built static files as an artifact for GitHub Pages
       - name: Upload static files as artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@v3
         with:
           # Path to the directory containing the built site
           path: docs/site
@@ -76,4 +76,4 @@ jobs:
       # Deploy the uploaded artifact to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       # Checkout the repository at the pushed commit
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       # Setup Python
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -54,7 +54,7 @@ jobs:
 
       # Upload the built static files as an artifact for GitHub Pages
       - name: Upload static files as artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           # Path to the directory containing the built site
           path: docs/site
@@ -76,4 +76,4 @@ jobs:
       # Deploy the uploaded artifact to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -21,11 +21,11 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       doc: ${{ steps.filter.outputs.doc }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@# v4
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -55,12 +55,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
         
       - name: Setup Java JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -85,12 +85,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Setup Java JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -116,12 +116,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -153,24 +153,24 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@v1
         with:
           version: latest
           virtualenvs-create: true
           virtualenvs-in-project: true
           
       - name: Cache Poetry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v4
         with:
           path: |
             gen-ai/orchestrator-server/src/main/python/server/.venv
@@ -208,18 +208,18 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.13'
           cache: 'pip'
           
       - name: Cache pre-commit
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -21,11 +21,11 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       doc: ${{ steps.filter.outputs.doc }}
     steps:
-      - uses: actions/checkout@# v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -55,12 +55,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
         
       - name: Setup Java JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -85,12 +85,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Setup Java JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -116,12 +116,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
           cache: 'pip'
@@ -153,24 +153,24 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
           
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
           version: latest
           virtualenvs-create: true
           virtualenvs-in-project: true
           
       - name: Cache Poetry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             gen-ai/orchestrator-server/src/main/python/server/.venv
@@ -208,18 +208,18 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
         
       - name: Setup Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
           cache: 'pip'
           
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -163,7 +163,7 @@ jobs:
           python-version: '3.13'
           
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: latest
           virtualenvs-create: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@v0.5.3
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
         with:
           config: .github/zizmor.yml
           advanced-security: "false"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+      - uses: zizmorcore/zizmor-action@v0.5.3
         with:
           config: .github/zizmor.yml
           advanced-security: "false"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,6 @@ repos:
           - "--ignore-vuln"
           - "GHSA-5239-wwwm-4pmq"
         additional_dependencies:
-          - "pip>=26.0"
+          - "pip>=26.1.2"
           - "filelock>=3.20.3"
           - "urllib3>=2.6.3"

--- a/bot/admin/server/src/main/kotlin/BotAdminService.kt
+++ b/bot/admin/server/src/main/kotlin/BotAdminService.kt
@@ -39,6 +39,7 @@ import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
 import ai.tock.bot.admin.bot.BotConfiguration
 import ai.tock.bot.admin.bot.BotVersion
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
 import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfigurationDAO
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfigurationDAO
 import ai.tock.bot.admin.bot.rag.BotRAGConfiguration
@@ -146,6 +147,7 @@ object BotAdminService {
     private val userReportDAO: UserReportDAO get() = injector.provide()
     internal val dialogReportDAO: DialogReportDAO get() = injector.provide()
     private val applicationConfigurationDAO: BotApplicationConfigurationDAO get() = injector.provide()
+    private val businessRulesConfigurationDAO: BotBusinessRulesConfigurationDAO get() = injector.provide()
     private val ragConfigurationDAO: BotRAGConfigurationDAO get() = injector.provide()
     private val sentenceGenerationConfigurationDAO: BotSentenceGenerationConfigurationDAO get() = injector.provide()
     private val observabilityConfigurationDAO: BotObservabilityConfigurationDAO get() = injector.provide()
@@ -1621,6 +1623,11 @@ object BotAdminService {
             app.name,
         ).forEach { story ->
             storyDefinitionDAO.delete(story)
+        }
+
+        // delete the Business Rules configuration
+        businessRulesConfigurationDAO.findByNamespaceAndBotId(app.namespace, app.name)?.let { config ->
+            businessRulesConfigurationDAO.delete(config._id)
         }
 
         // delete the RAG configuration

--- a/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
+++ b/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.model.genai
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
+import org.litote.kmongo.toId
+
+data class BotBusinessRulesConfigurationDTO(
+    val id: String? = null,
+    val namespace: String,
+    val botId: String,
+    val businessLexicon: String = "",
+    val coveredTopics: List<String> = emptyList(),
+    val excludedTopics: List<String> = emptyList(),
+) {
+    constructor(configuration: BotBusinessRulesConfiguration) : this(
+        id = configuration._id.toString(),
+        namespace = configuration.namespace,
+        botId = configuration.botId,
+        businessLexicon = configuration.businessLexicon,
+        coveredTopics = configuration.coveredTopics,
+        excludedTopics = configuration.excludedTopics,
+    )
+
+    fun toBotBusinessRulesConfiguration(existingId: Id<BotBusinessRulesConfiguration>? = null): BotBusinessRulesConfiguration =
+        BotBusinessRulesConfiguration(
+            _id = existingId ?: id?.toId() ?: newId(),
+            namespace = namespace,
+            botId = botId,
+            businessLexicon = businessLexicon,
+            coveredTopics = coveredTopics,
+            excludedTopics = excludedTopics,
+        )
+}

--- a/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
+++ b/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
@@ -17,34 +17,51 @@
 package ai.tock.bot.admin.model.genai
 
 import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
 import org.litote.kmongo.Id
 import org.litote.kmongo.newId
 import org.litote.kmongo.toId
 
 data class BotBusinessRulesConfigurationDTO(
     val id: String? = null,
-    val namespace: String,
-    val botId: String,
-    val businessLexicon: String = "",
     val coveredTopics: List<String> = emptyList(),
     val excludedTopics: List<String> = emptyList(),
+    val lexiconGroups: List<BotBusinessRulesLexiconGroupDTO> = emptyList(),
 ) {
     constructor(configuration: BotBusinessRulesConfiguration) : this(
         id = configuration._id.toString(),
-        namespace = configuration.namespace,
-        botId = configuration.botId,
-        businessLexicon = configuration.businessLexicon,
         coveredTopics = configuration.coveredTopics,
         excludedTopics = configuration.excludedTopics,
+        lexiconGroups = configuration.lexiconGroups.map { BotBusinessRulesLexiconGroupDTO(it) },
     )
 
-    fun toBotBusinessRulesConfiguration(existingId: Id<BotBusinessRulesConfiguration>? = null): BotBusinessRulesConfiguration =
+    fun toBotBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+        existingId: Id<BotBusinessRulesConfiguration>? = null,
+    ): BotBusinessRulesConfiguration =
         BotBusinessRulesConfiguration(
             _id = existingId ?: id?.toId() ?: newId(),
             namespace = namespace,
             botId = botId,
-            businessLexicon = businessLexicon,
             coveredTopics = coveredTopics,
             excludedTopics = excludedTopics,
+            lexiconGroups = lexiconGroups.map { it.toBotBusinessRulesLexiconGroup() },
+        )
+}
+
+data class BotBusinessRulesLexiconGroupDTO(
+    val id: Int? = null,
+    val terms: List<String> = emptyList(),
+) {
+    constructor(group: BotBusinessRulesLexiconGroup) : this(
+        id = group.id,
+        terms = group.terms,
+    )
+
+    fun toBotBusinessRulesLexiconGroup(): BotBusinessRulesLexiconGroup =
+        BotBusinessRulesLexiconGroup(
+            id = requireNotNull(id) { "Lexicon group id must be assigned before conversion" },
+            terms = terms,
         )
 }

--- a/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
+++ b/bot/admin/server/src/main/kotlin/model/genai/BotBusinessRulesConfigurationDTO.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.model.genai
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
+import org.litote.kmongo.Id
+import org.litote.kmongo.newId
+import org.litote.kmongo.toId
+
+data class BotBusinessRulesConfigurationDTO(
+    val id: String? = null,
+    val coveredTopics: List<String> = emptyList(),
+    val excludedTopics: List<String> = emptyList(),
+    val lexiconGroups: List<BotBusinessRulesLexiconGroupDTO> = emptyList(),
+) {
+    constructor(configuration: BotBusinessRulesConfiguration) : this(
+        id = configuration._id.toString(),
+        coveredTopics = configuration.coveredTopics,
+        excludedTopics = configuration.excludedTopics,
+        lexiconGroups = configuration.lexiconGroups.map { BotBusinessRulesLexiconGroupDTO(it) },
+    )
+
+    fun toBotBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+        existingId: Id<BotBusinessRulesConfiguration>? = null,
+    ): BotBusinessRulesConfiguration =
+        BotBusinessRulesConfiguration(
+            _id = existingId ?: id?.toId() ?: newId(),
+            namespace = namespace,
+            botId = botId,
+            coveredTopics = coveredTopics,
+            excludedTopics = excludedTopics,
+            lexiconGroups = lexiconGroups.map { it.toBotBusinessRulesLexiconGroup() },
+        )
+}
+
+data class BotBusinessRulesLexiconGroupDTO(
+    val id: Int? = null,
+    val terms: List<String> = emptyList(),
+) {
+    constructor(group: BotBusinessRulesLexiconGroup) : this(
+        id = group.id,
+        terms = group.terms,
+    )
+
+    fun toBotBusinessRulesLexiconGroup(): BotBusinessRulesLexiconGroup =
+        BotBusinessRulesLexiconGroup(
+            id = requireNotNull(id) { "Lexicon group id must be assigned before conversion" },
+            terms = terms,
+        )
+}

--- a/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.BotAdminService
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.admin.model.genai.BotBusinessRulesConfigurationDTO
+import ai.tock.shared.exception.rest.BadRequestException
+import ai.tock.shared.injector
+import ai.tock.shared.provide
+import ai.tock.shared.vertx.WebVerticle
+import com.mongodb.MongoWriteException
+import mu.KLogger
+import mu.KotlinLogging
+
+/**
+ * Service that manages bot business rules used by generative AI features.
+ */
+object BusinessRulesService {
+    private val logger: KLogger = KotlinLogging.logger {}
+    private val businessRulesConfigurationDAO: BotBusinessRulesConfigurationDAO get() = injector.provide()
+
+    /**
+     * Get the Business Rules configuration
+     * @param namespace: the namespace
+     * @param botId: the bot ID
+     */
+    fun getBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration? {
+        return businessRulesConfigurationDAO.findByNamespaceAndBotId(namespace, botId)
+    }
+
+    /**
+     * Save Business Rules configuration.
+     * @param businessRulesConfig : the business rules configuration to create or update
+     * @return [BotBusinessRulesConfiguration]
+     */
+    fun saveBusinessRules(businessRulesConfig: BotBusinessRulesConfigurationDTO): BotBusinessRulesConfiguration {
+        BotAdminService.getBotConfigurationsByNamespaceAndBotId(businessRulesConfig.namespace, businessRulesConfig.botId).firstOrNull()
+            ?: WebVerticle.badRequest("No bot configuration is defined yet [namespace: ${businessRulesConfig.namespace}, botId = ${businessRulesConfig.botId}]")
+
+        logger.info {
+            "Saving the Business Rules Configuration [namespace: ${businessRulesConfig.namespace}, botId: ${businessRulesConfig.botId}]"
+        }
+        return saveBusinessRulesConfiguration(businessRulesConfig)
+    }
+
+    private fun saveBusinessRulesConfiguration(businessRulesConfiguration: BotBusinessRulesConfigurationDTO): BotBusinessRulesConfiguration {
+        val existingConfiguration =
+            businessRulesConfigurationDAO.findByNamespaceAndBotId(
+                businessRulesConfiguration.namespace,
+                businessRulesConfiguration.botId,
+            )
+        val businessRulesConfig = businessRulesConfiguration.toBotBusinessRulesConfiguration(existingConfiguration?._id)
+
+        return try {
+            businessRulesConfigurationDAO.save(businessRulesConfig)
+        } catch (e: MongoWriteException) {
+            throw BadRequestException(e.message ?: "Business Rules Configuration: registration failed on mongo ")
+        } catch (e: Exception) {
+            throw BadRequestException(e.message ?: "Business Rules Configuration: registration failed ")
+        }
+    }
+}

--- a/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
@@ -19,6 +19,7 @@ package ai.tock.bot.admin.service
 import ai.tock.bot.admin.BotAdminService
 import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
 import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
 import ai.tock.bot.admin.model.genai.BotBusinessRulesConfigurationDTO
 import ai.tock.shared.exception.rest.BadRequestException
 import ai.tock.shared.injector
@@ -49,26 +50,44 @@ object BusinessRulesService {
 
     /**
      * Save Business Rules configuration.
-     * @param businessRulesConfig : the business rules configuration to create or update
+     * @param namespace the namespace
+     * @param botId the bot ID
+     * @param businessRulesConfig the business rules configuration to create or update
      * @return [BotBusinessRulesConfiguration]
      */
-    fun saveBusinessRules(businessRulesConfig: BotBusinessRulesConfigurationDTO): BotBusinessRulesConfiguration {
-        BotAdminService.getBotConfigurationsByNamespaceAndBotId(businessRulesConfig.namespace, businessRulesConfig.botId).firstOrNull()
-            ?: WebVerticle.badRequest("No bot configuration is defined yet [namespace: ${businessRulesConfig.namespace}, botId = ${businessRulesConfig.botId}]")
+    fun saveBusinessRules(
+        namespace: String,
+        botId: String,
+        businessRulesConfig: BotBusinessRulesConfigurationDTO,
+    ): BotBusinessRulesConfiguration {
+        BotAdminService.getBotConfigurationsByNamespaceAndBotId(namespace, botId).firstOrNull()
+            ?: WebVerticle.badRequest("No bot configuration is defined yet [namespace: $namespace, botId = $botId]")
 
         logger.info {
-            "Saving the Business Rules Configuration [namespace: ${businessRulesConfig.namespace}, botId: ${businessRulesConfig.botId}]"
+            "Saving the Business Rules Configuration [namespace: $namespace, botId: $botId]"
         }
-        return saveBusinessRulesConfiguration(businessRulesConfig)
+        return saveBusinessRulesConfiguration(namespace, botId, businessRulesConfig)
     }
 
-    private fun saveBusinessRulesConfiguration(businessRulesConfiguration: BotBusinessRulesConfigurationDTO): BotBusinessRulesConfiguration {
+    private fun saveBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+        businessRulesConfiguration: BotBusinessRulesConfigurationDTO,
+    ): BotBusinessRulesConfiguration {
         val existingConfiguration =
             businessRulesConfigurationDAO.findByNamespaceAndBotId(
-                businessRulesConfiguration.namespace,
-                businessRulesConfiguration.botId,
+                namespace,
+                botId,
             )
-        val businessRulesConfig = businessRulesConfiguration.toBotBusinessRulesConfiguration(existingConfiguration?._id)
+        val businessRulesConfigurationWithLexiconGroupIds =
+            businessRulesConfiguration.withAssignedLexiconGroupIds(existingConfiguration?.lexiconGroups.orEmpty())
+
+        val businessRulesConfig =
+            businessRulesConfigurationWithLexiconGroupIds.toBotBusinessRulesConfiguration(
+                namespace = namespace,
+                botId = botId,
+                existingId = existingConfiguration?._id,
+            )
 
         return try {
             businessRulesConfigurationDAO.save(businessRulesConfig)
@@ -77,5 +96,31 @@ object BusinessRulesService {
         } catch (e: Exception) {
             throw BadRequestException(e.message ?: "Business Rules Configuration: registration failed ")
         }
+    }
+
+    private fun BotBusinessRulesConfigurationDTO.withAssignedLexiconGroupIds(existingLexiconGroups: List<BotBusinessRulesLexiconGroup>): BotBusinessRulesConfigurationDTO {
+        val providedIds = lexiconGroups.mapNotNull { it.id }
+        val duplicatedIds =
+            providedIds.groupingBy { it }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+
+        if (duplicatedIds.isNotEmpty()) {
+            throw BadRequestException("Duplicate lexicon group id(s): ${duplicatedIds.joinToString()}")
+        }
+
+        if (providedIds.any { it <= 0 }) {
+            throw BadRequestException("Lexicon group ids must be positive")
+        }
+
+        var nextId = (existingLexiconGroups.map { it.id } + providedIds).maxOrNull()?.plus(1) ?: 1
+
+        return copy(
+            lexiconGroups =
+                lexiconGroups.map { group ->
+                    group.copy(id = group.id ?: nextId++)
+                },
+        )
     }
 }

--- a/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
+++ b/bot/admin/server/src/main/kotlin/service/BusinessRulesService.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.service
+
+import ai.tock.bot.admin.BotAdminService
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
+import ai.tock.bot.admin.model.genai.BotBusinessRulesConfigurationDTO
+import ai.tock.shared.exception.rest.BadRequestException
+import ai.tock.shared.injector
+import ai.tock.shared.provide
+import ai.tock.shared.vertx.WebVerticle
+import com.mongodb.MongoWriteException
+import mu.KLogger
+import mu.KotlinLogging
+
+/**
+ * Service that manages bot business rules used by generative AI features.
+ */
+object BusinessRulesService {
+    private val logger: KLogger = KotlinLogging.logger {}
+    private val businessRulesConfigurationDAO: BotBusinessRulesConfigurationDAO get() = injector.provide()
+
+    /**
+     * Get the Business Rules configuration
+     * @param namespace: the namespace
+     * @param botId: the bot ID
+     */
+    fun getBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration? {
+        return businessRulesConfigurationDAO.findByNamespaceAndBotId(namespace, botId)
+    }
+
+    /**
+     * Save Business Rules configuration.
+     * @param namespace the namespace
+     * @param botId the bot ID
+     * @param businessRulesConfig the business rules configuration to create or update
+     * @return [BotBusinessRulesConfiguration]
+     */
+    fun saveBusinessRules(
+        namespace: String,
+        botId: String,
+        businessRulesConfig: BotBusinessRulesConfigurationDTO,
+    ): BotBusinessRulesConfiguration {
+        BotAdminService.getBotConfigurationsByNamespaceAndBotId(namespace, botId).firstOrNull()
+            ?: WebVerticle.badRequest("No bot configuration is defined yet [namespace: $namespace, botId = $botId]")
+
+        logger.info {
+            "Saving the Business Rules Configuration [namespace: $namespace, botId: $botId]"
+        }
+        return saveBusinessRulesConfiguration(namespace, botId, businessRulesConfig)
+    }
+
+    private fun saveBusinessRulesConfiguration(
+        namespace: String,
+        botId: String,
+        businessRulesConfiguration: BotBusinessRulesConfigurationDTO,
+    ): BotBusinessRulesConfiguration {
+        val existingConfiguration =
+            businessRulesConfigurationDAO.findByNamespaceAndBotId(
+                namespace,
+                botId,
+            )
+        val businessRulesConfigurationWithLexiconGroupIds =
+            businessRulesConfiguration.withAssignedLexiconGroupIds(existingConfiguration?.lexiconGroups.orEmpty())
+
+        val businessRulesConfig =
+            businessRulesConfigurationWithLexiconGroupIds.toBotBusinessRulesConfiguration(
+                namespace = namespace,
+                botId = botId,
+                existingId = existingConfiguration?._id,
+            )
+
+        return try {
+            businessRulesConfigurationDAO.save(businessRulesConfig)
+        } catch (e: MongoWriteException) {
+            throw BadRequestException(e.message ?: "Business Rules Configuration: registration failed on mongo ")
+        } catch (e: Exception) {
+            throw BadRequestException(e.message ?: "Business Rules Configuration: registration failed ")
+        }
+    }
+
+    private fun BotBusinessRulesConfigurationDTO.withAssignedLexiconGroupIds(existingLexiconGroups: List<BotBusinessRulesLexiconGroup>): BotBusinessRulesConfigurationDTO {
+        val providedIds = lexiconGroups.mapNotNull { it.id }
+        val duplicatedIds =
+            providedIds.groupingBy { it }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+
+        if (duplicatedIds.isNotEmpty()) {
+            throw BadRequestException("Duplicate lexicon group id(s): ${duplicatedIds.joinToString()}")
+        }
+
+        if (providedIds.any { it <= 0 }) {
+            throw BadRequestException("Lexicon group ids must be positive")
+        }
+
+        var nextId = (existingLexiconGroups.map { it.id } + providedIds).maxOrNull()?.plus(1) ?: 1
+
+        return copy(
+            lexiconGroups =
+                lexiconGroups.map { group ->
+                    group.copy(id = group.id ?: nextId++)
+                },
+        )
+    }
+}

--- a/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
@@ -98,10 +98,10 @@ class GenAIVerticle : AbstractNamespaceRetriever() {
                 PATH_CONFIG_BUSINESS_RULES,
                 admin,
             ) { context: RoutingContext, request: BotBusinessRulesConfigurationDTO ->
-                return@blockingJsonPost checkNamespaceAndExecute(context, ::currentContextApp) {
+                return@blockingJsonPost checkNamespaceAndExecute(context, ::currentContextApp) { app ->
                     logger.info { "Saving 'Business Rules' configuration..." }
                     BotBusinessRulesConfigurationDTO(
-                        BusinessRulesService.saveBusinessRules(request),
+                        BusinessRulesService.saveBusinessRules(app.namespace, app.name, request),
                     )
                 }
             }

--- a/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.admin.verticle
 
 import ai.tock.bot.admin.indicators.metric.MetricFilter
+import ai.tock.bot.admin.model.genai.BotBusinessRulesConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotDocumentCompressorConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotObservabilityConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotRAGConfigurationDTO
@@ -25,6 +26,7 @@ import ai.tock.bot.admin.model.genai.BotSentenceGenerationInfoDTO
 import ai.tock.bot.admin.model.genai.BotVectorStoreConfigurationDTO
 import ai.tock.bot.admin.model.genai.PlaygroundRequest
 import ai.tock.bot.admin.model.genai.SentenceGenerationRequest
+import ai.tock.bot.admin.service.BusinessRulesService
 import ai.tock.bot.admin.service.CompletionService
 import ai.tock.bot.admin.service.DocumentCompressorService
 import ai.tock.bot.admin.service.ObservabilityService
@@ -49,6 +51,7 @@ class GenAIVerticle : AbstractNamespaceRetriever() {
         private const val PATH_CONFIG_VECTOR_STORE = "/gen-ai/bots/:botId/configuration/vector-store"
         private const val PATH_CONFIG_VECTOR_OBSERVABILITY = "/gen-ai/bots/:botId/configuration/observability"
         private const val PATH_CONFIG_DOCUMENT_COMPRESSOR = "/gen-ai/bots/:botId/configuration/document-compressor"
+        private const val PATH_CONFIG_BUSINESS_RULES = "/gen-ai/bots/:botId/configuration/business-rules"
 
         // Completion
         private const val PATH_COMPLETION_SENTENCE_GENERATION = "/gen-ai/bots/:botId/completion/sentence-generation"
@@ -87,6 +90,30 @@ class GenAIVerticle : AbstractNamespaceRetriever() {
                 checkNamespaceAndExecute(context, ::currentContextApp) { app ->
                     logger.info { "Deleting 'RAG' configuration..." }
                     RAGService.deleteConfig(app.namespace, app.name)
+                }
+            }
+
+            // ----------------------------------- Config - Business Rules --------------------------------
+            blockingJsonPost(
+                PATH_CONFIG_BUSINESS_RULES,
+                admin,
+            ) { context: RoutingContext, request: BotBusinessRulesConfigurationDTO ->
+                return@blockingJsonPost checkNamespaceAndExecute(context, ::currentContextApp) {
+                    logger.info { "Saving 'Business Rules' configuration..." }
+                    BotBusinessRulesConfigurationDTO(
+                        BusinessRulesService.saveBusinessRules(request),
+                    )
+                }
+            }
+
+            blockingJsonGet(
+                PATH_CONFIG_BUSINESS_RULES,
+                admin,
+            ) { context: RoutingContext ->
+                checkNamespaceAndExecute(context, ::currentContextApp) { app ->
+                    logger.info { "Retrieving 'Business Rules' configuration..." }
+                    BusinessRulesService.getBusinessRulesConfiguration(app.namespace, app.name)
+                        ?.let { BotBusinessRulesConfigurationDTO(it) }
                 }
             }
 

--- a/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
+++ b/bot/admin/server/src/main/kotlin/verticle/GenAIVerticle.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.admin.verticle
 
 import ai.tock.bot.admin.indicators.metric.MetricFilter
+import ai.tock.bot.admin.model.genai.BotBusinessRulesConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotDocumentCompressorConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotObservabilityConfigurationDTO
 import ai.tock.bot.admin.model.genai.BotRAGConfigurationDTO
@@ -25,6 +26,7 @@ import ai.tock.bot.admin.model.genai.BotSentenceGenerationInfoDTO
 import ai.tock.bot.admin.model.genai.BotVectorStoreConfigurationDTO
 import ai.tock.bot.admin.model.genai.PlaygroundRequest
 import ai.tock.bot.admin.model.genai.SentenceGenerationRequest
+import ai.tock.bot.admin.service.BusinessRulesService
 import ai.tock.bot.admin.service.CompletionService
 import ai.tock.bot.admin.service.DocumentCompressorService
 import ai.tock.bot.admin.service.ObservabilityService
@@ -49,6 +51,7 @@ class GenAIVerticle : AbstractNamespaceRetriever() {
         private const val PATH_CONFIG_VECTOR_STORE = "/gen-ai/bots/:botId/configuration/vector-store"
         private const val PATH_CONFIG_VECTOR_OBSERVABILITY = "/gen-ai/bots/:botId/configuration/observability"
         private const val PATH_CONFIG_DOCUMENT_COMPRESSOR = "/gen-ai/bots/:botId/configuration/document-compressor"
+        private const val PATH_CONFIG_BUSINESS_RULES = "/gen-ai/bots/:botId/configuration/business-rules"
 
         // Completion
         private const val PATH_COMPLETION_SENTENCE_GENERATION = "/gen-ai/bots/:botId/completion/sentence-generation"
@@ -87,6 +90,30 @@ class GenAIVerticle : AbstractNamespaceRetriever() {
                 checkNamespaceAndExecute(context, ::currentContextApp) { app ->
                     logger.info { "Deleting 'RAG' configuration..." }
                     RAGService.deleteConfig(app.namespace, app.name)
+                }
+            }
+
+            // ----------------------------------- Config - Business Rules --------------------------------
+            blockingJsonPost(
+                PATH_CONFIG_BUSINESS_RULES,
+                admin,
+            ) { context: RoutingContext, request: BotBusinessRulesConfigurationDTO ->
+                return@blockingJsonPost checkNamespaceAndExecute(context, ::currentContextApp) { app ->
+                    logger.info { "Saving 'Business Rules' configuration..." }
+                    BotBusinessRulesConfigurationDTO(
+                        BusinessRulesService.saveBusinessRules(app.namespace, app.name, request),
+                    )
+                }
+            }
+
+            blockingJsonGet(
+                PATH_CONFIG_BUSINESS_RULES,
+                admin,
+            ) { context: RoutingContext ->
+                checkNamespaceAndExecute(context, ::currentContextApp) { app ->
+                    logger.info { "Retrieving 'Business Rules' configuration..." }
+                    BusinessRulesService.getBusinessRulesConfiguration(app.namespace, app.name)
+                        ?.let { BotBusinessRulesConfigurationDTO(it) }
                 }
             }
 

--- a/bot/admin/web/src/app/bot-admin-app.component.ts
+++ b/bot/admin/web/src/app/bot-admin-app.component.ts
@@ -214,6 +214,11 @@ export class BotAdminAppComponent implements AuthListener, OnInit, OnDestroy {
             hidden: !this.state.hasRole(UserRole.admin)
           },
           {
+            link: '/rag/prompt-context',
+            title: 'Rag prompt context',
+            icon: 'journal-text'
+          },
+          {
             link: '/rag/exclusions',
             title: 'Sentences Rag exclusions',
             icon: 'lightbulb-off'

--- a/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.html
+++ b/bot/admin/web/src/app/configuration/vector-db-settings/vector-db-settings.component.html
@@ -14,64 +14,62 @@
   ~ limitations under the License.
   -->
 
-<tock-sticky-menu [offset]="50">
-  <div class="d-flex">
-    <h1 class="flex-grow-1 mb-0">Application vector database settings</h1>
+<div class="d-flex">
+  <h1 class="flex-grow-1 mb-0">Application vector database settings</h1>
 
-    <section class="grid-actions">
-      <button
-        [disabled]="!hasExportableData"
-        nbButton
-        ghost
-        shape="round"
-        nbTooltip="Export Vector DB settings dump"
-        (click)="exportSettings()"
-      >
-        <nb-icon icon="download"></nb-icon>
-      </button>
-      <button
-        nbButton
-        ghost
-        shape="round"
-        nbTooltip="Import Vector DB settings dump"
-        (click)="importSettings()"
-      >
-        <nb-icon icon="upload"></nb-icon>
-      </button>
+  <section class="grid-actions">
+    <button
+      [disabled]="!hasExportableData"
+      nbButton
+      ghost
+      shape="round"
+      nbTooltip="Export Vector DB settings dump"
+      (click)="exportSettings()"
+    >
+      <nb-icon icon="download"></nb-icon>
+    </button>
+    <button
+      nbButton
+      ghost
+      shape="round"
+      nbTooltip="Import Vector DB settings dump"
+      (click)="importSettings()"
+    >
+      <nb-icon icon="upload"></nb-icon>
+    </button>
 
-      <button
-        *ngIf="settingsBackup && form.dirty"
-        nbButton
-        ghost
-        status="primary"
-        nbTooltip="Cancel modifications"
-        (click)="cancel()"
-      >
-        <nb-icon icon="x-circle"></nb-icon>
-        CANCEL
-      </button>
-      <button
-        *ngIf="form.dirty"
-        nbButton
-        status="primary"
-        nbTooltip="Save settings"
-        (click)="submit()"
-      >
-        <nb-icon icon="floppy"></nb-icon>
-        SAVE
-      </button>
-    </section>
-  </div>
+    <button
+      *ngIf="settingsBackup && form.dirty"
+      nbButton
+      ghost
+      status="primary"
+      nbTooltip="Cancel modifications"
+      (click)="cancel()"
+    >
+      <nb-icon icon="x-circle"></nb-icon>
+      CANCEL
+    </button>
+    <button
+      *ngIf="form.dirty"
+      nbButton
+      status="primary"
+      nbTooltip="Save settings"
+      (click)="submit()"
+    >
+      <nb-icon icon="floppy"></nb-icon>
+      SAVE
+    </button>
+  </section>
+</div>
 
-  <small>
-    Optional vector database provider. By default, the vector database used to index the Rag documents is defined in environment variables,
-    but if you need a specific vector database for this application, you can provide its configuration here. This configuration will
-    override the environment configuration for the application
-    <b
-      ><i>{{ state.currentApplication.name }}</i></b
-    >.
-  </small>
-</tock-sticky-menu>
+<small>
+  Optional vector database provider. By default, the vector database used to index the Rag documents is defined in environment variables,
+  but if you need a specific vector database for this application, you can provide its configuration here. This configuration will override
+  the environment configuration for the application
+  <b
+    ><i>{{ state.currentApplication.name }}</i></b
+  >.
+</small>
 
 <tock-no-data-found
   *ngIf="configurations?.length === 0"

--- a/bot/admin/web/src/app/core/dirty-state.service.ts
+++ b/bot/admin/web/src/app/core/dirty-state.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+export interface DirtyStateGuard {
+  canDeactivate: () => Observable<boolean> | boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DirtyStateService {
+  private _guard: DirtyStateGuard | null = null;
+
+  register(guard: DirtyStateGuard): void {
+    this._guard = guard;
+  }
+
+  unregister(): void {
+    this._guard = null;
+  }
+
+  confirm(): Observable<boolean> {
+    if (!this._guard) return of(true);
+    const result = this._guard.canDeactivate();
+    return result instanceof Observable ? result : of(result);
+  }
+}

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.html
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.html
@@ -1,0 +1,448 @@
+<tock-sticky-menu [offset]="50">
+  <div class="d-flex flex-wrap align-items-center">
+    <h1 class="flex-grow-1 mb-0">Rag prompt context</h1>
+
+    <section class="grid-actions">
+      <button
+        [disabled]="!hasExportableData"
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Export prompt context settings dump"
+        (click)="exportSettings()"
+      >
+        <nb-icon icon="download"></nb-icon>
+      </button>
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Import prompt context settings dump"
+        (click)="importSettings()"
+      >
+        <nb-icon icon="upload"></nb-icon>
+      </button>
+
+      <ng-container *ngIf="isDirty">
+        <button
+          nbButton
+          ghost
+          status="basic"
+          nbTooltip="Discard changes and revert to last saved state"
+          [disabled]="isSaving"
+          (click)="cancel()"
+        >
+          <nb-icon icon="x-circle"></nb-icon>
+          CANCEL
+        </button>
+
+        <button
+          nbButton
+          status="primary"
+          [nbTooltip]="isValid ? 'Save settings' : 'Some lexicon groups have fewer than 2 terms'"
+          [nbSpinner]="isSaving"
+          [disabled]="isSaving || !isValid"
+          (click)="save()"
+        >
+          <nb-icon icon="floppy"></nb-icon>
+          SAVE CHANGES
+        </button>
+      </ng-container>
+    </section>
+  </div>
+
+  <small class="sticky-menu-scrolled-hidden"
+    >These elements are injected dynamically into the RAG chain prompt. Changes take effect on new queries after saving.</small
+  >
+</tock-sticky-menu>
+
+<div class="mt-3">
+  <!-- TOPICS COVERED -->
+  <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('covered')"
+    >
+      <div class="text-success">
+        <nb-icon icon="check-circle"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Topics covered</span>
+        <span class="font-size-small">Topics used to categorize conversations </span>
+      </div>
+      <nb-badge
+        [text]="coveredTopics.length.toString()"
+        status="success"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.covered ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.covered">
+      <p class="font-size-small text-muted">
+        See RAG Topics classification in the <a routerLink="/business-metrics/board">Custom Metrics</a> view. <br />
+        Note that questions not covered by these topics will still be processed, unless they match an excluded topic below or are
+        specifically handled at the prompt level.
+      </p>
+      <div>
+        <nb-tag-list
+          (tagRemove)="removeTag('covered', $event)"
+          class="mb-3"
+          *ngIf="coveredTopics.length"
+        >
+          <nb-tag
+            *ngFor="let topic of coveredTopics"
+            [text]="topic"
+            status="success"
+            [removable]="isTopicRemovable(topic)"
+          ></nb-tag>
+        </nb-tag-list>
+
+        <div
+          class="d-flex gap-1"
+          *ngIf="coveredTopics.length < 50"
+        >
+          <input
+            nbInput
+            type="text"
+            maxlength="50"
+            placeholder="Add a covered topic…"
+            #coveredInput
+            fullWidth
+            (keyup.enter)="addTag('covered', coveredInput)"
+          />
+          <button
+            nbButton
+            outline
+            status="primary"
+            nbTooltip="Add the topic"
+            [disabled]="!coveredInput.value"
+            (click)="addTag('covered', coveredInput)"
+          >
+            <nb-icon icon="plus"></nb-icon> Add
+          </button>
+        </div>
+
+        <div
+          *ngIf="_coveredWarning"
+          class="text-warning"
+        >
+          {{ _coveredWarning }}
+        </div>
+      </div>
+    </nb-card-body>
+  </nb-card>
+
+  <!-- TOPICS EXCLUDED -->
+  <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('excluded')"
+    >
+      <div class="text-danger">
+        <nb-icon icon="x-circle"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Excluded topics</span>
+        <span class="font-size-small">Subjects outside the bot's scope of competence</span>
+      </div>
+
+      <nb-badge
+        [text]="excludedTopics.length.toString()"
+        status="danger"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.excluded ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.excluded">
+      <p class="font-size-small text-muted">
+        Topics listed here are explicitly mentioned in the prompt as out of scope. The bot will decline questions on these subjects.
+      </p>
+      <div>
+        <nb-tag-list
+          (tagRemove)="removeTag('excluded', $event)"
+          class="mb-3"
+          *ngIf="excludedTopics.length"
+        >
+          <nb-tag
+            *ngFor="let topic of excludedTopics"
+            [text]="topic"
+            status="danger"
+            removable
+          ></nb-tag>
+        </nb-tag-list>
+
+        <div class="d-flex gap-1">
+          <input
+            nbInput
+            type="text"
+            placeholder="Add an excluded topic…"
+            #excludedInput
+            fullWidth
+            (keyup.enter)="addTag('excluded', excludedInput)"
+          />
+          <button
+            nbButton
+            outline
+            status="primary"
+            nbTooltip="Add the excluded topic"
+            [disabled]="!excludedInput.value"
+            (click)="addTag('excluded', excludedInput)"
+          >
+            <nb-icon icon="plus"></nb-icon> Add
+          </button>
+        </div>
+
+        <div
+          *ngIf="_excludedWarning"
+          class="text-warning"
+        >
+          {{ _excludedWarning }}
+        </div>
+      </div>
+    </nb-card-body>
+  </nb-card>
+
+  <!-- BUSINESS LEXICON -->
+  <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('lexicon')"
+    >
+      <div class="text-primary">
+        <nb-icon icon="book"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Business lexicon</span>
+        <span class="font-size-small">Synonym groups and acronym expansions to standardize user queries before search</span>
+      </div>
+
+      <nb-badge
+        [text]="lexiconGroups.length.toString()"
+        status="primary"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.lexicon ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.lexicon">
+      <p class="font-size-small text-muted">
+        When a user asks a question, the bot expands it behind the scenes using these groups — replacing or enriching terms with their
+        synonyms and acronym equivalents before searching. This helps surface relevant documents even when the user's wording doesn't
+        exactly match what's written in the knowledge base.
+      </p>
+
+      <div
+        class="d-flex gap-1 align-items-center mb-3"
+        *ngIf="lexiconGroups.length"
+      >
+        <nb-form-field class="flex-grow-1">
+          <nb-icon
+            nbPrefix
+            icon="search"
+          ></nb-icon>
+          <input
+            nbInput
+            fullWidth
+            fieldSize="small"
+            placeholder="Search term…"
+            [(ngModel)]="lexiconSearch"
+          />
+        </nb-form-field>
+        <span class="font-size-small text-nowrap text-muted">
+          {{ filteredLexiconGroups.length }}
+          <ng-container *ngIf="lexiconSearch">/ {{ lexiconGroups.length }}</ng-container>
+          group{{ lexiconGroups.length !== 1 ? 's' : '' }}
+        </span>
+      </div>
+
+      <tock-no-data-found
+        *ngIf="lexiconSearch && !filteredLexiconGroups.length"
+        title="No matching groups"
+        message="Try a different search term."
+      ></tock-no-data-found>
+
+      <div class="pcs-lex-list">
+        <nb-card
+          *ngFor="let group of filteredLexiconGroups; trackBy: trackById"
+          class="mb-2"
+        >
+          <nb-card-header class="d-flex gap-05 align-items-center p-2">
+            <nb-icon
+              icon="hash"
+              class="font-size-small text-muted"
+            ></nb-icon>
+            <span
+              *ngIf="getLexLabel(group) as label"
+              class="flex-grow-1 font-size-small text-muted"
+              [nbTooltip]="label"
+              >{{ label }}</span
+            >
+            <span
+              *ngIf="!getLexLabel(group)"
+              class="flex-grow-1 font-size-small text-muted font-italic"
+              >Add terms to name this group…</span
+            >
+            <button
+              nbButton
+              ghost
+              shape="round"
+              status="danger"
+              size="tiny"
+              nbTooltip="Delete this group"
+              (click)="deleteLexGroup(group.id)"
+            >
+              <nb-icon icon="trash"></nb-icon>
+            </button>
+          </nb-card-header>
+
+          <nb-card-body class="p-2">
+            <nb-tag-list
+              (tagRemove)="removeTerm(group.id, $event)"
+              *ngIf="group.terms?.length"
+            >
+              <nb-tag
+                *ngFor="let term of group.terms"
+                [text]="term"
+                status="primary"
+                appearance="outline"
+                removable
+              ></nb-tag>
+            </nb-tag-list>
+
+            <div
+              *ngIf="group.terms.length < 2"
+              class="d-flex gap-05 align-items-center font-size-small text-danger mt-1"
+            >
+              <nb-icon icon="exclamation-triangle"></nb-icon>
+              A synonym group must contain at least 2 terms.
+            </div>
+
+            <div class="d-flex align-items-center gap-1 mt-3">
+              <input
+                nbInput
+                type="text"
+                fieldSize="small"
+                placeholder="Add an acronym or synonym…"
+                #addTermInput
+                fullWidth
+                (keyup.enter)="addTerm(group.id, addTermInput)"
+              />
+              <button
+                nbButton
+                outline
+                status="primary"
+                size="small"
+                nbTooltip="Add the term"
+                [disabled]="!addTermInput.value"
+                (click)="addTerm(group.id, addTermInput)"
+              >
+                <nb-icon icon="plus"></nb-icon> Add
+              </button>
+            </div>
+          </nb-card-body>
+        </nb-card>
+      </div>
+
+      <button
+        nbButton
+        ghost
+        fullWidth
+        status="primary"
+        (click)="addLexGroup()"
+      >
+        <nb-icon
+          icon="plus"
+          class="mr-2"
+        ></nb-icon>
+        New synonym group
+      </button>
+    </nb-card-body>
+  </nb-card>
+</div>
+
+<ng-template #importModal>
+  <nb-card>
+    <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+      Import prompt context settings dump
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Cancel"
+        (click)="closeImportModal()"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </nb-card-header>
+
+    <nb-card-body>
+      <form
+        [formGroup]="importForm"
+        (submit)="submitImportSettings()"
+      >
+        <tock-form-control
+          label="Rag prompt context settings dump file"
+          name="importFile"
+          [required]="true"
+          [controls]="fileSource"
+          [showError]="isImportSubmitted"
+        >
+          <tock-file-upload
+            id="importFile"
+            formControlName="fileSource"
+            [autofocus]="true"
+            [fullWidth]="true"
+            [multiple]="false"
+            [fileTypeAccepted]="['json']"
+          ></tock-file-upload>
+        </tock-form-control>
+      </form>
+    </nb-card-body>
+
+    <nb-card-footer class="card-footer-actions">
+      <button
+        nbButton
+        ghost
+        size="small"
+        (click)="closeImportModal()"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        nbButton
+        status="primary"
+        size="small"
+        (click)="submitImportSettings()"
+      >
+        Import
+      </button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.html
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.html
@@ -1,0 +1,497 @@
+<tock-sticky-menu [offset]="50">
+  <div class="d-flex flex-wrap align-items-center">
+    <h1 class="flex-grow-1 mb-0">Rag prompt context</h1>
+
+    <section class="grid-actions">
+      <button
+        [disabled]="!hasExportableData"
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Export prompt context settings dump"
+        (click)="exportSettings()"
+      >
+        <nb-icon icon="download"></nb-icon>
+      </button>
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Import prompt context settings dump"
+        (click)="importSettings()"
+      >
+        <nb-icon icon="upload"></nb-icon>
+      </button>
+
+      <ng-container *ngIf="isDirty">
+        <button
+          nbButton
+          ghost
+          status="basic"
+          nbTooltip="Discard changes and revert to last saved state"
+          [disabled]="isSaving"
+          (click)="cancel()"
+        >
+          <nb-icon icon="x-circle"></nb-icon>
+          CANCEL
+        </button>
+
+        <button
+          nbButton
+          status="primary"
+          [nbTooltip]="isValid ? 'Save settings' : 'Some lexicon groups have fewer than 2 terms'"
+          [nbSpinner]="isSaving"
+          [disabled]="isSaving || !isValid"
+          (click)="save()"
+        >
+          <nb-icon icon="floppy"></nb-icon>
+          SAVE CHANGES
+        </button>
+      </ng-container>
+    </section>
+  </div>
+
+  <small class="sticky-menu-scrolled-hidden"
+    >These elements are injected dynamically into the RAG chain prompt. Changes take effect on new queries after saving.</small
+  >
+</tock-sticky-menu>
+
+<div class="mt-3">
+  <!-- TOPICS COVERED -->
+  <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('covered')"
+    >
+      <div class="text-success">
+        <nb-icon icon="check-circle"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Covered Topics</span>
+        <span class="font-size-small">Topics used to categorize conversations </span>
+      </div>
+      <nb-badge
+        [text]="coveredTopics.length.toString()"
+        status="success"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.covered ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.covered">
+      <p class="font-size-small text-muted">
+        See RAG Topics classification in the <a routerLink="/business-metrics/board">Custom Metrics</a> view. <br />
+        Note that questions not covered by these topics will still be processed, unless they match an excluded topic below or are
+        specifically handled at the prompt level.
+      </p>
+      <div>
+        <nb-tag-list
+          (tagRemove)="removeTag('covered', $event)"
+          class="mb-3"
+          *ngIf="coveredTopics.length"
+        >
+          <nb-tag
+            *ngFor="let topic of coveredTopics"
+            [text]="topic"
+            [status]="isTopicRemovable(topic) ? 'success' : 'primary'"
+            [removable]="isTopicRemovable(topic)"
+            nbTooltip="This topic is mandatory"
+            [nbTooltipDisabled]="isTopicRemovable(topic)"
+          ></nb-tag>
+        </nb-tag-list>
+
+        <div
+          class="d-flex gap-1"
+          *ngIf="coveredTopics.length < maxCoverTopics"
+        >
+          <input
+            nbInput
+            type="text"
+            [maxLength]="coveredTopicMaxLength"
+            placeholder="Add a covered topic…"
+            #coveredInput
+            fullWidth
+            (keyup.enter)="addTag('covered', coveredInput)"
+          />
+
+          <button
+            nbButton
+            outline
+            status="primary"
+            nbTooltip="Add the topic"
+            [disabled]="!coveredInput.value"
+            (click)="addTag('covered', coveredInput)"
+          >
+            <nb-icon icon="plus"></nb-icon> Add
+          </button>
+        </div>
+
+        <div
+          *ngIf="_coveredWarning"
+          class="text-warning"
+        >
+          {{ _coveredWarning }}
+        </div>
+      </div>
+    </nb-card-body>
+
+    <nb-card-footer
+      class="background-basic-color-2"
+      *ngIf="sections.covered && suggestedTopics.length"
+    >
+      <div
+        class="d-flex align-items-center gap-1 pointer pb-1"
+        (click)="showSuggestedTopics = !showSuggestedTopics"
+      >
+        <div class="flex-grow-1">
+          <div class="font-weight-bold text-muted">
+            There {{ suggestedTopics.length === 1 ? 'is' : 'are' }} {{ suggestedTopics.length }} suggested topic{{
+              suggestedTopics.length !== 1 ? 's' : ''
+            }}
+          </div>
+        </div>
+        <nb-icon
+          [icon]="showSuggestedTopics ? 'chevron-up-outline' : 'chevron-down-outline'"
+          pack="nebular-essentials"
+        ></nb-icon>
+      </div>
+
+      <p
+        *ngIf="showSuggestedTopics"
+        class="font-size-small text-muted lineHeight-1 m-0"
+      >
+        The following topic{{ suggestedTopics.length !== 1 ? 's' : '' }} {{ suggestedTopics.length === 1 ? 'was' : 'were' }} suggested by
+        the RAG chain when it couldn't categorize a conversation based on the covered topics list at the moment of execution. Review and add
+        {{ suggestedTopics.length === 1 ? 'it' : 'them' }} to your Covered Topics if relevant to improve future categorization.
+      </p>
+
+      <div
+        *ngIf="showSuggestedTopics"
+        class="d-flex gap-05 row-gap-1 flex-wrap align-items-center mt-2"
+      >
+        <div
+          class="tag tag-small tag-rounded tag-warning tag-hover pointer"
+          *ngFor="let topic of suggestedTopics"
+          nbTooltip="Click to add this suggested topic to the list of covered topics"
+          (click)="addSuggestedTag(topic); $event.stopPropagation()"
+        >
+          {{ topic }}
+        </div>
+      </div>
+    </nb-card-footer>
+  </nb-card>
+
+  <!-- TOPICS EXCLUDED -->
+  <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('excluded')"
+    >
+      <div class="text-danger">
+        <nb-icon icon="x-circle"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Excluded topics</span>
+        <span class="font-size-small">Subjects outside the bot's scope of competence</span>
+      </div>
+
+      <nb-badge
+        [text]="excludedTopics.length.toString()"
+        status="danger"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.excluded ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.excluded">
+      <p class="font-size-small text-muted">
+        Topics listed here are explicitly mentioned in the prompt as out of scope. The bot will decline questions on these subjects.
+      </p>
+      <div>
+        <nb-tag-list
+          (tagRemove)="removeTag('excluded', $event)"
+          class="mb-3"
+          *ngIf="excludedTopics.length"
+        >
+          <nb-tag
+            *ngFor="let topic of excludedTopics"
+            [text]="topic"
+            status="danger"
+            removable
+          ></nb-tag>
+        </nb-tag-list>
+
+        <div class="d-flex gap-1">
+          <input
+            nbInput
+            type="text"
+            placeholder="Add an excluded topic…"
+            #excludedInput
+            fullWidth
+            (keyup.enter)="addTag('excluded', excludedInput)"
+          />
+          <button
+            nbButton
+            outline
+            status="primary"
+            nbTooltip="Add the excluded topic"
+            [disabled]="!excludedInput.value"
+            (click)="addTag('excluded', excludedInput)"
+          >
+            <nb-icon icon="plus"></nb-icon> Add
+          </button>
+        </div>
+
+        <div
+          *ngIf="_excludedWarning"
+          class="text-warning"
+        >
+          {{ _excludedWarning }}
+        </div>
+      </div>
+    </nb-card-body>
+  </nb-card>
+
+  <!-- BUSINESS LEXICON -->
+  <!-- Temporarily commented out pending changes to the backend regarding query expansion before retrieval. DO NOT ERASE -->
+  <!-- <nb-card
+    class="pcs-section shadow-sm mb-3"
+    [nbSpinner]="loading || isSaving"
+  >
+    <nb-card-header
+      class="d-flex gap-1 align-items-center pointer"
+      (click)="toggleSection('lexicon')"
+    >
+      <div class="text-primary">
+        <nb-icon icon="book"></nb-icon>
+      </div>
+
+      <div class="d-flex flex-column flex-grow-1 font-size-medium text-muted">
+        <span class="font-weight-bold">Business lexicon</span>
+        <span class="font-size-small">Synonym groups and acronym expansions to standardize user queries before search</span>
+      </div>
+
+      <nb-badge
+        [text]="lexiconGroups.length.toString()"
+        status="primary"
+        position="top right"
+        class="position-relative"
+      ></nb-badge>
+      <nb-icon
+        [icon]="sections.lexicon ? 'chevron-up-outline' : 'chevron-down-outline'"
+        pack="nebular-essentials"
+      ></nb-icon>
+    </nb-card-header>
+
+    <nb-card-body *ngIf="sections.lexicon">
+      <p class="font-size-small text-muted">
+        When a user asks a question, the bot expands it behind the scenes using these groups — replacing or enriching terms with their
+        synonyms and acronym equivalents before searching. This helps surface relevant documents even when the user's wording doesn't
+        exactly match what's written in the knowledge base.
+      </p>
+
+      <div
+        class="d-flex gap-1 align-items-center mb-3"
+        *ngIf="lexiconGroups.length"
+      >
+        <nb-form-field class="flex-grow-1">
+          <nb-icon
+            nbPrefix
+            icon="search"
+          ></nb-icon>
+          <input
+            nbInput
+            fullWidth
+            fieldSize="small"
+            placeholder="Search term…"
+            [(ngModel)]="lexiconSearch"
+          />
+        </nb-form-field>
+        <span class="font-size-small text-nowrap text-muted">
+          {{ filteredLexiconGroups.length }}
+          <ng-container *ngIf="lexiconSearch">/ {{ lexiconGroups.length }}</ng-container>
+          group{{ lexiconGroups.length !== 1 ? 's' : '' }}
+        </span>
+      </div>
+
+      <tock-no-data-found
+        *ngIf="lexiconSearch && !filteredLexiconGroups.length"
+        title="No matching groups"
+        message="Try a different search term."
+      ></tock-no-data-found>
+
+      <div class="pcs-lex-list">
+        <nb-card
+          *ngFor="let group of filteredLexiconGroups; trackBy: trackById"
+          class="mb-2"
+        >
+          <nb-card-header class="d-flex gap-05 align-items-center p-2">
+            <nb-icon
+              icon="hash"
+              class="font-size-small text-muted"
+            ></nb-icon>
+            <span
+              *ngIf="getLexLabel(group) as label"
+              class="flex-grow-1 font-size-small text-muted"
+              [nbTooltip]="label"
+              >{{ label }}</span
+            >
+            <span
+              *ngIf="!getLexLabel(group)"
+              class="flex-grow-1 font-size-small text-muted font-italic"
+              >Add terms to name this group…</span
+            >
+            <button
+              nbButton
+              ghost
+              shape="round"
+              status="danger"
+              size="tiny"
+              nbTooltip="Delete this group"
+              (click)="deleteLexGroup(group.id)"
+            >
+              <nb-icon icon="trash"></nb-icon>
+            </button>
+          </nb-card-header>
+
+          <nb-card-body class="p-2">
+            <nb-tag-list
+              (tagRemove)="removeTerm(group.id, $event)"
+              *ngIf="group.terms?.length"
+            >
+              <nb-tag
+                *ngFor="let term of group.terms"
+                [text]="term"
+                status="primary"
+                appearance="outline"
+                removable
+              ></nb-tag>
+            </nb-tag-list>
+
+            <div
+              *ngIf="group.terms.length < 2"
+              class="d-flex gap-05 align-items-center font-size-small text-danger mt-1"
+            >
+              <nb-icon icon="exclamation-triangle"></nb-icon>
+              A synonym group must contain at least 2 terms.
+            </div>
+
+            <div class="d-flex align-items-center gap-1 mt-3">
+              <input
+                nbInput
+                type="text"
+                fieldSize="small"
+                placeholder="Add an acronym or synonym…"
+                #addTermInput
+                fullWidth
+                (keyup.enter)="addTerm(group.id, addTermInput)"
+              />
+              <button
+                nbButton
+                outline
+                status="primary"
+                size="small"
+                nbTooltip="Add the term"
+                [disabled]="!addTermInput.value"
+                (click)="addTerm(group.id, addTermInput)"
+              >
+                <nb-icon icon="plus"></nb-icon> Add
+              </button>
+            </div>
+          </nb-card-body>
+        </nb-card>
+      </div>
+
+      <button
+        nbButton
+        ghost
+        fullWidth
+        status="primary"
+        (click)="addLexGroup()"
+      >
+        <nb-icon
+          icon="plus"
+          class="mr-2"
+        ></nb-icon>
+        New synonym group
+      </button>
+    </nb-card-body>
+  </nb-card> -->
+</div>
+
+<ng-template #importModal>
+  <nb-card>
+    <nb-card-header class="d-flex justify-content-between align-items-start gap-1">
+      Import prompt context settings dump
+      <button
+        nbButton
+        ghost
+        shape="round"
+        nbTooltip="Cancel"
+        (click)="closeImportModal()"
+      >
+        <nb-icon icon="x-lg"></nb-icon>
+      </button>
+    </nb-card-header>
+
+    <nb-card-body>
+      <form
+        [formGroup]="importForm"
+        (submit)="submitImportSettings()"
+      >
+        <tock-form-control
+          label="Rag prompt context settings dump file"
+          name="importFile"
+          [required]="true"
+          [controls]="fileSource"
+          [showError]="isImportSubmitted"
+        >
+          <tock-file-upload
+            id="importFile"
+            formControlName="fileSource"
+            [autofocus]="true"
+            [fullWidth]="true"
+            [multiple]="false"
+            [fileTypeAccepted]="['json']"
+          ></tock-file-upload>
+        </tock-form-control>
+      </form>
+    </nb-card-body>
+
+    <nb-card-footer class="card-footer-actions">
+      <button
+        nbButton
+        ghost
+        size="small"
+        (click)="closeImportModal()"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        nbButton
+        status="primary"
+        size="small"
+        (click)="submitImportSettings()"
+      >
+        Import
+      </button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.scss
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.scss
@@ -1,0 +1,7 @@
+.grid-actions {
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-auto-flow: column;
+  align-items: center;
+  justify-content: end;
+}

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
@@ -1,0 +1,427 @@
+import { Component, ElementRef, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { RagAnswerStatusLabels, getExportFileName, normalizeString, readFileAsText } from '../../shared/utils';
+import { StateService } from '../../core-nlp/state.service';
+import { NbDialogRef, NbDialogService, NbToastrService } from '@nebular/theme';
+import { saveAs } from 'file-saver-es';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FileValidators } from '../../shared/validators';
+import { Observable, Subject, filter, from, takeUntil } from 'rxjs';
+import { RestService } from '../../core-nlp/rest/rest.service';
+import { ChoiceDialogComponent } from '../../shared/components';
+import { BotConfigurationService } from '../../core/bot-configuration.service';
+import { DirtyStateGuard, DirtyStateService } from '../../core/dirty-state.service';
+import { IndicatorDefinition } from '../../metrics/models';
+import { CanComponentDeactivate } from '../../shared/guards/can-deactivate.guard';
+
+interface LexiconGroup {
+  id: number;
+  terms: string[];
+}
+
+interface PromptContext {
+  coveredTopics: string[];
+  excludedTopics: string[];
+  lexiconGroups: LexiconGroup[];
+}
+
+@Component({
+  selector: 'tock-prompt-context-settings',
+  templateUrl: './prompt-context-settings.component.html',
+  styleUrls: ['./prompt-context-settings.component.scss']
+})
+export class PromptContextSettingsComponent implements OnInit, CanComponentDeactivate, DirtyStateGuard, OnDestroy {
+  destroy$: Subject<unknown> = new Subject();
+  loading: boolean = false;
+  isSaving = false;
+
+  sections: Record<string, boolean> = {
+    covered: true,
+    excluded: true,
+    lexicon: true
+  };
+
+  coveredTopics: string[] = [];
+  excludedTopics: string[] = [];
+  lexiconGroups: LexiconGroup[] = [];
+  lexiconSearch = '';
+
+  private _lexIdSeq = 10;
+
+  showSuggestedTopics: boolean = false;
+  private _indicators: IndicatorDefinition[] | null = null;
+
+  private _snapshot: PromptContext | null = null;
+
+  _coveredWarning: string | undefined;
+  _excludedWarning: string | undefined;
+
+  maxCoverTopics = 50;
+  coveredTopicMaxLength = 50;
+
+  @ViewChild('coveredInput') coveredInput: ElementRef;
+  @ViewChild('importModal') importModal: TemplateRef<any>;
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    private state: StateService,
+    private rest: RestService,
+    private toastrService: NbToastrService,
+    private nbDialogService: NbDialogService,
+    private dirtyState: DirtyStateService
+  ) {}
+
+  ngOnInit(): void {
+    this.dirtyState.register(this);
+
+    this.botConfiguration.configurations
+      .pipe(
+        filter((configs) => configs.length > 0),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(() => {
+        this.loadSettings();
+      });
+  }
+
+  loadSettings() {
+    this.loading = true;
+    this.settingsLoader().subscribe((res) => {
+      if (res?.coveredTopics) {
+        this.coveredTopics = res.coveredTopics;
+        this.excludedTopics = res.excludedTopics;
+        this.lexiconGroups = res.lexiconGroups;
+        this._takeSnapshot();
+      } else {
+        this.coveredTopics = [RagAnswerStatusLabels.small_talk];
+        this.excludedTopics = [];
+        this.lexiconGroups = [];
+        this._takeSnapshot();
+      }
+      this.loading = false;
+
+      this.loadIndicators();
+    });
+  }
+
+  private settingsLoader(): Observable<PromptContext> {
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/business-rules`;
+    return this.rest.get<PromptContext>(url, (settings: PromptContext) => settings);
+  }
+
+  loadIndicators() {
+    this.showSuggestedTopics = false;
+    this._indicators = [];
+    this.indicatorsLoader().subscribe((res) => {
+      this._indicators = res;
+    });
+  }
+
+  private indicatorsLoader(): Observable<IndicatorDefinition[]> {
+    const url = `/bot/${this.state.currentApplication.name}/indicators`;
+    return this.rest.get(url, (indicators) => indicators);
+  }
+
+  get suggestedTopics(): string[] {
+    const ragSuggestedTopicsIndicatorName = 'rag_suggested_topics';
+    const indicatorValues = this._indicators?.find((item) => item.name === ragSuggestedTopicsIndicatorName)?.values ?? [];
+
+    return indicatorValues
+      .filter((item) => {
+        const normalizedLabel = normalizeString(item.label).toLowerCase();
+        return !this.coveredTopics.some((topic) => normalizeString(topic).toLowerCase() === normalizedLabel);
+      })
+      .map((e) => e.label);
+  }
+
+  // ─── Validation ──────────────────────────────────────────────────────────────
+
+  get invalidLexiconGroups(): LexiconGroup[] {
+    return this.lexiconGroups.filter((g) => g.terms.length < 2);
+  }
+
+  get isValid(): boolean {
+    return this.invalidLexiconGroups.length === 0;
+  }
+
+  // ─── Dirty state ─────────────────────────────────────────────────────────────
+
+  get isDirty(): boolean {
+    if (!this._snapshot) return false;
+    return JSON.stringify(this._currentState()) !== JSON.stringify(this._snapshot);
+  }
+
+  private _currentState(): PromptContext {
+    if (!this.coveredTopics) {
+      return {
+        coveredTopics: [],
+        excludedTopics: [],
+        lexiconGroups: []
+      };
+    }
+
+    return {
+      coveredTopics: [...this.coveredTopics],
+      excludedTopics: [...this.excludedTopics],
+      // Deep clone so nested arrays don't share references with the snapshot
+      lexiconGroups: this.lexiconGroups.map((g) => ({ id: g.id, terms: [...g.terms] }))
+    };
+  }
+
+  private _takeSnapshot(): void {
+    this._snapshot = this._currentState();
+  }
+
+  // ─── Sections ────────────────────────────────────────────────────────────────
+
+  toggleSection(key: string): void {
+    this.sections[key] = !this.sections[key];
+  }
+
+  // ─── Topics (covered / excluded) ─────────────────────────────────────────────
+
+  isTopicRemovable(topic: string): boolean {
+    if (topic === RagAnswerStatusLabels.small_talk) return false;
+
+    return true;
+  }
+
+  addTag(key: 'covered' | 'excluded', inputEl: HTMLInputElement): void {
+    this._coveredWarning = undefined;
+    this._excludedWarning = undefined;
+
+    const value = inputEl.value.trim();
+    if (!value) return;
+
+    const list = key === 'covered' ? this.coveredTopics : this.excludedTopics;
+    const otherList = key === 'covered' ? this.excludedTopics : this.coveredTopics;
+    const normalizedValue = normalizeString(value).toLowerCase();
+
+    const isInList = (lst: string[]) => lst.some((item) => normalizeString(item).toLowerCase() === normalizedValue);
+
+    if (!isInList(list) && !isInList(otherList)) {
+      list.push(value);
+    } else {
+      if (isInList(list)) {
+        if (key === 'covered') this._coveredWarning = 'This topic is already listed';
+        if (key === 'excluded') this._excludedWarning = 'This topic is already listed';
+      }
+
+      if (isInList(otherList)) {
+        if (key === 'covered')
+          this._coveredWarning = 'An excluded topic with the same name already exists. A topic cannot be both covered and excluded';
+        if (key === 'excluded')
+          this._excludedWarning = 'A covered topic with the same name already exists. A topic cannot be both covered and excluded';
+      }
+
+      setTimeout(() => {
+        this._coveredWarning = undefined;
+        this._excludedWarning = undefined;
+      }, 3000);
+    }
+
+    inputEl.value = '';
+  }
+
+  removeTag(key: 'covered' | 'excluded', tag: { text: string }): void {
+    const list = key === 'covered' ? this.coveredTopics : this.excludedTopics;
+    const idx = list.indexOf(tag.text);
+    if (idx !== -1) list.splice(idx, 1);
+  }
+
+  addSuggestedTag(topic: string) {
+    this.coveredInput.nativeElement.value = topic.substring(0, this.coveredTopicMaxLength);
+  }
+
+  // ─── Lexicon groups ───────────────────────────────────────────────────────────
+
+  get filteredLexiconGroups(): LexiconGroup[] {
+    const q = this.lexiconSearch.toLowerCase().trim();
+    if (!q) return this.lexiconGroups;
+    return this.lexiconGroups.filter((g) => g.terms.some((t) => t.toLowerCase().includes(q)));
+  }
+
+  getLexLabel(group: LexiconGroup): string | null {
+    const nonEmpty = group.terms.filter((t) => t.trim());
+    if (!nonEmpty.length) return null;
+    if (nonEmpty.length === 1) return nonEmpty[0];
+    return `${nonEmpty[0]} / ${nonEmpty[1]}`;
+  }
+
+  addLexGroup(): void {
+    this.lexiconGroups.unshift({ id: this._lexIdSeq++, terms: [] });
+    this.lexiconSearch = '';
+  }
+
+  deleteLexGroup(id: number): void {
+    this.lexiconGroups = this.lexiconGroups.filter((g) => g.id !== id);
+  }
+
+  addTerm(groupId: number, inputEl: HTMLInputElement): void {
+    const value = inputEl.value?.trim();
+    if (!value) return;
+    const group = this.lexiconGroups.find((g) => g.id === groupId);
+    if (group && !group.terms.includes(value)) group.terms.push(value);
+    inputEl.value = '';
+  }
+
+  removeTerm(groupId: number, tag: { text: string }): void {
+    const group = this.lexiconGroups.find((g) => g.id === groupId);
+    if (!group) return;
+    const idx = group.terms.indexOf(tag.text);
+    if (idx !== -1) group.terms.splice(idx, 1);
+  }
+
+  // ─── Tracking ────────────────────────────────────────────────────────────────
+
+  trackById(_: number, item: LexiconGroup): number {
+    return item.id;
+  }
+
+  // ─── Export ─────────────────────────────────────────────────────────────────
+
+  get hasExportableData(): boolean {
+    const currentState = this._currentState();
+    return currentState.coveredTopics.length > 0 || currentState.excludedTopics.length > 0 || currentState.lexiconGroups.length > 0;
+  }
+
+  exportSettings() {
+    const currentState = this._currentState();
+
+    const jsonBlob = new Blob([JSON.stringify(currentState)], {
+      type: 'application/json'
+    });
+
+    const exportFileName = getExportFileName(
+      this.state.currentApplication.namespace,
+      this.state.currentApplication.name,
+      'Rag prompt context settings',
+      'json'
+    );
+
+    saveAs(jsonBlob, exportFileName);
+
+    this.toastrService.show(`Rag prompt context settings dump provided`, 'Rag prompt context settings dump', {
+      duration: 3000,
+      status: 'success'
+    });
+  }
+
+  // ─── Import ─────────────────────────────────────────────────────────────────
+
+  importModalRef: NbDialogRef<any>;
+
+  importSettings(): void {
+    this.isImportSubmitted = false;
+    this.importForm.reset();
+    this.importModalRef = this.nbDialogService.open(this.importModal);
+  }
+
+  closeImportModal(): void {
+    this.importModalRef.close();
+  }
+
+  isImportSubmitted: boolean = false;
+
+  importForm: FormGroup = new FormGroup({
+    fileSource: new FormControl<File[]>([], {
+      nonNullable: true,
+      validators: [Validators.required, FileValidators.mimeTypeSupported(['application/json'])]
+    })
+  });
+
+  get fileSource(): FormControl {
+    return this.importForm.get('fileSource') as FormControl;
+  }
+
+  get canSaveImport(): boolean {
+    return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
+  }
+
+  submitImportSettings(): void {
+    this.isImportSubmitted = true;
+    if (this.canSaveImport) {
+      const file = this.fileSource.value[0];
+
+      readFileAsText(file).then((fileContent) => {
+        const settings = JSON.parse(fileContent.data);
+
+        if (!settings.coveredTopics?.length && !settings.excludedTopics?.length && !settings.lexiconGroups?.length) {
+          this.toastrService.show(
+            `The file provided does not contain the expected data. Please check the file.`,
+            'Rag prompt context import fails',
+            {
+              duration: 6000,
+              status: 'danger'
+            }
+          );
+          return;
+        }
+
+        if (settings.coveredTopics?.length) this.coveredTopics = settings.coveredTopics;
+        if (settings.excludedTopics?.length) this.excludedTopics = settings.excludedTopics;
+        if (settings.lexiconGroups?.length) this.lexiconGroups = settings.lexiconGroups;
+
+        this.closeImportModal();
+      });
+    }
+  }
+
+  // ─── Actions ─────────────────────────────────────────────────────────────────
+
+  cancel(): void {
+    if (!this._snapshot) return;
+    this.coveredTopics = [...this._snapshot.coveredTopics];
+    this.excludedTopics = [...this._snapshot.excludedTopics];
+    this.lexiconGroups = this._snapshot.lexiconGroups.map((g) => ({ id: g.id, terms: [...g.terms] }));
+    this.lexiconSearch = '';
+  }
+
+  save(): void {
+    if (!this.isValid) return;
+
+    this.isSaving = true;
+
+    const payload = this._currentState();
+
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/business-rules`;
+
+    this.rest
+      .post(url, payload, (settings: PromptContext) => settings, null, true)
+      .subscribe({
+        next: () => {
+          this._takeSnapshot();
+          this.isSaving = false;
+        },
+        error: () => {
+          this.isSaving = false;
+        }
+      });
+  }
+
+  // ─── Deactivation guard ─────────────────────────────────────────────────────────────────
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (!this.isDirty) return true;
+
+    const dialogRef = this.nbDialogService.open(ChoiceDialogComponent, {
+      closeOnBackdropClick: false,
+      context: {
+        title: 'Unsaved changes',
+        subtitle: 'You have unsaved changes. What would you like to do?',
+        actions: [
+          { actionName: 'Stay on page', buttonStatus: 'basic', ghost: true, returnValue: false },
+          { actionName: 'Leave without saving', buttonStatus: 'danger', returnValue: true }
+        ],
+        modalStatus: 'danger'
+      }
+    });
+
+    return from(dialogRef.onClose) as Observable<boolean>;
+  }
+
+  ngOnDestroy(): void {
+    this.dirtyState.unregister();
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
@@ -1,0 +1,376 @@
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { RagAnswerStatusLabels, getExportFileName, readFileAsText } from '../../shared/utils';
+import { StateService } from '../../core-nlp/state.service';
+import { NbDialogRef, NbDialogService, NbToastrService } from '@nebular/theme';
+import { saveAs } from 'file-saver-es';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FileValidators } from '../../shared/validators';
+import { Observable, Subject, from, of, takeUntil } from 'rxjs';
+import { RestService } from '../../core-nlp/rest/rest.service';
+import { CanComponentDeactivate } from './prompt-context-settings.guard';
+import { ChoiceDialogComponent } from '../../shared/components';
+import { BotConfigurationService } from '../../core/bot-configuration.service';
+
+interface LexiconGroup {
+  id: number;
+  terms: string[];
+}
+
+interface PromptContext {
+  coveredTopics: string[];
+  excludedTopics: string[];
+  lexiconGroups: LexiconGroup[];
+}
+
+@Component({
+  selector: 'tock-prompt-context-settings',
+  templateUrl: './prompt-context-settings.component.html',
+  styleUrls: ['./prompt-context-settings.component.scss']
+})
+export class PromptContextSettingsComponent implements OnInit, CanComponentDeactivate, OnDestroy {
+  destroy$: Subject<unknown> = new Subject();
+  loading: boolean = false;
+  isSaving = false;
+
+  sections: Record<string, boolean> = {
+    covered: true,
+    excluded: true,
+    lexicon: true
+  };
+
+  coveredTopics: string[] = [];
+  excludedTopics: string[] = [];
+  lexiconGroups: LexiconGroup[] = [];
+  lexiconSearch = '';
+
+  private _lexIdSeq = 10;
+  private _snapshot: PromptContext | null = null;
+
+  _coveredWarning: string | undefined;
+  _excludedWarning: string | undefined;
+
+  @ViewChild('importModal') importModal: TemplateRef<any>;
+
+  constructor(
+    private botConfiguration: BotConfigurationService,
+    private state: StateService,
+    private rest: RestService,
+    private toastrService: NbToastrService,
+    private nbDialogService: NbDialogService
+  ) {}
+
+  ngOnInit(): void {
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((confs) => {
+      this.loadSettings();
+    });
+  }
+
+  loadSettings() {
+    this.loading = true;
+    this.settingsLoader().subscribe((res) => {
+      if (res?.coveredTopics) {
+        this.coveredTopics = res.coveredTopics;
+        this.excludedTopics = res.excludedTopics;
+        this.lexiconGroups = res.lexiconGroups;
+        this._takeSnapshot();
+      } else {
+        this.coveredTopics = [RagAnswerStatusLabels.small_talk];
+        this.excludedTopics = [];
+        this.lexiconGroups = [];
+        this._takeSnapshot();
+      }
+      this.loading = false;
+    });
+  }
+
+  private settingsLoader(): Observable<PromptContext> {
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/business-rules`;
+    return this.rest.get<PromptContext>(url, (settings: PromptContext) => settings);
+  }
+
+  // ─── Validation ──────────────────────────────────────────────────────────────
+
+  get invalidLexiconGroups(): LexiconGroup[] {
+    return this.lexiconGroups.filter((g) => g.terms.length < 2);
+  }
+
+  get isValid(): boolean {
+    return this.invalidLexiconGroups.length === 0;
+  }
+
+  // ─── Dirty state ─────────────────────────────────────────────────────────────
+
+  get isDirty(): boolean {
+    if (!this._snapshot) return false;
+    return JSON.stringify(this._currentState()) !== JSON.stringify(this._snapshot);
+  }
+
+  private _currentState(): PromptContext {
+    if (!this.coveredTopics) {
+      return {
+        coveredTopics: [],
+        excludedTopics: [],
+        lexiconGroups: []
+      };
+    }
+
+    return {
+      coveredTopics: [...this.coveredTopics],
+      excludedTopics: [...this.excludedTopics],
+      // Deep clone so nested arrays don't share references with the snapshot
+      lexiconGroups: this.lexiconGroups.map((g) => ({ id: g.id, terms: [...g.terms] }))
+    };
+  }
+
+  private _takeSnapshot(): void {
+    this._snapshot = this._currentState();
+  }
+
+  // ─── Sections ────────────────────────────────────────────────────────────────
+
+  toggleSection(key: string): void {
+    this.sections[key] = !this.sections[key];
+  }
+
+  // ─── Topics (covered / excluded) ─────────────────────────────────────────────
+
+  isTopicRemovable(topic: string): boolean {
+    if (topic === RagAnswerStatusLabels.small_talk) return false;
+
+    return true;
+  }
+
+  addTag(key: 'covered' | 'excluded', inputEl: HTMLInputElement): void {
+    this._coveredWarning = undefined;
+    this._excludedWarning = undefined;
+
+    const value = inputEl.value.trim();
+    if (!value) return;
+
+    const list = key === 'covered' ? this.coveredTopics : this.excludedTopics;
+    const otherList = key === 'covered' ? this.excludedTopics : this.coveredTopics;
+    const normalizedValue = value.toLowerCase().replace(/\s+/g, '');
+
+    const isInList = (lst: string[]) => lst.some((item) => item.toLowerCase().replace(/\s+/g, '') === normalizedValue);
+
+    if (!isInList(list) && !isInList(otherList)) {
+      list.push(value);
+    } else {
+      if (isInList(list)) {
+        if (key === 'covered') this._coveredWarning = 'This topic is already listed';
+        if (key === 'excluded') this._excludedWarning = 'This topic is already listed';
+      }
+
+      if (isInList(otherList)) {
+        if (key === 'covered')
+          this._coveredWarning = 'An excluded topic with the same name already exists. A topic cannot be both covered and excluded';
+        if (key === 'excluded')
+          this._excludedWarning = 'A covered topic with the same name already exists. A topic cannot be both covered and excluded';
+      }
+
+      setTimeout(() => {
+        this._coveredWarning = undefined;
+        this._excludedWarning = undefined;
+      }, 3000);
+    }
+
+    inputEl.value = '';
+  }
+
+  removeTag(key: 'covered' | 'excluded', tag: { text: string }): void {
+    const list = key === 'covered' ? this.coveredTopics : this.excludedTopics;
+    const idx = list.indexOf(tag.text);
+    if (idx !== -1) list.splice(idx, 1);
+  }
+
+  // ─── Lexicon groups ───────────────────────────────────────────────────────────
+
+  get filteredLexiconGroups(): LexiconGroup[] {
+    const q = this.lexiconSearch.toLowerCase().trim();
+    if (!q) return this.lexiconGroups;
+    return this.lexiconGroups.filter((g) => g.terms.some((t) => t.toLowerCase().includes(q)));
+  }
+
+  getLexLabel(group: LexiconGroup): string | null {
+    const nonEmpty = group.terms.filter((t) => t.trim());
+    if (!nonEmpty.length) return null;
+    if (nonEmpty.length === 1) return nonEmpty[0];
+    return `${nonEmpty[0]} / ${nonEmpty[1]}`;
+  }
+
+  addLexGroup(): void {
+    this.lexiconGroups.unshift({ id: this._lexIdSeq++, terms: [] });
+    this.lexiconSearch = '';
+  }
+
+  deleteLexGroup(id: number): void {
+    this.lexiconGroups = this.lexiconGroups.filter((g) => g.id !== id);
+  }
+
+  addTerm(groupId: number, inputEl: HTMLInputElement): void {
+    const value = inputEl.value?.trim();
+    if (!value) return;
+    const group = this.lexiconGroups.find((g) => g.id === groupId);
+    if (group && !group.terms.includes(value)) group.terms.push(value);
+    inputEl.value = '';
+  }
+
+  removeTerm(groupId: number, tag: { text: string }): void {
+    const group = this.lexiconGroups.find((g) => g.id === groupId);
+    if (!group) return;
+    const idx = group.terms.indexOf(tag.text);
+    if (idx !== -1) group.terms.splice(idx, 1);
+  }
+
+  // ─── Tracking ────────────────────────────────────────────────────────────────
+
+  trackById(_: number, item: LexiconGroup): number {
+    return item.id;
+  }
+
+  // ─── Export ─────────────────────────────────────────────────────────────────
+
+  get hasExportableData(): boolean {
+    const currentState = this._currentState();
+    return currentState.coveredTopics.length > 0 || currentState.excludedTopics.length > 0 || currentState.lexiconGroups.length > 0;
+  }
+
+  exportSettings() {
+    const currentState = this._currentState();
+
+    const jsonBlob = new Blob([JSON.stringify(currentState)], {
+      type: 'application/json'
+    });
+
+    const exportFileName = getExportFileName(
+      this.state.currentApplication.namespace,
+      this.state.currentApplication.name,
+      'Rag prompt context settings',
+      'json'
+    );
+
+    saveAs(jsonBlob, exportFileName);
+
+    this.toastrService.show(`Rag prompt context settings dump provided`, 'Rag prompt context settings dump', {
+      duration: 3000,
+      status: 'success'
+    });
+  }
+
+  // ─── Import ─────────────────────────────────────────────────────────────────
+
+  importModalRef: NbDialogRef<any>;
+
+  importSettings(): void {
+    this.isImportSubmitted = false;
+    this.importForm.reset();
+    this.importModalRef = this.nbDialogService.open(this.importModal);
+  }
+
+  closeImportModal(): void {
+    this.importModalRef.close();
+  }
+
+  isImportSubmitted: boolean = false;
+
+  importForm: FormGroup = new FormGroup({
+    fileSource: new FormControl<File[]>([], {
+      nonNullable: true,
+      validators: [Validators.required, FileValidators.mimeTypeSupported(['application/json'])]
+    })
+  });
+
+  get fileSource(): FormControl {
+    return this.importForm.get('fileSource') as FormControl;
+  }
+
+  get canSaveImport(): boolean {
+    return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
+  }
+
+  submitImportSettings(): void {
+    this.isImportSubmitted = true;
+    if (this.canSaveImport) {
+      const file = this.fileSource.value[0];
+
+      readFileAsText(file).then((fileContent) => {
+        const settings = JSON.parse(fileContent.data);
+
+        if (!settings.coveredTopics?.length && !settings.excludedTopics?.length && !settings.lexiconGroups?.length) {
+          this.toastrService.show(
+            `The file provided does not contain the expected data. Please check the file.`,
+            'Rag prompt context import fails',
+            {
+              duration: 6000,
+              status: 'danger'
+            }
+          );
+          return;
+        }
+
+        if (settings.coveredTopics?.length) this.coveredTopics = settings.coveredTopics;
+        if (settings.excludedTopics?.length) this.excludedTopics = settings.excludedTopics;
+        if (settings.lexiconGroups?.length) this.lexiconGroups = settings.lexiconGroups;
+
+        this.closeImportModal();
+      });
+    }
+  }
+
+  // ─── Actions ─────────────────────────────────────────────────────────────────
+
+  cancel(): void {
+    if (!this._snapshot) return;
+    this.coveredTopics = [...this._snapshot.coveredTopics];
+    this.excludedTopics = [...this._snapshot.excludedTopics];
+    this.lexiconGroups = this._snapshot.lexiconGroups.map((g) => ({ id: g.id, terms: [...g.terms] }));
+    this.lexiconSearch = '';
+  }
+
+  save(): void {
+    if (!this.isValid) return;
+
+    this.isSaving = true;
+
+    const payload = this._currentState();
+
+    const url = `/gen-ai/bots/${this.state.currentApplication.name}/configuration/business-rules`;
+
+    this.rest
+      .post(url, payload, (settings: PromptContext) => settings, null, true)
+      .subscribe({
+        next: () => {
+          this._takeSnapshot();
+          this.isSaving = false;
+        },
+        error: () => {
+          this.isSaving = false;
+        }
+      });
+  }
+
+  // ─── Deactivation guard ─────────────────────────────────────────────────────────────────
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (!this.isDirty) return true;
+
+    const dialogRef = this.nbDialogService.open(ChoiceDialogComponent, {
+      context: {
+        title: 'Unsaved changes',
+        subtitle: 'You have unsaved changes. What would you like to do?',
+        actions: [
+          { actionName: 'Stay on page', buttonStatus: 'basic', ghost: true, returnValue: false },
+          { actionName: 'Leave without saving', buttonStatus: 'danger', returnValue: true }
+        ],
+        modalStatus: 'danger'
+      }
+    });
+
+    return from(dialogRef.onClose) as Observable<boolean>;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.component.ts
@@ -10,6 +10,7 @@ import { RestService } from '../../core-nlp/rest/rest.service';
 import { CanComponentDeactivate } from './prompt-context-settings.guard';
 import { ChoiceDialogComponent } from '../../shared/components';
 import { BotConfigurationService } from '../../core/bot-configuration.service';
+import { DirtyStateGuard, DirtyStateService } from '../../core/dirty-state.service';
 
 interface LexiconGroup {
   id: number;
@@ -27,7 +28,7 @@ interface PromptContext {
   templateUrl: './prompt-context-settings.component.html',
   styleUrls: ['./prompt-context-settings.component.scss']
 })
-export class PromptContextSettingsComponent implements OnInit, CanComponentDeactivate, OnDestroy {
+export class PromptContextSettingsComponent implements OnInit, DirtyStateGuard, OnDestroy {
   destroy$: Subject<unknown> = new Subject();
   loading: boolean = false;
   isSaving = false;
@@ -56,13 +57,14 @@ export class PromptContextSettingsComponent implements OnInit, CanComponentDeact
     private state: StateService,
     private rest: RestService,
     private toastrService: NbToastrService,
-    private nbDialogService: NbDialogService
+    private nbDialogService: NbDialogService,
+    private dirtyState: DirtyStateService
   ) {}
 
   ngOnInit(): void {
-    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe((confs) => {
-      this.loadSettings();
-    });
+    this.dirtyState.register(this);
+
+    this.botConfiguration.configurations.pipe(takeUntil(this.destroy$)).subscribe(() => this.loadSettings());
   }
 
   loadSettings() {
@@ -370,6 +372,7 @@ export class PromptContextSettingsComponent implements OnInit, CanComponentDeact
   }
 
   ngOnDestroy(): void {
+    this.dirtyState.unregister();
     this.destroy$.next(true);
     this.destroy$.complete();
   }

--- a/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.guard.ts
+++ b/bot/admin/web/src/app/rag/prompt-context/prompt-context-settings.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface CanComponentDeactivate {
+  canDeactivate: () => Observable<boolean> | Promise<boolean> | boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PromptContextSettingsGuard implements CanDeactivate<CanComponentDeactivate> {
+  canDeactivate(component: CanComponentDeactivate): Observable<boolean> | Promise<boolean> | boolean {
+    return component.canDeactivate ? component.canDeactivate() : true;
+  }
+}

--- a/bot/admin/web/src/app/rag/rag-routing.module.ts
+++ b/bot/admin/web/src/app/rag/rag-routing.module.ts
@@ -21,6 +21,8 @@ import { AuthGuard } from '../core-nlp/auth/auth.guard';
 import { RagExcludedComponent } from './rag-excluded/rag-excluded.component';
 import { RagSettingsComponent } from './rag-settings/rag-settings.component';
 import { RagTabsComponent } from './rag-tabs.component';
+import { PromptContextSettingsComponent } from './prompt-context/prompt-context-settings.component';
+import { CanDeactivateGuard } from '../shared/guards/can-deactivate.guard';
 
 const routes: Routes = [
   {
@@ -37,7 +39,13 @@ const routes: Routes = [
       },
       {
         path: 'settings',
-        component: RagSettingsComponent
+        component: RagSettingsComponent,
+        canDeactivate: [CanDeactivateGuard]
+      },
+      {
+        path: 'prompt-context',
+        component: PromptContextSettingsComponent,
+        canDeactivate: [CanDeactivateGuard]
       }
     ]
   }

--- a/bot/admin/web/src/app/rag/rag-routing.module.ts
+++ b/bot/admin/web/src/app/rag/rag-routing.module.ts
@@ -21,6 +21,8 @@ import { AuthGuard } from '../core-nlp/auth/auth.guard';
 import { RagExcludedComponent } from './rag-excluded/rag-excluded.component';
 import { RagSettingsComponent } from './rag-settings/rag-settings.component';
 import { RagTabsComponent } from './rag-tabs.component';
+import { PromptContextSettingsComponent } from './prompt-context/prompt-context-settings.component';
+import { PromptContextSettingsGuard } from './prompt-context/prompt-context-settings.guard';
 
 const routes: Routes = [
   {
@@ -38,6 +40,11 @@ const routes: Routes = [
       {
         path: 'settings',
         component: RagSettingsComponent
+      },
+      {
+        path: 'prompt-context',
+        component: PromptContextSettingsComponent,
+        canDeactivate: [PromptContextSettingsGuard]
       }
     ]
   }

--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -159,16 +159,16 @@ Never:
 
 **Covered Topics:**
 
-- Artificial Intelligence (AI) concepts and applications
-- ChatBots and conversational AI
-- Large Language Models (LLM) and their use cases
-- Embeddings and vector-based retrieval
-- RAG (Retrieval-Augmented Generation) workflows
+\`\`\`json
+{{ covered_topics }}
+\`\`\`
+
 
 **Excluded Topics:**
 
-- Financial advice unrelated to AI documentation
-- Legal guidance outside AI compliance rules
+\`\`\`json
+{{ excluded_topics }}
+\`\`\`
 
 ---
 

--- a/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/rag-settings.component.ts
@@ -16,7 +16,7 @@
 
 import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { debounceTime, forkJoin, Observable, Subject, takeUntil, pairwise } from 'rxjs';
+import { debounceTime, forkJoin, Observable, Subject, takeUntil, pairwise, from } from 'rxjs';
 import { NbDialogRef, NbDialogService, NbToastrService, NbWindowService } from '@nebular/theme';
 
 import { RestService } from '../../core-nlp/rest/rest.service';
@@ -38,6 +38,8 @@ import {
 import { ChoiceDialogComponent } from '../../shared/components';
 import { saveAs } from 'file-saver-es';
 import { FileValidators } from '../../shared/validators';
+import { CanComponentDeactivate } from '../../shared/guards/can-deactivate.guard';
+import { DirtyStateGuard, DirtyStateService } from '../../core/dirty-state.service';
 
 interface RagSettingsForm {
   id: FormControl<string>;
@@ -69,7 +71,7 @@ interface RagSettingsForm {
   templateUrl: './rag-settings.component.html',
   styleUrls: ['./rag-settings.component.scss']
 })
-export class RagSettingsComponent implements OnInit, OnDestroy {
+export class RagSettingsComponent implements OnInit, CanComponentDeactivate, DirtyStateGuard, OnDestroy {
   destroy$: Subject<unknown> = new Subject();
 
   configurations: BotApplicationConfiguration[];
@@ -97,10 +99,13 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
     private toastrService: NbToastrService,
     private botConfiguration: BotConfigurationService,
     private nbWindowService: NbWindowService,
-    private nbDialogService: NbDialogService
+    private nbDialogService: NbDialogService,
+    private dirtyState: DirtyStateService
   ) {}
 
   ngOnInit(): void {
+    this.dirtyState.register(this);
+
     this.form.valueChanges.pipe(takeUntil(this.destroy$), debounceTime(200)).subscribe(() => {
       this.setActivationDisabledState();
     });
@@ -146,6 +151,7 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
 
       // Reset form on configuration change
       this.form.reset();
+      this.form.markAsPristine();
 
       this.setFormDefaultValues();
 
@@ -662,7 +668,29 @@ export class RagSettingsComponent implements OnInit, OnDestroy {
     });
   }
 
+  // ─── Deactivation guard ─────────────────────────────────────────────────────────────────
+
+  canDeactivate(): Observable<boolean> | boolean {
+    if (!this.form.dirty) return true;
+
+    const dialogRef = this.nbDialogService.open(ChoiceDialogComponent, {
+      closeOnBackdropClick: false,
+      context: {
+        title: 'Unsaved changes',
+        subtitle: 'You have unsaved changes. What would you like to do?',
+        actions: [
+          { actionName: 'Stay on page', buttonStatus: 'basic', ghost: true, returnValue: false },
+          { actionName: 'Leave without saving', buttonStatus: 'danger', returnValue: true }
+        ],
+        modalStatus: 'danger'
+      }
+    });
+
+    return from(dialogRef.onClose) as Observable<boolean>;
+  }
+
   ngOnDestroy(): void {
+    this.dirtyState.unregister();
     this.destroy$.next(true);
     this.destroy$.complete();
   }

--- a/bot/admin/web/src/app/rag/rag.module.ts
+++ b/bot/admin/web/src/app/rag/rag.module.ts
@@ -21,6 +21,7 @@ import {
   NbAccordionModule,
   NbAlertModule,
   NbAutocompleteModule,
+  NbBadgeModule,
   NbButtonModule,
   NbCardModule,
   NbCheckboxModule,
@@ -31,6 +32,7 @@ import {
   NbRouteTabsetModule,
   NbSelectModule,
   NbSpinnerModule,
+  NbTagModule,
   NbToggleModule,
   NbTooltipModule
 } from '@nebular/theme';
@@ -39,6 +41,7 @@ import { BotSharedModule } from '../shared/bot-shared.module';
 import { RagRoutingModule } from './rag-routing.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RagExcludedComponent } from './rag-excluded/rag-excluded.component';
+import { PromptContextSettingsComponent } from './prompt-context/prompt-context-settings.component';
 
 @NgModule({
   imports: [
@@ -61,9 +64,11 @@ import { RagExcludedComponent } from './rag-excluded/rag-excluded.component';
     NbCheckboxModule,
     NbAlertModule,
     NbAutocompleteModule,
-    NbFormFieldModule
+    NbFormFieldModule,
+    NbBadgeModule,
+    NbTagModule
   ],
-  declarations: [RagTabsComponent, RagSettingsComponent, RagExcludedComponent],
+  declarations: [RagTabsComponent, RagSettingsComponent, RagExcludedComponent, PromptContextSettingsComponent],
   providers: []
 })
 export class RagModule {}

--- a/bot/admin/web/src/app/shared/components/choice-dialog/choice-dialog.component.html
+++ b/bot/admin/web/src/app/shared/components/choice-dialog/choice-dialog.component.html
@@ -50,7 +50,7 @@
       size="small"
       [ghost]="actionDef.ghost"
       [status]="actionDef.buttonStatus"
-      (click)="dialogRef.close(actionDef.actionName.toLowerCase())"
+      (click)="handleCloseAction(actionDef)"
     >
       {{ actionDef.actionName }}
     </button>

--- a/bot/admin/web/src/app/shared/components/choice-dialog/choice-dialog.component.ts
+++ b/bot/admin/web/src/app/shared/components/choice-dialog/choice-dialog.component.ts
@@ -28,7 +28,7 @@ export class ChoiceDialogComponent implements OnInit {
   @Input() subtitle: string;
   @Input() list?: string[];
   @Input() cancellable: boolean = true;
-  @Input() actions: { actionName: string; buttonStatus?: string; ghost?: boolean }[];
+  @Input() actions: { actionName: string; buttonStatus?: string; ghost?: boolean; returnValue?: any }[];
 
   constructor(public dialogRef: NbDialogRef<ChoiceDialogComponent>) {}
 
@@ -37,5 +37,14 @@ export class ChoiceDialogComponent implements OnInit {
       if (!actionDef.buttonStatus) actionDef.buttonStatus = 'primary';
       if (actionDef.ghost == null) actionDef.ghost = false;
     });
+  }
+
+  handleCloseAction(actionDef) {
+    if (typeof actionDef.returnValue != 'undefined') {
+      this.dialogRef.close(actionDef.returnValue);
+      return;
+    }
+
+    this.dialogRef.close(actionDef.actionName.toLowerCase());
   }
 }

--- a/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.scss
+++ b/bot/admin/web/src/app/shared/components/sticky-menu/sticky-menu.component.scss
@@ -58,6 +58,9 @@
       .sticky-menu-scrolled-info {
         display: block;
       }
+      .sticky-menu-scrolled-hidden {
+        display: none;
+      }
     }
 
     .content-wrapper {

--- a/bot/admin/web/src/app/shared/guards/can-deactivate.guard.ts
+++ b/bot/admin/web/src/app/shared/guards/can-deactivate.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface CanComponentDeactivate {
+  canDeactivate: () => Observable<boolean> | Promise<boolean> | boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate> {
+  canDeactivate(component: CanComponentDeactivate): Observable<boolean> | Promise<boolean> | boolean {
+    return component.canDeactivate ? component.canDeactivate() : true;
+  }
+}

--- a/bot/admin/web/src/app/theme/components/header/header.component.ts
+++ b/bot/admin/web/src/app/theme/components/header/header.component.ts
@@ -27,6 +27,7 @@ import { BotConfigurationService } from '../../../core/bot-configuration.service
 import { CoreConfig } from '../../../core-nlp/core.config';
 import { Router } from '@angular/router';
 import { TestDialogService } from '../../../shared/components/test-dialog/test-dialog.service';
+import { DirtyStateService } from '../../../core/dirty-state.service';
 
 @Component({
   selector: 'tock-header',
@@ -55,7 +56,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private botConfiguration: BotConfigurationService,
     private config: CoreConfig,
     private router: Router,
-    private testDialogService: TestDialogService
+    private testDialogService: TestDialogService,
+    private dirtyState: DirtyStateService
   ) {}
 
   ngOnInit() {
@@ -86,24 +88,52 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   changeNamespace(namespace: string) {
-    this.applicationService
-      .selectNamespace(namespace)
-      .pipe(take(1))
-      .subscribe((_) =>
-        this.auth.loadUser().subscribe((_) => {
-          // Looks like this call to resetConfiguration is superfluous as applicationService already calls it via resetConfigurationUnsuscriber. We comment it out to avoid double calls on components rerender when changing namespace. We will see if it causes any issue.
-          // this.applicationService.resetConfiguration();
+    const initialNS = this.state.currentApplication?.namespace;
 
-          this.applicationService
-            .getApplications()
-            .pipe(take(1))
-            .subscribe((applications) => {
-              if (!applications.length) {
-                this.router.navigateByUrl(this.config.configurationUrl);
-              }
-            });
-        })
-      );
+    this.dirtyState.confirm().subscribe((canProceed) => {
+      if (!canProceed) {
+        this.currentNamespaceName = null;
+        setTimeout(() => {
+          this.currentNamespaceName = initialNS;
+        });
+        return;
+      }
+
+      this.applicationService
+        .selectNamespace(namespace)
+        .pipe(take(1))
+        .subscribe(() =>
+          this.auth.loadUser().subscribe(() => {
+            this.applicationService
+              .getApplications()
+              .pipe(take(1))
+              .subscribe((applications) => {
+                if (!applications.length) {
+                  this.router.navigateByUrl(this.config.configurationUrl);
+                }
+              });
+          })
+        );
+    });
+  }
+
+  changeApplication(app: string) {
+    const initialBot = this.state.currentApplication?.name;
+
+    this.dirtyState.confirm().subscribe((canProceed) => {
+      if (!canProceed) {
+        this.currentApplicationName = null;
+        setTimeout(() => {
+          this.currentApplicationName = initialBot;
+        });
+        return;
+      }
+
+      setTimeout(() => {
+        this.state.changeApplicationWithName(app);
+        this.settings.onApplicationChange(app);
+      });
+    });
   }
 
   changeTheme(themeName: string) {
@@ -136,13 +166,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   goToDialogs() {
     this.router.navigateByUrl('/analytics/dialogs');
-  }
-
-  changeApplication(app) {
-    setTimeout((_) => {
-      this.state.changeApplicationWithName(app);
-      this.settings.onApplicationChange(app);
-    });
   }
 
   changeLocale(locale) {

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -76,6 +76,10 @@
   line-height: 1.5rem;
 }
 
+.font-size-medium {
+  font-size: medium;
+}
+
 .font-size-small {
   font-size: small;
 }

--- a/bot/admin/web/src/app/theme/styles/utilities.scss
+++ b/bot/admin/web/src/app/theme/styles/utilities.scss
@@ -76,6 +76,10 @@
   line-height: 1.5rem;
 }
 
+.font-size-medium {
+  font-size: medium;
+}
+
 .font-size-small {
   font-size: small;
 }
@@ -428,6 +432,88 @@ nb-menu {
         height: var(--toggle-switcher-icon-size-small);
         width: var(--toggle-switcher-icon-size-small);
       }
+    }
+  }
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.6rem 1rem;
+  border-radius: 5px;
+  font-size: 0.85rem;
+
+  border: 1px solid;
+  line-height: 1;
+
+  &.tag-small {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.7rem;
+    border-radius: 3px;
+  }
+
+  &.tag-rounded {
+    border-radius: 9999px;
+  }
+
+  &.tag-basic {
+    background-color: var(--tag-filled-basic-background-color);
+    border-color: var(--tag-filled-basic-border-color);
+    color: var(--tag-filled-basic-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-basic-hover-background-color);
+      border-color: var(--tag-filled-basic-hover-border-color);
+    }
+  }
+
+  &.tag-primary {
+    background-color: var(--tag-filled-primary-background-color);
+    border-color: var(--tag-filled-primary-border-color) #3366ff;
+    color: var(--tag-filled-primary-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-primary-hover-background-color);
+      border-color: var(--tag-filled-primary-hover-border-color);
+    }
+  }
+
+  &.tag-success {
+    background-color: var(--tag-filled-success-background-color);
+    border-color: var(--tag-filled-success-border-color);
+    color: var(--tag-filled-success-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-success-hover-background-color);
+      border-color: var(--tag-filled-success-hover-border-color);
+    }
+  }
+
+  &.tag-info {
+    background-color: var(--tag-filled-info-background-color);
+    border-color: var(--tag-filled-info-border-color);
+    color: var(--tag-filled-info-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-info-hover-background-color);
+      border-color: var(--tag-filled-info-hover-border-color);
+    }
+  }
+
+  &.tag-warning {
+    background-color: var(--tag-filled-warning-background-color);
+    border-color: var(--tag-filled-warning-border-color);
+    color: var(--tag-filled-warning-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-warning-hover-background-color);
+      border-color: var(--tag-filled-warning-hover-border-color);
+    }
+  }
+
+  &.tag-danger {
+    background-color: var(--tag-filled-danger-background-color);
+    border-color: var(--tag-filled-danger-border-color);
+    color: var(--tag-filled-danger-text-color);
+    &.tag-hover:hover {
+      background-color: var(--tag-filled-danger-hover-background-color);
+      border-color: var(--tag-filled-danger-hover-border-color);
     }
   }
 }

--- a/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
@@ -22,7 +22,12 @@ data class BotBusinessRulesConfiguration(
     val _id: Id<BotBusinessRulesConfiguration>,
     val namespace: String,
     val botId: String,
-    val businessLexicon: String = "",
     val coveredTopics: List<String> = emptyList(),
     val excludedTopics: List<String> = emptyList(),
+    val lexiconGroups: List<BotBusinessRulesLexiconGroup> = emptyList(),
+)
+
+data class BotBusinessRulesLexiconGroup(
+    val id: Int,
+    val terms: List<String> = emptyList(),
 )

--- a/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.bot.businessrules
+
+import org.litote.kmongo.Id
+
+data class BotBusinessRulesConfiguration(
+    val _id: Id<BotBusinessRulesConfiguration>,
+    val namespace: String,
+    val botId: String,
+    val coveredTopics: List<String> = emptyList(),
+    val excludedTopics: List<String> = emptyList(),
+    val lexiconGroups: List<BotBusinessRulesLexiconGroup> = emptyList(),
+)
+
+data class BotBusinessRulesLexiconGroup(
+    val id: Int,
+    val terms: List<String> = emptyList(),
+)

--- a/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfiguration.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.bot.businessrules
+
+import org.litote.kmongo.Id
+
+data class BotBusinessRulesConfiguration(
+    val _id: Id<BotBusinessRulesConfiguration>,
+    val namespace: String,
+    val botId: String,
+    val businessLexicon: String = "",
+    val coveredTopics: List<String> = emptyList(),
+    val excludedTopics: List<String> = emptyList(),
+)

--- a/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfigurationDAO.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfigurationDAO.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.bot.businessrules
+
+import org.litote.kmongo.Id
+
+interface BotBusinessRulesConfigurationDAO {
+    fun save(conf: BotBusinessRulesConfiguration): BotBusinessRulesConfiguration
+
+    fun findByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration?
+
+    fun delete(id: Id<BotBusinessRulesConfiguration>)
+}

--- a/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfigurationDAO.kt
+++ b/bot/engine/src/main/kotlin/admin/bot/businessrules/BotBusinessRulesConfigurationDAO.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.admin.bot.businessrules
+
+import org.litote.kmongo.Id
+
+interface BotBusinessRulesConfigurationDAO {
+    fun listenChanges(listener: () -> Unit)
+
+    fun save(conf: BotBusinessRulesConfiguration): BotBusinessRulesConfiguration
+
+    fun findByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration?
+
+    fun delete(id: Id<BotBusinessRulesConfiguration>)
+}

--- a/bot/engine/src/main/kotlin/definition/BotDefinition.kt
+++ b/bot/engine/src/main/kotlin/definition/BotDefinition.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.bot.definition
 
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
 import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfiguration
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfiguration
 import ai.tock.bot.admin.bot.rag.BotRAGConfiguration
@@ -151,6 +152,11 @@ interface BotDefinition : I18nKeyProvider {
      * Document Compressor configuration
      */
     var documentCompressorConfiguration: BotDocumentCompressorConfiguration?
+
+    /**
+     * Business rules configuration
+     */
+    var businessRulesConfiguration: BotBusinessRulesConfiguration?
 
     /**
      * The list of each story.

--- a/bot/engine/src/main/kotlin/definition/BotDefinitionBase.kt
+++ b/bot/engine/src/main/kotlin/definition/BotDefinitionBase.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.bot.definition
 
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
 import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfiguration
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfiguration
 import ai.tock.bot.admin.bot.rag.BotRAGConfiguration
@@ -65,6 +66,7 @@ open class BotDefinitionBase(
     override var vectorStoreConfiguration: BotVectorStoreConfiguration? = null,
     override var observabilityConfiguration: BotObservabilityConfiguration? = null,
     override var documentCompressorConfiguration: BotDocumentCompressorConfiguration? = null,
+    override var businessRulesConfiguration: BotBusinessRulesConfiguration? = null,
 ) : BotDefinition {
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -42,6 +42,7 @@ import ai.tock.bot.definition.StoryDefinition
 import ai.tock.bot.definition.StoryHandlerListener
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.action.ActionNotificationType
+import ai.tock.bot.engine.config.BotBusinessRulesConfigurationMonitor
 import ai.tock.bot.engine.config.BotDocumentCompressorConfigurationMonitor
 import ai.tock.bot.engine.config.BotObservabilityConfigurationMonitor
 import ai.tock.bot.engine.config.BotRAGConfigurationMonitor
@@ -596,6 +597,7 @@ object BotRepository {
                 BotObservabilityConfigurationMonitor.monitor(bot)
                 BotVectorStoreConfigurationMonitor.monitor(bot)
                 BotDocumentCompressorConfigurationMonitor.monitor(bot)
+                BotBusinessRulesConfigurationMonitor.monitor(bot)
                 // register connector controller map
                 connectorControllerMap[this] = controller
                 applicationIdBotApplicationConfigurationMap[toKey()] = this
@@ -618,6 +620,7 @@ object BotRepository {
                 BotObservabilityConfigurationMonitor.unmonitor(controller.bot)
                 BotVectorStoreConfigurationMonitor.unmonitor(controller.bot)
                 BotDocumentCompressorConfigurationMonitor.unmonitor(controller.bot)
+                BotBusinessRulesConfigurationMonitor.unmonitor(controller.bot)
                 TockConnectorController.unregister(controller)
             }
         }

--- a/bot/engine/src/main/kotlin/engine/config/BotBusinessRulesConfigurationMonitor.kt
+++ b/bot/engine/src/main/kotlin/engine/config/BotBusinessRulesConfigurationMonitor.kt
@@ -57,7 +57,7 @@ internal object BotBusinessRulesConfigurationMonitor {
         bot.botDefinition.businessRulesConfiguration =
             businessRulesConfigurationDAO.findByNamespaceAndBotId(
                 bot.botDefinition.namespace,
-                bot.botDefinition.botId
+                bot.botDefinition.botId,
             )
     }
 }

--- a/bot/engine/src/main/kotlin/engine/config/BotBusinessRulesConfigurationMonitor.kt
+++ b/bot/engine/src/main/kotlin/engine/config/BotBusinessRulesConfigurationMonitor.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.engine.config
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.engine.Bot
+import ai.tock.shared.injector
+import com.github.salomonbrys.kodein.instance
+import mu.KotlinLogging
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ *
+ */
+internal object BotBusinessRulesConfigurationMonitor {
+    private val logger = KotlinLogging.logger {}
+
+    private val businessRulesConfigurationDAO: BotBusinessRulesConfigurationDAO by injector.instance()
+    private val botsToMonitor: MutableSet<Bot> = CopyOnWriteArraySet()
+
+    init {
+        logger.info { "start bot business rules configuration monitor" }
+        businessRulesConfigurationDAO.listenChanges {
+            logger.info { "refresh bots business rules configuration" }
+            botsToMonitor.forEach {
+                refresh(it)
+            }
+        }
+    }
+
+    fun monitor(bot: Bot) {
+        logger.debug { "load business rules configuration & monitor bot $bot" }
+        refresh(bot)
+        botsToMonitor.add(bot)
+    }
+
+    fun unmonitor(bot: Bot) {
+        botsToMonitor.remove(bot)
+    }
+
+    private fun refresh(bot: Bot) {
+        logger.debug { "Refreshing bot business rules configuration ${bot.botDefinition.botId} (${bot.configuration.applicationId}-${bot.configuration._id})..." }
+        bot.botDefinition.businessRulesConfiguration =
+            businessRulesConfigurationDAO.findByNamespaceAndBotId(
+                bot.botDefinition.namespace,
+                bot.botDefinition.botId
+            )
+    }
+}

--- a/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
+++ b/bot/engine/src/main/kotlin/engine/config/RAGAnswerHandler.kt
@@ -178,6 +178,7 @@ object RAGAnswerHandler : AbstractProactiveAnswerHandler {
             // Gen AI Orchestrator environment variable vector settings
             val ragConfiguration = botDefinition.ragConfiguration!!
             val vectorStoreConfiguration = botDefinition.vectorStoreConfiguration
+            val businessRulesConfiguration = botDefinition.businessRulesConfiguration
             val vectorStoreSetting = vectorStoreConfiguration?.takeIf { it.enabled }?.setting
 
             val (documentSearchParams, indexName) =
@@ -219,6 +220,8 @@ object RAGAnswerHandler : AbstractProactiveAnswerHandler {
                                             mapOf(
                                                 "question" to action.toString(),
                                                 "locale" to userPreferences.locale.displayLanguage,
+                                                "covered_topics" to businessRulesConfiguration?.coveredTopics.orEmpty(),
+                                                "excluded_topics" to businessRulesConfiguration?.excludedTopics.orEmpty(),
                                             ),
                                     ),
                                 embeddingQuestionEmSetting = ragConfiguration.emSetting,

--- a/bot/engine/src/test/kotlin/engine/BotEngineTest.kt
+++ b/bot/engine/src/test/kotlin/engine/BotEngineTest.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.engine
 
 import ai.tock.bot.admin.bot.BotApplicationConfiguration
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
 import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfigurationDAO
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfigurationDAO
 import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
@@ -90,6 +91,7 @@ internal abstract class BotEngineTest {
     val featureDAO: FeatureDAO = mockk(relaxed = true)
     val botObservabilityConfigurationDAO: BotObservabilityConfigurationDAO = mockk(relaxed = true)
     val botDocumentCompressorConfigurationDAO: BotDocumentCompressorConfigurationDAO = mockk(relaxed = true)
+    val botBusinessRulesConfigurationDAO: BotBusinessRulesConfigurationDAO = mockk(relaxed = true)
     val storyConfigurationMonitor: StoryConfigurationMonitor = spyk(StoryConfigurationMonitor(storyDefinitionConfigurationDAO))
 
     val entityA = Entity(EntityType("a"), "a")
@@ -143,6 +145,7 @@ internal abstract class BotEngineTest {
             bind<BotVectorStoreConfigurationDAO>() with provider { botVectorStoreConfigurationDAO }
             bind<BotObservabilityConfigurationDAO>() with provider { botObservabilityConfigurationDAO }
             bind<BotDocumentCompressorConfigurationDAO>() with provider { botDocumentCompressorConfigurationDAO }
+            bind<BotBusinessRulesConfigurationDAO>() with provider { botBusinessRulesConfigurationDAO }
             bind<StoryConfigurationMonitor>() with provider { storyConfigurationMonitor }
         }
     }

--- a/bot/storage-mongo/src/main/kotlin/BotBusinessRulesConfigurationMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/BotBusinessRulesConfigurationMongoDAO.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.mongo
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.mongo.MongoBotConfiguration.asyncDatabase
+import ai.tock.bot.mongo.MongoBotConfiguration.database
+import ai.tock.shared.ensureUniqueIndex
+import ai.tock.shared.watch
+import org.litote.kmongo.Id
+import org.litote.kmongo.deleteOneById
+import org.litote.kmongo.eq
+import org.litote.kmongo.findOne
+import org.litote.kmongo.getCollection
+import org.litote.kmongo.reactivestreams.getCollectionOfName
+import org.litote.kmongo.save
+
+internal object BotBusinessRulesConfigurationMongoDAO : BotBusinessRulesConfigurationDAO {
+    private const val COLLECTION_NAME = "bot_business_rules_configuration"
+    internal val col = database.getCollection<BotBusinessRulesConfiguration>(COLLECTION_NAME)
+    private val asyncCol = asyncDatabase.getCollectionOfName<BotBusinessRulesConfiguration>(COLLECTION_NAME)
+
+    init {
+        col.ensureUniqueIndex(BotBusinessRulesConfiguration::namespace, BotBusinessRulesConfiguration::botId)
+    }
+
+    override fun listenChanges(listener: () -> Unit) {
+        asyncCol.watch { listener() }
+    }
+
+    override fun findByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration? {
+        return col.findOne(
+            BotBusinessRulesConfiguration::namespace eq namespace,
+            BotBusinessRulesConfiguration::botId eq botId,
+        )
+    }
+
+    override fun save(conf: BotBusinessRulesConfiguration): BotBusinessRulesConfiguration {
+        col.save(conf)
+        return conf
+    }
+
+    override fun delete(id: Id<BotBusinessRulesConfiguration>) {
+        col.deleteOneById(id)
+    }
+}

--- a/bot/storage-mongo/src/main/kotlin/BotBusinessRulesConfigurationMongoDAO.kt
+++ b/bot/storage-mongo/src/main/kotlin/BotBusinessRulesConfigurationMongoDAO.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.mongo
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
+import ai.tock.bot.mongo.MongoBotConfiguration.database
+import ai.tock.shared.ensureUniqueIndex
+import org.litote.kmongo.Id
+import org.litote.kmongo.deleteOneById
+import org.litote.kmongo.eq
+import org.litote.kmongo.findOne
+import org.litote.kmongo.getCollection
+import org.litote.kmongo.save
+
+internal object BotBusinessRulesConfigurationMongoDAO : BotBusinessRulesConfigurationDAO {
+    private const val COLLECTION_NAME = "bot_business_rules_configuration"
+    internal val col = database.getCollection<BotBusinessRulesConfiguration>(COLLECTION_NAME)
+
+    init {
+        col.ensureUniqueIndex(BotBusinessRulesConfiguration::namespace, BotBusinessRulesConfiguration::botId)
+    }
+
+    override fun findByNamespaceAndBotId(
+        namespace: String,
+        botId: String,
+    ): BotBusinessRulesConfiguration? {
+        return col.findOne(
+            BotBusinessRulesConfiguration::namespace eq namespace,
+            BotBusinessRulesConfiguration::botId eq botId,
+        )
+    }
+
+    override fun save(conf: BotBusinessRulesConfiguration): BotBusinessRulesConfiguration {
+        col.save(conf)
+        return conf
+    }
+
+    override fun delete(id: Id<BotBusinessRulesConfiguration>) {
+        col.deleteOneById(id)
+    }
+}

--- a/bot/storage-mongo/src/main/kotlin/Ioc.kt
+++ b/bot/storage-mongo/src/main/kotlin/Ioc.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.mongo
 
 import ai.tock.bot.admin.bot.BotApplicationConfigurationDAO
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfigurationDAO
 import ai.tock.bot.admin.bot.compressor.BotDocumentCompressorConfigurationDAO
 import ai.tock.bot.admin.bot.observability.BotObservabilityConfigurationDAO
 import ai.tock.bot.admin.bot.rag.BotRAGConfigurationDAO
@@ -64,6 +65,7 @@ val botMongoModule =
                 )
             }
         bind<BotApplicationConfigurationDAO>() with provider { BotApplicationConfigurationMongoDAO }
+        bind<BotBusinessRulesConfigurationDAO>() with provider { BotBusinessRulesConfigurationMongoDAO }
         bind<BotRAGConfigurationDAO>() with provider { BotRAGConfigurationMongoDAO }
         bind<BotObservabilityConfigurationDAO>() with provider { BotObservabilityConfigurationMongoDAO }
         bind<BotDocumentCompressorConfigurationDAO>() with provider { BotDocumentCompressorConfigurationMongoDAO }

--- a/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.mongo
 
 import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.litote.kmongo.newId
@@ -36,9 +37,15 @@ internal class BotBusinessRulesConfigurationMongoDAOTest : AbstractTest() {
                 newId(),
                 "namespace1",
                 "botId1",
-                businessLexicon = "Term: definition",
                 coveredTopics = listOf("payments", "subscriptions"),
                 excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
             )
 
         BotBusinessRulesConfigurationMongoDAO.save(config)
@@ -54,15 +61,31 @@ internal class BotBusinessRulesConfigurationMongoDAOTest : AbstractTest() {
                 newId(),
                 "namespace1",
                 "botId1",
-                businessLexicon = "Term: definition",
                 coveredTopics = listOf("payments"),
                 excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
             )
 
         val updatedConfig =
             config.copy(
-                businessLexicon = "Updated term: updated definition",
                 coveredTopics = listOf("payments", "subscriptions"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account", "Deposit account"),
+                        ),
+                        BotBusinessRulesLexiconGroup(
+                            id = 2,
+                            terms = listOf("LDDS", "Sustainable development savings account"),
+                        ),
+                    ),
             )
 
         BotBusinessRulesConfigurationMongoDAO.save(config)
@@ -80,9 +103,15 @@ internal class BotBusinessRulesConfigurationMongoDAOTest : AbstractTest() {
                 newId(),
                 "namespace1",
                 "botId1",
-                businessLexicon = "Term: definition",
                 coveredTopics = listOf("payments"),
                 excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
             )
 
         BotBusinessRulesConfigurationMongoDAO.save(config)

--- a/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.mongo
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesLexiconGroup
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.litote.kmongo.newId
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class BotBusinessRulesConfigurationMongoDAOTest : AbstractTest() {
+    @BeforeEach
+    fun cleanup() {
+        BotBusinessRulesConfigurationMongoDAO.col.drop()
+    }
+
+    @Test
+    fun `save business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                coveredTopics = listOf("payments", "subscriptions"),
+                excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertEquals(config, configBDD)
+    }
+
+    @Test
+    fun `update business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                coveredTopics = listOf("payments"),
+                excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
+            )
+
+        val updatedConfig =
+            config.copy(
+                coveredTopics = listOf("payments", "subscriptions"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account", "Deposit account"),
+                        ),
+                        BotBusinessRulesLexiconGroup(
+                            id = 2,
+                            terms = listOf("LDDS", "Sustainable development savings account"),
+                        ),
+                    ),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        BotBusinessRulesConfigurationMongoDAO.save(updatedConfig)
+
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertEquals(updatedConfig, configBDD)
+    }
+
+    @Test
+    fun `delete business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                coveredTopics = listOf("payments"),
+                excludedTopics = listOf("legal advice"),
+                lexiconGroups =
+                    listOf(
+                        BotBusinessRulesLexiconGroup(
+                            id = 1,
+                            terms = listOf("Checking account", "Current account"),
+                        ),
+                    ),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        BotBusinessRulesConfigurationMongoDAO.delete(config._id)
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertNull(configBDD)
+    }
+}

--- a/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/BotBusinessRulesConfigurationMongoDAOTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.mongo
+
+import ai.tock.bot.admin.bot.businessrules.BotBusinessRulesConfiguration
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.litote.kmongo.newId
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class BotBusinessRulesConfigurationMongoDAOTest : AbstractTest() {
+    @BeforeEach
+    fun cleanup() {
+        BotBusinessRulesConfigurationMongoDAO.col.drop()
+    }
+
+    @Test
+    fun `save business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                businessLexicon = "Term: definition",
+                coveredTopics = listOf("payments", "subscriptions"),
+                excludedTopics = listOf("legal advice"),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertEquals(config, configBDD)
+    }
+
+    @Test
+    fun `update business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                businessLexicon = "Term: definition",
+                coveredTopics = listOf("payments"),
+                excludedTopics = listOf("legal advice"),
+            )
+
+        val updatedConfig =
+            config.copy(
+                businessLexicon = "Updated term: updated definition",
+                coveredTopics = listOf("payments", "subscriptions"),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        BotBusinessRulesConfigurationMongoDAO.save(updatedConfig)
+
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertEquals(updatedConfig, configBDD)
+    }
+
+    @Test
+    fun `delete business rules configuration`() {
+        val config =
+            BotBusinessRulesConfiguration(
+                newId(),
+                "namespace1",
+                "botId1",
+                businessLexicon = "Term: definition",
+                coveredTopics = listOf("payments"),
+                excludedTopics = listOf("legal advice"),
+            )
+
+        BotBusinessRulesConfigurationMongoDAO.save(config)
+        BotBusinessRulesConfigurationMongoDAO.delete(config._id)
+        val configBDD = BotBusinessRulesConfigurationMongoDAO.findByNamespaceAndBotId("namespace1", "botId1")
+
+        assertNull(configBDD)
+    }
+}

--- a/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/.pre-commit-config.yaml
+++ b/gen-ai/orchestrator-server/src/main/python/tock-llm-indexing-tools/.pre-commit-config.yaml
@@ -43,6 +43,6 @@ repos:
           - "--ignore-vuln"
           - "GHSA-5239-wwwm-4pmq"
         additional_dependencies:
-          - "pip>=26.0"
+          - "pip>=26.1.2"
           - "filelock>=3.20.3"
           - "urllib3>=2.6.3"


### PR DESCRIPTION
Ticket : [DERCBOT-1904](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1904)

### Goal
Add backend storage, APIs, and RAG prompt injection for bot business rules used by GenAI/RAG configuration.

### Details
- Add a new Mongo collection for business rules, indexed by namespace and botId
- Store covered topics, excluded topics, and lexicon groups per bot
- Add a GET endpoint: `/gen-ai/bots/:botId/configuration/business-rules`
- Add a POST endpoint for create/update on the same path
- Use POST as a full replacement of the business rules configuration
- Clean up the business rules configuration when deleting an application
- Load and cache business rules configuration like the other GenAI bot configs
- Refresh the cached business rules when the Mongo configuration changes
- Inject `covered_topics` and `excluded_topics` into the RAG question-answering prompt inputs