### PR TITLE
[DERCBOT-1914] Enrich RAG context with source metadata and chunk ids

### DIFF
--- a/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
+++ b/bot/admin/web/src/app/rag/rag-settings/models/engines-configurations.ts
@@ -347,7 +347,7 @@ Must list ALL retrieved chunks.
 
 For each chunk:
 
-- chunk: identifier
+- chunk: exact chunk_id value from the context
 - sentences: exact sentences extracted from context, used to answer the question.
 - used_in_response: true or false
 - reason: required if the chunk is not used in response.

--- a/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/src/gen_ai_orchestrator/services/langchain/rag_chain.py
@@ -23,6 +23,7 @@ import time
 from functools import partial
 from operator import itemgetter
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from langchain_classic.retrievers import ContextualCompressionRetriever
 from langchain_community.chat_message_histories import ChatMessageHistory
@@ -226,7 +227,7 @@ async def execute_rag_chain(
                 metadata=doc.metadata.copy(),
             )
             for doc in response['documents']
-            if doc.metadata['id'] in contexts_by_chunk
+            if get_chunk_identifier(doc) in contexts_by_chunk
         },
         observability_info=get_observability_info(
             observability_handler,
@@ -236,6 +237,45 @@ async def execute_rag_chain(
         if debug
         else None,
     )
+
+
+def get_chunk_identifier(doc: Document) -> str:
+    """Build the chunk identifier exposed to the LLM."""
+    document_id = doc.metadata.get('id')
+    chunk = doc.metadata.get('chunk')
+    if document_id and chunk:
+        return f'{document_id}:{chunk}'
+    if document_id:
+        return str(document_id)
+    return str(chunk or '')
+
+
+def get_web_source_url(doc: Document) -> Optional[str]:
+    """Return the document source only when it is an HTTP(S) URL."""
+    source = doc.metadata.get('source') or doc.metadata.get('reference')
+    if not source:
+        return None
+
+    source_url = str(source).strip()
+    parsed_url = urlparse(source_url)
+    if parsed_url.scheme in {'http', 'https'} and parsed_url.netloc:
+        return source_url
+    return None
+
+
+def format_rag_context_documents(
+    documents: List[Document],
+) -> List[dict[str, Optional[str]]]:
+    """Format retrieved documents as the JSON context injected in the RAG prompt."""
+    return [
+        {
+            'chunk_id': get_chunk_identifier(doc),
+            'title': doc.metadata.get('title'),
+            'source_url': get_web_source_url(doc),
+            'chunk_text': doc.page_content,
+        }
+        for doc in documents
+    ]
 
 
 def get_source_content(doc: Document) -> str:
@@ -353,13 +393,7 @@ def create_rag_chain(
         answer=(
             {
                 'context': lambda x: json.dumps(
-                    [
-                        {
-                            'chunk_id': doc.metadata['id'],
-                            'chunk_text': doc.page_content,
-                        }
-                        for doc in x['documents']
-                    ],
+                    format_rag_context_documents(x['documents']),
                     ensure_ascii=False,
                     indent=2,
                 ),

--- a/gen-ai/orchestrator-server/src/main/python/server/tests/services/test_rag_chain.py
+++ b/gen-ai/orchestrator-server/src/main/python/server/tests/services/test_rag_chain.py
@@ -41,7 +41,140 @@ from gen_ai_orchestrator.services.langchain.impls.document_compressor.bloomz_rer
 from gen_ai_orchestrator.services.langchain.rag_chain import (
     check_guardrail_output,
     execute_rag_chain,
+    format_rag_context_documents,
+    get_chunk_identifier,
+    get_web_source_url,
 )
+
+
+def _rag_request() -> RAGRequest:
+    return RAGRequest(
+        **{
+            'dialog': {'history': [], 'tags': []},
+            'question_answering_llm_setting': {
+                'provider': 'OpenAI',
+                'api_key': {
+                    'type': 'Raw',
+                    'secret': 'ab7***************************A1IV4B',
+                },
+                'temperature': 1.2,
+                'model': 'gpt-3.5-turbo',
+            },
+            'question_answering_prompt': {
+                'formatter': 'f-string',
+                'template': 'Context: {context}\nQuestion: {question}',
+                'inputs': {
+                    'question': 'How to find a page?',
+                },
+            },
+            'embedding_question_em_setting': {
+                'provider': 'OpenAI',
+                'api_key': {
+                    'type': 'Raw',
+                    'secret': 'ab7***************************A1IV4B',
+                },
+                'model': 'text-embedding-ada-002',
+            },
+            'document_index_name': 'my-index-name',
+            'document_search_params': {
+                'provider': 'OpenSearch',
+                'filter': [],
+                'k': 4,
+            },
+            'vector_store_setting': {
+                'provider': 'OpenSearch',
+                'host': 'localhost',
+                'port': 9200,
+                'username': 'admin',
+                'password': {
+                    'type': 'Raw',
+                    'secret': 'admin',
+                },
+            },
+        }
+    )
+
+
+def test_format_rag_context_documents_adds_source_metadata_and_composite_chunk_id():
+    web_doc = Document(
+        page_content='Web page content',
+        metadata={
+            'id': 'doc-1',
+            'chunk': '2/5',
+            'title': 'A web page',
+            'source': 'https://intranet.example.com/page',
+        },
+    )
+    file_doc = Document(
+        page_content='File content',
+        metadata={
+            'id': 'doc-2',
+            'chunk': '1/1',
+            'title': 'A file',
+            'source': 'document.pdf',
+        },
+    )
+
+    assert get_chunk_identifier(web_doc) == 'doc-1:2/5'
+    assert get_web_source_url(web_doc) == 'https://intranet.example.com/page'
+    assert get_web_source_url(file_doc) is None
+    assert format_rag_context_documents([web_doc, file_doc]) == [
+        {
+            'chunk_id': 'doc-1:2/5',
+            'title': 'A web page',
+            'source_url': 'https://intranet.example.com/page',
+            'chunk_text': 'Web page content',
+        },
+        {
+            'chunk_id': 'doc-2:1/1',
+            'title': 'A file',
+            'source_url': None,
+            'chunk_text': 'File content',
+        },
+    ]
+
+
+@patch('gen_ai_orchestrator.services.langchain.rag_chain.create_rag_chain')
+@pytest.mark.asyncio
+async def test_execute_rag_chain_matches_footnotes_with_composite_chunk_id(
+    mocked_create_rag_chain,
+):
+    doc = Document(
+        page_content='A web page\n\nThe useful source content.',
+        metadata={
+            'id': 'doc-1',
+            'chunk': '2/5',
+            'title': 'A web page',
+            'source': 'https://intranet.example.com/page',
+        },
+    )
+    mocked_chain = mocked_create_rag_chain.return_value
+    mocked_chain.ainvoke = AsyncMock(
+        return_value={
+            'answer': {
+                'status': 'found_in_context',
+                'answer': 'Use the intranet page.',
+                'display_answer': True,
+                'context_usage': [
+                    {
+                        'chunk': 'doc-1:2/5',
+                        'sentences': ['The useful source content.'],
+                        'used_in_response': True,
+                    }
+                ],
+            },
+            'documents': [doc],
+        }
+    )
+
+    response = await execute_rag_chain(_rag_request(), debug=False)
+
+    assert len(response.footnotes) == 1
+    footnote = next(iter(response.footnotes))
+    assert footnote.identifier == 'doc-1'
+    assert footnote.title == 'A web page'
+    assert str(footnote.url) == 'https://intranet.example.com/page'
+    assert footnote.content == 'The useful source content.'
 
 
 @patch(


### PR DESCRIPTION
Ticket: [DERCBOT-1914](https://jiradc.intra.arkea.com:8443/jira/browse/DERCBOT-1914)

### Goal
Expose richer RAG context metadata so the LLM can identify the exact source chunk and return web page URLs when available.

### Details
- Add `title` and `source_url` to the JSON context injected into the RAG prompt
- Populate `source_url` only when the document source is an HTTP(S) URL
- Change `chunk_id` to concatenate the document id and chunk value
- Match RAG footnotes using the new composite chunk identifier
- Update the default RAG prompt instructions to require the exact `chunk_id`