### PR TITLE
[DERCBOT-1924] Fix race condition when starting dataset run

### DIFF
--- a/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetRunWorker.kt
@@ -44,6 +44,8 @@ private const val DEFAULT_DATASET_RUN_WORKER_POLL_INTERVAL_MS = 2000L
 private const val DEFAULT_DATASET_RUN_WORKER_MAX_RETRIES = 0
 private const val RAG_DEBUG_MESSAGE_TEXT = "RAG"
 private const val RAG_TECHNICAL_ERROR_STATUS = "technical_error"
+private const val MISSING_QUESTION_RESULT_ERROR =
+    "Dataset question result was missing before execution; the question was not sent to the bot."
 private val MIN_TIMER_DELAY: Duration = Duration.ofMillis(1)
 
 fun interface DatasetQuestionExecutor {
@@ -108,13 +110,34 @@ class DatasetRunProcessor(
                 .associateBy { it.questionId }
                 .toMutableMap()
 
+        dataset.questions
+            .filterNot { questionResultsById.containsKey(it.id) }
+            .forEach { question ->
+                logger.error { "Missing dataset question result for run ${run._id} and question ${question.id}." }
+                questionResultsById[question.id] =
+                    datasetRunDAO.saveQuestionResult(
+                        DatasetRunQuestionResult(
+                            namespace = run.namespace,
+                            botId = run.botId,
+                            datasetId = run.datasetId,
+                            runId = run._id,
+                            questionId = question.id,
+                            state = DatasetRunQuestionResultState.FAILED,
+                            startedAt = now(),
+                            endedAt = now(),
+                            userIdModifier = "dataset_${run._id}_${question.id}",
+                            error = MISSING_QUESTION_RESULT_ERROR,
+                        ),
+                    )
+            }
+
         dataset.questions.forEach { question ->
             val refreshedRun = datasetRunDAO.getRunById(run._id) ?: return
             if (refreshedRun.state == DatasetRunState.CANCELLED) {
                 return
             }
 
-            val questionResult = questionResultsById[question.id] ?: return@forEach
+            val questionResult = questionResultsById.getValue(question.id)
             if (questionResult.state.isTerminal()) {
                 return@forEach
             }

--- a/bot/admin/server/src/main/kotlin/service/DatasetService.kt
+++ b/bot/admin/server/src/main/kotlin/service/DatasetService.kt
@@ -138,19 +138,17 @@ object DatasetService {
         val now = Instant.now()
         val languageTag = request.language.trim()
 
-        val savedRun =
-            datasetRunDAO.saveRun(
-                DatasetRun(
-                    namespace = namespace,
-                    botId = botId,
-                    datasetId = dataset._id,
-                    state = DatasetRunState.QUEUED,
-                    startTime = now,
-                    startedBy = userLogin,
-                    language = Locale.forLanguageTag(languageTag),
-                    botApplicationConfigurationId = testConfiguration._id,
-                    settingsSnapshot = buildSettingsSnapshot(namespace, botId),
-                ),
+        val run =
+            DatasetRun(
+                namespace = namespace,
+                botId = botId,
+                datasetId = dataset._id,
+                state = DatasetRunState.QUEUED,
+                startTime = now,
+                startedBy = userLogin,
+                language = Locale.forLanguageTag(languageTag),
+                botApplicationConfigurationId = testConfiguration._id,
+                settingsSnapshot = buildSettingsSnapshot(namespace, botId),
             )
 
         datasetRunDAO.saveQuestionResults(
@@ -159,13 +157,14 @@ object DatasetService {
                     namespace = namespace,
                     botId = botId,
                     datasetId = dataset._id,
-                    runId = savedRun._id,
+                    runId = run._id,
                     questionId = question.id,
-                    userIdModifier = "dataset_${savedRun._id}_${question.id}",
+                    userIdModifier = "dataset_${run._id}_${question.id}",
                 )
             },
         )
 
+        val savedRun = datasetRunDAO.saveRun(run)
         val questionResults = datasetRunDAO.getQuestionResultsByRunId(savedRun._id)
         return savedRun.toDTO(
             includeSettingsSnapshot = false,

--- a/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetRunProcessorTest.kt
@@ -185,6 +185,55 @@ class DatasetRunProcessorTest {
     }
 
     @Test
+    fun `processNextQueuedRun marks missing question results as failed instead of skipping them`() {
+        val dataset = newDataset()
+        val run = newRun(dataset)
+        val firstQuestion = dataset.questions.first()
+        val secondQuestion = dataset.questions.last()
+        val firstResult = newQuestionResult(run, dataset, firstQuestion.id)
+        val savedQuestionResults = mutableListOf<DatasetRunQuestionResult>()
+        val savedRuns = mutableListOf<DatasetRun>()
+
+        every { datasetRunDAO.claimNextQueuedRun() } returns run
+        every { datasetDAO.getDatasetById(any()) } returns dataset
+        every { datasetRunDAO.getQuestionResultsByRunId(any()) } returns listOf(firstResult)
+        every { datasetRunDAO.getRunById(any()) } returns run.copy(state = DatasetRunState.RUNNING)
+        every { datasetRunDAO.saveQuestionResult(any()) } answers {
+            firstArg<DatasetRunQuestionResult>().also { savedQuestionResults.add(it) }
+        }
+        every { datasetRunDAO.saveRun(any()) } answers {
+            firstArg<DatasetRun>().also { savedRuns.add(it) }
+        }
+
+        val processor =
+            DatasetRunProcessor(
+                datasetDAO = datasetDAO,
+                datasetRunDAO = datasetRunDAO,
+                questionExecutor =
+                    DatasetQuestionExecutor { _, questionResult, _ ->
+                        BotDialogResponse(emptyList(), userActionId = "user-action-${questionResult.questionId}")
+                    },
+                clock = fixedClock,
+            )
+
+        val processed = processor.processNextQueuedRun()
+
+        assertTrue(processed)
+        assertEquals(DatasetRunState.COMPLETED, savedRuns.last().state)
+
+        val failedMissingResult = savedQuestionResults.first { it.questionId == secondQuestion.id }
+        assertEquals(DatasetRunQuestionResultState.FAILED, failedMissingResult.state)
+        assertEquals(
+            "Dataset question result was missing before execution; the question was not sent to the bot.",
+            failedMissingResult.error,
+        )
+
+        val completedResult = savedQuestionResults.last { it.questionId == firstQuestion.id }
+        assertEquals(DatasetRunQuestionResultState.COMPLETED, completedResult.state)
+        assertEquals("user-action-${firstQuestion.id}", completedResult.userActionId)
+    }
+
+    @Test
     fun `processNextQueuedRun stops immediately when the claimed run is already cancelled`() {
         val dataset = newDataset(questionCount = 1)
         val run = newRun(dataset)

--- a/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
+++ b/bot/admin/server/src/test/kotlin/service/DatasetServiceTest.kt
@@ -63,6 +63,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -152,6 +153,10 @@ class DatasetServiceTest : AbstractTest() {
         assertEquals(2, result.stats.totalQuestions)
         assertEquals(0, result.stats.completedQuestions)
         assertEquals(0, result.stats.failedQuestions)
+        verifyOrder {
+            datasetRunDAO.saveQuestionResults(any())
+            datasetRunDAO.saveRun(any())
+        }
 
         val savedRun = runSlot.captured
         assertEquals(dataset._id, savedRun.datasetId)


### PR DESCRIPTION
  Ticket : [DERCBOT-1924](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1924)

  ### Goal
  Fix an issue where a dataset run could be marked as completed while some questions were never executed.

  ### Details
  - Create all dataset question tracking entries before making the run available to the worker
  - Prevent the worker from picking a run before all questions are prepared
  - Add a fallback in the worker when a question tracking entry is unexpectedly missing
  - Mark missing question results as failed with an explicit error instead of silently skipping them