### PR TITLE
resolve #2058 [Bot Engine] add transientContext argument to pushNotification

### DIFF
--- a/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
+++ b/bot/connector-messenger/src/main/kotlin/MessengerConnector.kt
@@ -45,6 +45,7 @@ import ai.tock.bot.connector.messenger.model.send.SenderAction.typing_off
 import ai.tock.bot.connector.messenger.model.send.SenderAction.typing_on
 import ai.tock.bot.connector.messenger.model.send.UrlPayload
 import ai.tock.bot.connector.messenger.model.webhook.CallbackRequest
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -624,6 +625,7 @@ class MessengerConnector internal constructor(
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {
@@ -638,6 +640,7 @@ class MessengerConnector internal constructor(
             ),
             ConnectorData(
                 MessengerConnectorCallback(connectorId, notificationType, errorListener),
+                transientContext = transientContext,
             ),
         )
     }

--- a/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
+++ b/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
@@ -23,6 +23,7 @@ import ai.tock.bot.connector.ConnectorFeature.CAROUSEL
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.connector.media.MediaMessage
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -199,6 +200,7 @@ class OpenAIConnector internal constructor(
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {

--- a/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
+++ b/bot/connector-open-ai/src/main/kotlin/OpenAIConnector.kt
@@ -160,7 +160,7 @@ class OpenAIConnector internal constructor(
                 context.request().getHeader("Accept-Language")
                     ?.let { Locale.forLanguageTag(it) } ?: defaultLocale
             val event = request.toEvent(connectorId, chatId)
-            handleEvent(connectorId, locale, event, controller, context, emptyMap())
+            handleEvent(connectorId, locale, event, controller, context, emptyMap(), DialogContext.EMPTY)
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)
@@ -176,6 +176,7 @@ class OpenAIConnector internal constructor(
         controller: ConnectorController,
         context: RoutingContext?,
         headersMetadata: Map<String, String>,
+        transientDialogContext: DialogContext,
     ) {
         val callback =
             OpenAIConnectorCallback(
@@ -190,6 +191,7 @@ class OpenAIConnector internal constructor(
             ConnectorData(
                 callback = callback,
                 metadata = headersMetadata,
+                transientContext = transientDialogContext,
             ),
         )
     }
@@ -222,6 +224,7 @@ class OpenAIConnector internal constructor(
             controller = controller,
             context = null,
             headersMetadata = emptyMap(),
+            transientDialogContext = transientContext,
         )
     }
 

--- a/bot/connector-twitter/src/main/kotlin/TwitterConnector.kt
+++ b/bot/connector-twitter/src/main/kotlin/TwitterConnector.kt
@@ -34,6 +34,7 @@ import ai.tock.bot.connector.twitter.model.outcoming.DirectMessageOutcomingEvent
 import ai.tock.bot.connector.twitter.model.outcoming.OutcomingEvent
 import ai.tock.bot.connector.twitter.model.outcoming.Tweet
 import ai.tock.bot.connector.twitter.model.toMediaCategory
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -260,6 +261,7 @@ internal class TwitterConnector internal constructor(
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -149,7 +149,7 @@ class WebConnector internal constructor(
                                     ?: context.body().asString() ?: error("message is mandatory and is missing")
                             context.response().setupSSE()
 
-                            handleRequest(controller, context, body)
+                            handleRequest(controller, context, body, transientContext = DialogContext.EMPTY)
                         } catch (t: Throwable) {
                             context.fail(t)
                         }
@@ -162,6 +162,7 @@ class WebConnector internal constructor(
                 .coHandler { context ->
                     // Override the user on the request body
                     val tockUserId: String? = context.get<String>(TOCK_USER_ID)
+                    val transientContext: DialogContext = context.get(WebSecurityHandler.TRANSIENT_DIALOG_CONTEXT_KEY) ?: DialogContext.EMPTY
                     val body =
                         tockUserId?.let {
                             val jsonBody = context.body().asJsonObject() ?: JsonObject()
@@ -170,7 +171,7 @@ class WebConnector internal constructor(
                         } ?: context.body().asString()
 
                     // Handle the request
-                    handleRequest(controller, context, body)
+                    handleRequest(controller, context, body, transientContext)
                 }
         }
     }
@@ -185,6 +186,7 @@ class WebConnector internal constructor(
         controller: ConnectorController,
         context: RoutingContext,
         body: String,
+        transientContext: DialogContext,
     ) {
         val timerData = BotRepository.requestTimer.start("web_webhook")
         try {
@@ -205,7 +207,7 @@ class WebConnector internal constructor(
             val event = request.toEvent(applicationId)
             val requestInfos = WebRequestInfos(context.request())
             WebRequestInfosByEvent.put(event.id.toString(), requestInfos)
-            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos), transientDialogContext = DialogContext.EMPTY, errorListener = null)
+            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos), transientDialogContext = transientContext, errorListener = null)
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)

--- a/bot/connector-web/src/main/kotlin/WebConnector.kt
+++ b/bot/connector-web/src/main/kotlin/WebConnector.kt
@@ -32,6 +32,7 @@ import ai.tock.bot.connector.web.send.WebCard
 import ai.tock.bot.connector.web.send.WebCarousel
 import ai.tock.bot.connector.web.sse.SseEndpoint
 import ai.tock.bot.connector.web.sse.SseEndpoint.Companion.webMapper
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -204,7 +205,7 @@ class WebConnector internal constructor(
             val event = request.toEvent(applicationId)
             val requestInfos = WebRequestInfos(context.request())
             WebRequestInfosByEvent.put(event.id.toString(), requestInfos)
-            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos), errorListener = null)
+            handleEvent(applicationId, request.locale, event, controller, context, extraHeadersAsMetadata(requestInfos), transientDialogContext = DialogContext.EMPTY, errorListener = null)
         } catch (t: Throwable) {
             BotRepository.requestTimer.throwable(t, timerData)
             context.fail(t)
@@ -221,6 +222,7 @@ class WebConnector internal constructor(
         context: RoutingContext?,
         headersMetadata: Map<String, String>,
         errorListener: ((Throwable) -> Unit)?,
+        transientDialogContext: DialogContext,
     ) {
         val callback =
             WebConnectorCallback(
@@ -242,6 +244,7 @@ class WebConnector internal constructor(
             ConnectorData(
                 callback = callback,
                 metadata = headersMetadata,
+                transientContext = transientDialogContext,
             ),
         )
     }
@@ -252,6 +255,7 @@ class WebConnector internal constructor(
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {
@@ -274,6 +278,7 @@ class WebConnector internal constructor(
             context = null,
             headersMetadata = emptyMap(),
             errorListener = errorListener,
+            transientDialogContext = transientContext,
         )
     }
 

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -31,6 +31,7 @@ import ai.tock.bot.connector.whatsapp.cloud.services.WhatsAppCloudApiService
 import ai.tock.bot.connector.whatsapp.cloud.spi.TemplateGenerationContext
 import ai.tock.bot.connector.whatsapp.cloud.spi.TemplateManagementContext
 import ai.tock.bot.connector.whatsapp.cloud.spi.WhatsappTemplateProvider
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -261,6 +262,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
     ) {
@@ -275,6 +277,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
             ),
             ConnectorData(
                 WhatsAppConnectorCloudCallback(connectorId),
+                transientContext = transientContext,
             ),
         )
     }

--- a/bot/engine/src/main/kotlin/connector/Connector.kt
+++ b/bot/engine/src/main/kotlin/connector/Connector.kt
@@ -17,6 +17,7 @@
 package ai.tock.bot.connector
 
 import ai.tock.bot.connector.media.MediaMessage
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryStepDef
 import ai.tock.bot.engine.BotBus
@@ -127,6 +128,7 @@ interface Connector {
         intent: IntentAware,
         step: StoryStepDef? = null,
         parameters: Map<String, String> = emptyMap(),
+        transientContext: DialogContext = DialogContext.EMPTY,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit = {},
     ): Unit = throw UnsupportedOperationException("Connector $connectorType does not support notification")

--- a/bot/engine/src/main/kotlin/connector/ConnectorData.kt
+++ b/bot/engine/src/main/kotlin/connector/ConnectorData.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.bot.connector
 
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.engine.user.PlayerId
 
 /**
@@ -45,9 +46,10 @@ open class ConnectorData(
      */
     val referer: String? = null,
     /**
-     * optional metadata metadata from connector
+     * optional metadata from connector
      */
     val metadata: Map<String, String> = emptyMap(),
+    val transientContext: DialogContext = DialogContext.EMPTY,
 ) {
     /**
      * Set to true if the bot does not make any answer to a user sentence.

--- a/bot/engine/src/main/kotlin/definition/DialogContext.kt
+++ b/bot/engine/src/main/kotlin/definition/DialogContext.kt
@@ -64,13 +64,6 @@ interface DialogContext {
     fun asMap(): Map<DialogContextKey<*>, Any>
 
     operator fun <T : Any> get(key: DialogContextKey<T>): T?
-
-    operator fun <T : Any> set(
-        key: DialogContextKey<T>,
-        value: T,
-    )
-
-    fun <T : Any> add(entry: Pair<DialogContextKey<T>, T>)
 }
 
 interface MutableDialogContext : DialogContext {
@@ -82,6 +75,13 @@ interface MutableDialogContext : DialogContext {
         key: DialogContextKey<T>,
         value: T,
     )
+
+    operator fun <T : Any> set(
+        key: DialogContextKey<T>,
+        value: T,
+    )
+
+    fun <T : Any> add(entry: Pair<DialogContextKey<T>, T>)
 
     fun remove(key: DialogContextKey<*>)
 

--- a/bot/engine/src/main/kotlin/definition/DialogContext.kt
+++ b/bot/engine/src/main/kotlin/definition/DialogContext.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2017/2025 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.tock.bot.definition
+
+import com.fasterxml.jackson.annotation.JsonValue
+import java.util.Collections
+import kotlin.reflect.safeCast
+
+/**
+ * An arbitrary data store for dialogs, intended for use by bot stories
+ *
+ * @see ai.tock.bot.engine.BotBus.getBusContextValue
+ * @see ai.tock.bot.engine.BotBus.setBusContextValue
+ */
+interface DialogContext {
+    companion object {
+        val EMPTY: DialogContext = DialogContextMap.EMPTY
+
+        fun <T : Any> of(entry: Pair<DialogContextKey<T>, T>): DialogContext =
+            DialogContextMap().apply {
+                add(entry)
+            }
+
+        fun <T1 : Any, T2 : Any> of(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+        ): DialogContext =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+            }
+
+        fun <T1 : Any, T2 : Any, T3 : Any> of(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+            entry3: Pair<DialogContextKey<T3>, T3>,
+        ): DialogContext =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+                add(entry3)
+            }
+
+        fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any> of(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+            entry3: Pair<DialogContextKey<T3>, T3>,
+            entry4: Pair<DialogContextKey<T4>, T4>,
+        ): DialogContext =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+                add(entry3)
+                add(entry4)
+            }
+    }
+
+    /**
+     * @return a Map view of this context store
+     */
+    fun asMap(): Map<DialogContextKey<*>, Any>
+
+    operator fun <T : Any> get(key: DialogContextKey<T>): T?
+
+    operator fun <T : Any> set(
+        key: DialogContextKey<T>,
+        value: T,
+    )
+
+    fun <T : Any> add(entry: Pair<DialogContextKey<T>, T>)
+}
+
+interface MutableDialogContext : DialogContext {
+    override fun asMap(): MutableMap<DialogContextKey<*>, Any>
+
+    operator fun <T : Any> plusAssign(entry: Pair<DialogContextKey<T>, T>)
+
+    fun <T : Any> put(
+        key: DialogContextKey<T>,
+        value: T,
+    )
+
+    fun remove(key: DialogContextKey<*>)
+}
+
+class DialogContextMap private constructor(
+    @JsonValue private val entries: MutableMap<DialogContextKey<*>, Any>,
+) : MutableDialogContext {
+    companion object {
+        val EMPTY = DialogContextMap(Collections.emptyMap())
+    }
+
+    constructor() : this(mutableMapOf())
+    constructor(other: DialogContext) : this(other.asMap().toMutableMap())
+
+    override fun asMap() = entries
+
+    override operator fun <T : Any> get(key: DialogContextKey<T>): T? {
+        return key.type.safeCast(entries[key])
+    }
+
+    override fun <T : Any> set(
+        key: DialogContextKey<T>,
+        value: T,
+    ) {
+        entries[key] = value
+    }
+
+    override operator fun <T : Any> plusAssign(entry: Pair<DialogContextKey<T>, T>) {
+        put(entry.first, entry.second)
+    }
+
+    override fun <T : Any> add(entry: Pair<DialogContextKey<T>, T>) {
+        put(entry.first, entry.second)
+    }
+
+    override fun <T : Any> put(
+        key: DialogContextKey<T>,
+        value: T,
+    ) {
+        entries[key] = value
+    }
+
+    override fun remove(key: DialogContextKey<*>) {
+        entries.remove(key)
+    }
+
+    override fun toString(): String {
+        return entries.toString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DialogContextMap
+
+        return entries == other.entries
+    }
+
+    override fun hashCode(): Int {
+        return entries.hashCode()
+    }
+}

--- a/bot/engine/src/main/kotlin/definition/DialogContext.kt
+++ b/bot/engine/src/main/kotlin/definition/DialogContext.kt
@@ -23,50 +23,39 @@ import kotlin.reflect.safeCast
 /**
  * An arbitrary data store for dialogs, intended for use by bot stories
  *
+ * In contexts where the data is persisted, the key's type is used for (de)serialization
+ *
+ * @see ai.tock.bot.engine.BotBus.contextValue
+ * @see ai.tock.bot.engine.BotBus.changeContextValue
  * @see ai.tock.bot.engine.BotBus.getBusContextValue
  * @see ai.tock.bot.engine.BotBus.setBusContextValue
  */
 interface DialogContext {
     companion object {
+        /**
+         * The empty immutable [DialogContext]
+         */
         val EMPTY: DialogContext = DialogContextMap.EMPTY
 
-        fun <T : Any> of(entry: Pair<DialogContextKey<T>, T>): DialogContext =
-            DialogContextMap().apply {
-                add(entry)
-            }
+        fun <T : Any> of(entry: Pair<DialogContextKey<T>, T>): DialogContext = DialogContextMap(entry)
 
         fun <T1 : Any, T2 : Any> of(
             entry1: Pair<DialogContextKey<T1>, T1>,
             entry2: Pair<DialogContextKey<T2>, T2>,
-        ): DialogContext =
-            DialogContextMap().apply {
-                add(entry1)
-                add(entry2)
-            }
+        ): DialogContext = DialogContextMap(entry1, entry2)
 
         fun <T1 : Any, T2 : Any, T3 : Any> of(
             entry1: Pair<DialogContextKey<T1>, T1>,
             entry2: Pair<DialogContextKey<T2>, T2>,
             entry3: Pair<DialogContextKey<T3>, T3>,
-        ): DialogContext =
-            DialogContextMap().apply {
-                add(entry1)
-                add(entry2)
-                add(entry3)
-            }
+        ): DialogContext = DialogContextMap(entry1, entry2, entry3)
 
         fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any> of(
             entry1: Pair<DialogContextKey<T1>, T1>,
             entry2: Pair<DialogContextKey<T2>, T2>,
             entry3: Pair<DialogContextKey<T3>, T3>,
             entry4: Pair<DialogContextKey<T4>, T4>,
-        ): DialogContext =
-            DialogContextMap().apply {
-                add(entry1)
-                add(entry2)
-                add(entry3)
-                add(entry4)
-            }
+        ): DialogContext = DialogContextMap(entry1, entry2, entry3, entry4)
     }
 
     /**
@@ -95,13 +84,56 @@ interface MutableDialogContext : DialogContext {
     )
 
     fun remove(key: DialogContextKey<*>)
+
+    fun clear()
 }
 
 class DialogContextMap private constructor(
     @JsonValue private val entries: MutableMap<DialogContextKey<*>, Any>,
 ) : MutableDialogContext {
     companion object {
+        /**
+         * The empty context map (immutable)
+         */
         val EMPTY = DialogContextMap(Collections.emptyMap())
+
+        operator fun <T : Any> invoke(entry: Pair<DialogContextKey<T>, T>): DialogContextMap =
+            DialogContextMap().apply {
+                add(entry)
+            }
+
+        operator fun <T1 : Any, T2 : Any> invoke(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+        ): DialogContextMap =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+            }
+
+        operator fun <T1 : Any, T2 : Any, T3 : Any> invoke(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+            entry3: Pair<DialogContextKey<T3>, T3>,
+        ): DialogContextMap =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+                add(entry3)
+            }
+
+        operator fun <T1 : Any, T2 : Any, T3 : Any, T4 : Any> invoke(
+            entry1: Pair<DialogContextKey<T1>, T1>,
+            entry2: Pair<DialogContextKey<T2>, T2>,
+            entry3: Pair<DialogContextKey<T3>, T3>,
+            entry4: Pair<DialogContextKey<T4>, T4>,
+        ): DialogContextMap =
+            DialogContextMap().apply {
+                add(entry1)
+                add(entry2)
+                add(entry3)
+                add(entry4)
+            }
     }
 
     constructor() : this(mutableMapOf())
@@ -121,11 +153,11 @@ class DialogContextMap private constructor(
     }
 
     override operator fun <T : Any> plusAssign(entry: Pair<DialogContextKey<T>, T>) {
-        put(entry.first, entry.second)
+        set(entry.first, entry.second)
     }
 
     override fun <T : Any> add(entry: Pair<DialogContextKey<T>, T>) {
-        put(entry.first, entry.second)
+        set(entry.first, entry.second)
     }
 
     override fun <T : Any> put(
@@ -137,6 +169,10 @@ class DialogContextMap private constructor(
 
     override fun remove(key: DialogContextKey<*>) {
         entries.remove(key)
+    }
+
+    override fun clear() {
+        entries.clear()
     }
 
     override fun toString(): String {

--- a/bot/engine/src/main/kotlin/definition/DialogContextKey.kt
+++ b/bot/engine/src/main/kotlin/definition/DialogContextKey.kt
@@ -21,25 +21,38 @@ import kotlin.reflect.KClass
 /**
  * Represents a key for a value in a [DialogContext]
  *
+ * New instances should be constructed using the [reified factory][Companion.invoke] and stored in a constant:
+ * ```
+ * object MyKeys {
+ *     val myDataKey = DialogContextKey<Boolean>("my_data")
+ * }
+ * ```
+ *
  * @param <T> the type of the value
  */
-class DialogContextKey<T : Any>(val type: KClass<T>, val name: String) {
-    override fun toString(): String = name
+class DialogContextKey<T : Any>(val id: String, val type: KClass<T>) {
+    companion object {
+        /**
+         * Factory method for [DialogContextKey]
+         */
+        inline operator fun <reified T : Any> invoke(name: String) = DialogContextKey(name, T::class)
+    }
 
+    override fun toString(): String = id
+
+    /**
+     * Two keys are considered equal if they have the same identifier
+     */
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as DialogContextKey<*>
 
-        return name == other.name
+        return id == other.id
     }
 
     override fun hashCode(): Int {
-        return name.hashCode()
-    }
-
-    companion object {
-        inline operator fun <reified T : Any> invoke(name: String) = DialogContextKey(T::class, name)
+        return id.hashCode()
     }
 }

--- a/bot/engine/src/main/kotlin/definition/DialogContextKey.kt
+++ b/bot/engine/src/main/kotlin/definition/DialogContextKey.kt
@@ -18,8 +18,26 @@ package ai.tock.bot.definition
 
 import kotlin.reflect.KClass
 
+/**
+ * Represents a key for a value in a [DialogContext]
+ *
+ * @param <T> the type of the value
+ */
 class DialogContextKey<T : Any>(val type: KClass<T>, val name: String) {
     override fun toString(): String = name
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DialogContextKey<*>
+
+        return name == other.name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
 
     companion object {
         inline operator fun <reified T : Any> invoke(name: String) = DialogContextKey(T::class, name)

--- a/bot/engine/src/main/kotlin/definition/PushNotifications.kt
+++ b/bot/engine/src/main/kotlin/definition/PushNotifications.kt
@@ -18,6 +18,7 @@ package ai.tock.bot.definition
 
 import ai.tock.bot.connector.ConnectorException
 import ai.tock.bot.connector.NotifyBotStateModifier
+import ai.tock.bot.engine.AsyncBus
 import ai.tock.bot.engine.BotRepository
 import ai.tock.bot.engine.Bus
 import ai.tock.bot.engine.action.ActionNotificationType
@@ -63,6 +64,7 @@ fun notify(
             intent = intent,
             step = step,
             parameters = parameters.toMap(),
+            transientContext = DialogContext.EMPTY,
             stateModifier = stateModifier,
             notificationType = notificationType,
             errorListener = errorListener,
@@ -79,6 +81,7 @@ fun notify(
  * @param intent the notification intent
  * @param step the optional step target
  * @param parameters the optional parameters
+ * @param transientContext transient parameters accessible from [AsyncBus.getBusContextValue]
  * @param stateModifier allow the notification to bypass current user state
  * @param notificationType the notification type if any
  * @throws SkippedEventException if a concurrent request prevents processing of the pushed event
@@ -91,6 +94,7 @@ suspend fun BotDefinition.pushNotification(
     intent: IntentAware,
     step: StoryStepDef? = null,
     parameters: Parameters = Parameters.EMPTY,
+    transientContext: DialogContext = DialogContext.EMPTY,
     stateModifier: NotifyBotStateModifier = NotifyBotStateModifier.KEEP_CURRENT_STATE,
     notificationType: ActionNotificationType? = null,
 ) {
@@ -101,6 +105,7 @@ suspend fun BotDefinition.pushNotification(
         intent = intent,
         step = step,
         parameters = parameters.toMap(),
+        transientContext = transientContext,
         stateModifier = stateModifier,
         notificationType = notificationType,
         namespace = namespace,

--- a/bot/engine/src/main/kotlin/engine/AsyncBotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/AsyncBotBus.kt
@@ -49,7 +49,6 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import java.util.Locale
 import kotlin.coroutines.CoroutineContext
-import kotlin.reflect.safeCast
 
 @ExperimentalTockCoroutines
 open class AsyncBotBus(val syncBus: BotBus) : AsyncBus {
@@ -147,7 +146,7 @@ open class AsyncBotBus(val syncBus: BotBus) : AsyncBus {
     }
 
     override fun <T : Any> getContextValue(key: DialogContextKey<T>): T? {
-        return syncBus.dialog.state.context[key.name]?.let(key.type::safeCast)
+        return syncBus.dialog.state.context[key]
     }
 
     override fun <T : Any> setContextValue(

--- a/bot/engine/src/main/kotlin/engine/AsyncBotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/AsyncBotBus.kt
@@ -161,11 +161,11 @@ open class AsyncBotBus(val syncBus: BotBus) : AsyncBus {
         key: DialogContextKey<T>,
         value: T?,
     ) {
-        syncBus.setBusContextValue(key.name, value)
+        syncBus.setBusContextValue(key, value)
     }
 
     override fun <T : Any> getBusContextValue(key: DialogContextKey<T>): T? {
-        return syncBus.getBusContextValue<Any?>(key.name)?.let(key.type::safeCast)
+        return syncBus.getBusContextValue(key)
     }
 
     override suspend fun isFeatureEnabled(

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -349,7 +349,14 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
      */
     fun <T : Any> contextValue(name: String): T? {
         @Suppress("UNCHECKED_CAST")
-        return dialog.state.context[name] as? T?
+        return contextValue(DialogContextKey(name, Any::class)) as T?
+    }
+
+    /**
+     * Returns the persistent current context value.
+     */
+    fun <T : Any> contextValue(key: DialogContextKey<T>): T? {
+        return dialog.state.context[key]
     }
 
     /**
@@ -364,6 +371,17 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
     fun changeContextValue(
         name: String,
         value: Any?,
+    ) {
+        dialog.state.setContextValue(name, value)
+    }
+
+    /**
+     * Updates persistent context value.
+     * Do not store Collection or Map in the context, only plain objects or typed arrays.
+     */
+    fun <T : Any> changeContextValue(
+        name: DialogContextKey<T>,
+        value: T?,
     ) {
         dialog.state.setContextValue(name, value)
     }
@@ -389,7 +407,7 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
     @Deprecated("This overload performs unchecked casting", ReplaceWith("getBusContextValue(DialogContextKey(key))"))
     fun <T> getBusContextValue(name: String): T? {
         @Suppress("UNCHECKED_CAST")
-        return getBusContextValue(DialogContextKey(Any::class, name)) as T
+        return getBusContextValue(DialogContextKey(name, Any::class)) as T
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -347,6 +347,7 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
     /**
      * Returns the persistent current context value.
      */
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("contextValue(DialogContextKey(key))"))
     fun <T : Any> contextValue(name: String): T? {
         @Suppress("UNCHECKED_CAST")
         return contextValue(DialogContextKey(name, Any::class)) as T?
@@ -368,6 +369,7 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
      * Updates persistent context value.
      * Do not store Collection or Map in the context, only plain objects or typed arrays.
      */
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("changeContextValue(DialogContextKey(key), value)"))
     fun changeContextValue(
         name: String,
         value: Any?,
@@ -380,10 +382,10 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
      * Do not store Collection or Map in the context, only plain objects or typed arrays.
      */
     fun <T : Any> changeContextValue(
-        name: DialogContextKey<T>,
+        key: DialogContextKey<T>,
         value: T?,
     ) {
-        dialog.state.setContextValue(name, value)
+        dialog.state.setContextValue(key, value)
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -347,7 +347,7 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
     /**
      * Returns the persistent current context value.
      */
-    @Deprecated("This overload performs unchecked casting", ReplaceWith("contextValue(DialogContextKey(key))"))
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("contextValue(DialogContextKey(name))"))
     fun <T : Any> contextValue(name: String): T? {
         @Suppress("UNCHECKED_CAST")
         return contextValue(DialogContextKey(name, Any::class)) as T?
@@ -369,7 +369,7 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
      * Updates persistent context value.
      * Do not store Collection or Map in the context, only plain objects or typed arrays.
      */
-    @Deprecated("This overload performs unchecked casting", ReplaceWith("changeContextValue(DialogContextKey(key), value)"))
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("changeContextValue(DialogContextKey(name), value)"))
     fun changeContextValue(
         name: String,
         value: Any?,
@@ -406,10 +406,10 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
      * Returns the non-persistent current context value.
      * Bus context values are useful to store a temporary (ie request scoped) state.
      */
-    @Deprecated("This overload performs unchecked casting", ReplaceWith("getBusContextValue(DialogContextKey(key))"))
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("getBusContextValue(DialogContextKey(name))"))
     fun <T> getBusContextValue(name: String): T? {
         @Suppress("UNCHECKED_CAST")
-        return getBusContextValue(DialogContextKey(name, Any::class)) as T
+        return getBusContextValue(DialogContextKey(name, Any::class)) as T?
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/BotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/BotBus.kt
@@ -25,6 +25,7 @@ import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.definition.AsyncStoryDefinition
 import ai.tock.bot.definition.BotDefinition
+import ai.tock.bot.definition.DialogContextKey
 import ai.tock.bot.definition.I18nStoryHandler
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.definition.IntentAware
@@ -376,30 +377,52 @@ interface BotBus : Bus<BotBus>, DialogEntityAccess {
     ) = changeContextValue(key.key, value)
 
     /**
-     * Returns the non persistent current context value.
+     * Returns the non-persistent current context value.
      * Bus context values are useful to store a temporary (ie request scoped) state.
      */
-    fun <T> getBusContextValue(name: String): T?
+    fun <T : Any> getBusContextValue(key: DialogContextKey<T>): T?
 
     /**
-     * Returns the non persistent current context value.
+     * Returns the non-persistent current context value.
      * Bus context values are useful to store a temporary (ie request scoped) state.
      */
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("getBusContextValue(DialogContextKey(key))"))
+    fun <T> getBusContextValue(name: String): T? {
+        @Suppress("UNCHECKED_CAST")
+        return getBusContextValue(DialogContextKey(Any::class, name)) as T
+    }
+
+    /**
+     * Returns the non-persistent current context value.
+     * Bus context values are useful to store a temporary (ie request scoped) state.
+     */
+    @Deprecated("This overload performs unchecked casting", ReplaceWith("getBusContextValue(DialogContextKey(key.key))"))
     fun <T> getBusContextValue(key: ParameterKey): T? = getBusContextValue(key.key)
 
     /**
-     * Updates the non persistent current context value.
+     * Updates the non-persistent current context value.
      * Bus context values are useful to store a temporary (ie request scoped) state.
      */
+    fun <T : Any> setBusContextValue(
+        key: DialogContextKey<T>,
+        value: T?,
+    )
+
+    /**
+     * Updates the non-persistent current context value.
+     * Bus context values are useful to store a temporary (ie request scoped) state.
+     */
+    @Deprecated("This overload makes unsafe assumptions about the type of value", ReplaceWith("setBusContextValue(DialogContextKey(key), value)"))
     fun setBusContextValue(
         key: String,
         value: Any?,
     )
 
     /**
-     * Updates the non persistent current context value.
+     * Updates the non-persistent current context value.
      * Bus context values are useful to store a temporary (ie request scoped) state.
      */
+    @Deprecated("This overload makes unsafe assumptions about the type of value", ReplaceWith("setBusContextValue(DialogContextKey(key.key), value)"))
     fun setBusContextValue(
         key: ParameterKey,
         value: Any?,

--- a/bot/engine/src/main/kotlin/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/engine/BotRepository.kt
@@ -36,6 +36,7 @@ import ai.tock.bot.definition.BotAnswerInterceptor
 import ai.tock.bot.definition.BotDefinition
 import ai.tock.bot.definition.BotProvider
 import ai.tock.bot.definition.BotProviderId
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryDefinition
@@ -211,7 +212,7 @@ object BotRepository {
         errorListener: (Throwable) -> Unit = {},
     ) {
         runBlocking {
-            notifyAsync(namespace, botId, applicationId, recipientId, intent, step, parameters, stateModifier, notificationType, errorListener)
+            notifyAsync(namespace, botId, applicationId, recipientId, intent, step, parameters, transientContext = DialogContext.EMPTY, stateModifier, notificationType, errorListener)
         }
     }
 
@@ -223,6 +224,7 @@ object BotRepository {
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         stateModifier: NotifyBotStateModifier,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit,
@@ -236,7 +238,7 @@ object BotRepository {
             }
         val conf = key?.let { getConfigurationByApplicationId(it) } ?: error("unknown application $applicationId")
         connectorControllerMap.getValue(conf)
-            .notifyAndCheckState(recipientId, intent, step, parameters, stateModifier, notificationType, errorListener)
+            .notifyAndCheckState(recipientId, intent, step, parameters, transientContext, stateModifier, notificationType, errorListener)
     }
 
     private suspend fun ConnectorController.notifyAndCheckState(
@@ -244,6 +246,7 @@ object BotRepository {
         intent: IntentAware,
         step: StoryStepDef?,
         parameters: Map<String, String>,
+        transientContext: DialogContext,
         stateModifier: NotifyBotStateModifier,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit = {},
@@ -260,7 +263,7 @@ object BotRepository {
         }
 
         try {
-            notify(recipientId, intent, step, parameters, notificationType, errorListener)
+            notify(recipientId, intent, step, parameters, transientContext, notificationType, errorListener)
         } finally {
             if (stateModifier == NotifyBotStateModifier.ACTIVATE_ONLY_FOR_THIS_NOTIFICATION) {
                 val userTimelineAfterNotification =

--- a/bot/engine/src/main/kotlin/engine/BusContext.kt
+++ b/bot/engine/src/main/kotlin/engine/BusContext.kt
@@ -18,6 +18,9 @@ package ai.tock.bot.engine
 
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
+import ai.tock.bot.definition.DialogContext
+import ai.tock.bot.definition.DialogContextMap
+import ai.tock.bot.definition.MutableDialogContext
 import ai.tock.bot.engine.action.ActionNotificationType
 import ai.tock.bot.engine.action.ActionPriority
 import ai.tock.bot.engine.action.ActionPriority.normal
@@ -31,7 +34,7 @@ import mu.KotlinLogging
 internal data class BusContext(
     var currentDelay: Long = 0,
     val connectorMessages: MutableMap<ConnectorType, ConnectorMessage> = mutableMapOf(),
-    val contextMap: MutableMap<String, Any> = mutableMapOf(),
+    val contextMap: MutableDialogContext = DialogContextMap(),
     var priority: ActionPriority = normal,
     var notificationType: ActionNotificationType? = null,
     var visibility: ActionVisibility = ActionVisibility.UNKNOWN,
@@ -39,6 +42,10 @@ internal data class BusContext(
     companion object {
         val logger: KLogger = KotlinLogging.logger {}
     }
+
+    constructor(transientContext: DialogContext) : this(
+        contextMap = DialogContextMap(transientContext),
+    )
 
     fun clear() {
         connectorMessages.clear()

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -74,7 +74,7 @@ interface ConnectorController {
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit = {},
     ) {
-        connector.notify(this, recipientId, intent, step, parameters, notificationType = notificationType, errorListener = errorListener)
+        connector.notify(this, recipientId, intent, step, parameters, transientContext = transientContext, notificationType = notificationType, errorListener = errorListener)
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/engine/ConnectorController.kt
@@ -22,6 +22,7 @@ import ai.tock.bot.connector.ConnectorCallbackBase
 import ai.tock.bot.connector.ConnectorData
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.definition.BotDefinition
+import ai.tock.bot.definition.DialogContext
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.definition.StoryDefinition
 import ai.tock.bot.definition.StoryStepDef
@@ -69,10 +70,11 @@ interface ConnectorController {
         intent: IntentAware,
         step: StoryStepDef? = null,
         parameters: Map<String, String> = emptyMap(),
+        transientContext: DialogContext = DialogContext.EMPTY,
         notificationType: ActionNotificationType?,
         errorListener: (Throwable) -> Unit = {},
     ) {
-        connector.notify(this, recipientId, intent, step, parameters, notificationType, errorListener)
+        connector.notify(this, recipientId, intent, step, parameters, notificationType = notificationType, errorListener = errorListener)
     }
 
     /**

--- a/bot/engine/src/main/kotlin/engine/TockBotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/TockBotBus.kt
@@ -21,6 +21,8 @@ import ai.tock.bot.connector.ConnectorData
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.definition.BotDefinition
+import ai.tock.bot.definition.DialogContextKey
+import ai.tock.bot.definition.DialogContextMap
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.engine.action.Action
 import ai.tock.bot.engine.action.ActionNotificationType
@@ -93,7 +95,7 @@ internal class TockBotBus(
 
     override val underlyingConnector: Connector = connector.connector
 
-    private val context: BusContext = BusContext()
+    private val context: BusContext = BusContext(contextMap = DialogContextMap(connectorData.transientContext))
 
     override val entities: Map<String, EntityStateValue> = currentDialog.state.entityValues
     override val intent: Intent? = currentDialog.state.currentIntent
@@ -124,25 +126,33 @@ internal class TockBotBus(
         userLocale = findSupportedLocale(locale)
     }
 
-    /**
-     * Returns the non persistent current context value.
-     */
-    override fun <T> getBusContextValue(name: String): T? {
-        @Suppress("UNCHECKED_CAST")
-        return context.contextMap[name] as T
+    override fun <T : Any> getBusContextValue(key: DialogContextKey<T>): T? {
+        return context.contextMap[key]
     }
 
-    /**
-     * Updates the non persistent current context value.
-     */
-    override fun setBusContextValue(
-        key: String,
-        value: Any?,
+    override fun <T : Any> setBusContextValue(
+        key: DialogContextKey<T>,
+        value: T?,
     ) {
         if (value == null) {
             context.contextMap.remove(key)
         } else {
             context.contextMap[key] = value
+        }
+    }
+
+    /**
+     * Updates the non persistent current context value.
+     */
+    @Deprecated("This overload makes unsafe assumptions about the type of value", replaceWith = ReplaceWith("setBusContextValue(DialogContextKey(key), value)"))
+    override fun setBusContextValue(
+        key: String,
+        value: Any?,
+    ) {
+        if (value == null) {
+            context.contextMap.asMap().keys.removeIf { it.name == key }
+        } else {
+            setBusContextValue(DialogContextKey(value.javaClass.kotlin, key), value)
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/TockBotBus.kt
+++ b/bot/engine/src/main/kotlin/engine/TockBotBus.kt
@@ -150,9 +150,9 @@ internal class TockBotBus(
         value: Any?,
     ) {
         if (value == null) {
-            context.contextMap.asMap().keys.removeIf { it.name == key }
+            context.contextMap.remove(DialogContextKey(key, Any::class))
         } else {
-            setBusContextValue(DialogContextKey(value.javaClass.kotlin, key), value)
+            setBusContextValue(DialogContextKey(key, value.javaClass.kotlin), value)
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/dialog/DialogState.kt
+++ b/bot/engine/src/main/kotlin/engine/dialog/DialogState.kt
@@ -17,7 +17,9 @@
 package ai.tock.bot.engine.dialog
 
 import ai.tock.bot.definition.DialogContextKey
+import ai.tock.bot.definition.DialogContextMap
 import ai.tock.bot.definition.Intent
+import ai.tock.bot.definition.MutableDialogContext
 import ai.tock.bot.engine.user.UserLocation
 import ai.tock.nlp.api.client.model.Entity
 import ai.tock.nlp.entity.Value
@@ -38,7 +40,7 @@ data class DialogState(
     /**
      * The context of the dialog, a versatile map.
      */
-    val context: MutableMap<String, Any> = mutableMapOf(),
+    val context: MutableDialogContext = DialogContextMap(),
     /**
      * The current [UserLocation] if any.
      */
@@ -50,9 +52,9 @@ data class DialogState(
     var nextActionState: NextUserActionState? = null,
 ) {
     companion object {
-        private const val SWITCH_STORY_BUS_KEY = "_tock_switch"
-        private const val ASK_AGAIN_STORY_BUS_KEY = "_tock_ask_again"
-        private const val ASK_AGAIN_STORY_ROUND_BUS_KEY = "_tock_ask_again_round"
+        private val SWITCH_STORY_BUS_KEY = DialogContextKey<Boolean>("_tock_switch")
+        private val ASK_AGAIN_STORY_BUS_KEY = DialogContextKey<Boolean>("_tock_ask_again")
+        private val ASK_AGAIN_STORY_ROUND_BUS_KEY = DialogContextKey<Int>("_tock_ask_again_round")
 
         /**
          * Init a new state from the specified state.
@@ -86,7 +88,7 @@ data class DialogState(
     internal var askAgainRound: Int = askAgainRoundDefault
         get() {
             // retrieve default value
-            val value = context[ASK_AGAIN_STORY_ROUND_BUS_KEY] as? Int
+            val value = context[ASK_AGAIN_STORY_ROUND_BUS_KEY]
             return if (value == null) {
                 context[ASK_AGAIN_STORY_ROUND_BUS_KEY] = field
                 field
@@ -109,12 +111,12 @@ data class DialogState(
         value: Any?,
     ) {
         if (value == null) {
-            context.remove(name)
+            context.remove(DialogContextKey(name, Any::class))
         } else {
             if (value is Collection<*> || value is Map<*, *>) {
                 error("Storing collection or map is dialog context is unsupported, use plain objects or typed arrays")
             }
-            context[name] = value
+            context[DialogContextKey(name, value.javaClass.kotlin)] = value
         }
     }
 
@@ -124,16 +126,16 @@ data class DialogState(
      */
     fun <T : Any> setContextValue(
         key: DialogContextKey<T>,
-        value: Any?,
+        value: T?,
     ) {
-        require(key.type.typeParameters.isEmpty()) {
-            "Generic type parameters cannot be safely preserved in a dialog context"
-        }
-
         if (value == null) {
-            context.remove(key.name)
+            context.remove(key)
         } else {
-            context[key.name] = value
+            require(key.type.typeParameters.isEmpty()) {
+                "Generic type parameters cannot be safely preserved in a dialog context"
+            }
+
+            context[key] = value
         }
     }
 

--- a/bot/engine/src/test/kotlin/definition/BotDefinitionTest.kt
+++ b/bot/engine/src/test/kotlin/definition/BotDefinitionTest.kt
@@ -208,7 +208,7 @@ class BotDefinitionTest {
                     DialogState(
                         currentIntent = intent,
                         entityValues = mutableMapOf(),
-                        context = mutableMapOf(),
+                        context = DialogContextMap(),
                     ),
                 stories =
                     mutableListOf(
@@ -256,7 +256,7 @@ class BotDefinitionTest {
                     DialogState(
                         currentIntent = intent,
                         entityValues = mutableMapOf(),
-                        context = mutableMapOf(),
+                        context = DialogContextMap(),
                     ),
                 stories =
                     mutableListOf(

--- a/bot/engine/src/test/kotlin/definition/PushNotificationsTest.kt
+++ b/bot/engine/src/test/kotlin/definition/PushNotificationsTest.kt
@@ -92,21 +92,39 @@ internal class PushNotificationsTest : BotEngineTest() {
     fun `GIVEN stateModifier THEN notify calls connector notify method`() {
         notify(CONNECTOR_ID, botDefinition.namespace, botDefinition.botId, recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
 
-        coVerify { connector.notify(any(), recipientId, intent, null, any(), any(), any()) }
+        coVerify {
+            connector.notify(
+                any(),
+                recipientId,
+                intent,
+                parameters = any(),
+                notificationType = any(),
+                errorListener = any(),
+            )
+        }
     }
 
     @Test
     fun `GIVEN no notificationType passed THEN notify pass null NotificationType to connector`() {
         notify(CONNECTOR_ID, botDefinition.namespace, botDefinition.botId, recipientId, intent, stateModifier = KEEP_CURRENT_STATE)
 
-        coVerify { connector.notify(any(), recipientId, intent, null, any(), null, any()) }
+        coVerify {
+            connector.notify(
+                any(),
+                recipientId,
+                intent,
+                parameters = any(),
+                notificationType = null,
+                errorListener = any(),
+            )
+        }
     }
 
     @OptIn(ExperimentalTockCoroutines::class)
     @Test
     suspend fun `GIVEN locked user session WHEN pushNotification is called THEN throw SkippedEventException`() {
         coEvery { userLock.tryLock(recipientId.id) } returns false
-        coEvery { connector.notify(any(), any(), any(), null, emptyMap(), any(), any()) } coAnswers {
+        coEvery { connector.notify(any(), any(), any(), notificationType = any(), errorListener = any()) } coAnswers {
             firstArg<ConnectorController>().handleUserEvent(
                 SendChoice(
                     PlayerId(botDefinition.botId, PlayerType.bot),
@@ -117,7 +135,7 @@ internal class PushNotificationsTest : BotEngineTest() {
                     emptyMap(),
                 ),
                 ConnectorData(
-                    ConnectorCallbackBase(CONNECTOR_ID, ConnectorType(CONNECTOR_ID), arg(6)),
+                    ConnectorCallbackBase(CONNECTOR_ID, ConnectorType(CONNECTOR_ID), arg<(Throwable) -> Unit>(7)),
                 ),
             )
         }

--- a/bot/engine/src/test/kotlin/engine/dialog/DialogStateTest.kt
+++ b/bot/engine/src/test/kotlin/engine/dialog/DialogStateTest.kt
@@ -16,6 +16,7 @@
 
 package ai.tock.bot.engine.dialog
 
+import ai.tock.bot.definition.DialogContextKey
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -43,8 +44,8 @@ class DialogStateTest {
     fun `setContextValue removes an existing value if value parameter is null`() {
         val state = DialogState()
         state.setContextValue("test", "a")
-        assertEquals(state.context["test"], "a")
+        assertEquals(state.context[DialogContextKey("test")], "a")
         state.setContextValue("test", null)
-        assertTrue(state.context.isEmpty())
+        assertTrue(state.context.asMap().isEmpty())
     }
 }

--- a/bot/storage-mongo/src/main/kotlin/DialogCol.kt
+++ b/bot/storage-mongo/src/main/kotlin/DialogCol.kt
@@ -19,6 +19,8 @@ package ai.tock.bot.mongo
 import ai.tock.bot.admin.annotation.BotAnnotation
 import ai.tock.bot.admin.dialog.ActionReport
 import ai.tock.bot.admin.dialog.DialogReport
+import ai.tock.bot.definition.DialogContextKey
+import ai.tock.bot.definition.DialogContextMap
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.definition.StoryDefinition
 import ai.tock.bot.engine.action.Action
@@ -59,6 +61,8 @@ import org.litote.kmongo.Id
 import org.litote.kmongo.newId
 import java.time.Instant
 import java.time.Instant.now
+import kotlin.reflect.KClass
+import kotlin.reflect.safeCast
 
 /**
  *
@@ -213,7 +217,7 @@ internal data class DialogCol(
         constructor(state: DialogState) : this(
             state.currentIntent,
             state.entityValues.mapValues { EntityStateValueWrapper(it.value) },
-            state.context.map { e -> e.key to AnyValueWrapper(e.value) }.toMap(),
+            state.context.asMap().map { e -> e.key.id to AnyValueWrapper(e.key.type, e.value) }.toMap(),
             state.userLocation,
             state.nextActionState,
         )
@@ -222,11 +226,28 @@ internal data class DialogCol(
             return DialogState(
                 currentIntent,
                 entityValues.mapValues { it.value.toEntityStateValue(actionsMap) }.toMutableMap(),
-                context.filter { it.value != null && it.value!!.value != null }.mapValues { it.value!!.value!! }
-                    .toMutableMap(),
+                convertContext(),
                 userLocation,
                 nextActionState,
             )
+        }
+
+        private fun convertContext(): DialogContextMap =
+            DialogContextMap().apply {
+                context.forEach { (keyId, wrapper) ->
+                    val value = wrapper?.value
+                    if (value != null) {
+                        trySet(keyId, wrapper.klass, value)
+                    }
+                }
+            }
+
+        private fun <T : Any> DialogContextMap.trySet(
+            keyId: String,
+            klass: KClass<T>,
+            value: Any,
+        ) {
+            klass.safeCast(value)?.let { set(DialogContextKey(keyId, klass), it) }
         }
     }
 

--- a/bot/storage-mongo/src/test/kotlin/DialogColDeserializationTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/DialogColDeserializationTest.kt
@@ -16,6 +16,8 @@
 
 package ai.tock.bot.mongo
 
+import ai.tock.bot.definition.DialogContextKey
+import ai.tock.bot.definition.DialogContextMap
 import ai.tock.bot.definition.Intent
 import ai.tock.bot.definition.StoryDefinition
 import ai.tock.bot.engine.action.Action
@@ -113,10 +115,11 @@ class DialogColDeserializationTest : AbstractTest(false) {
 
     @Test
     fun serializeAndDeserializeDialog_shouldLeftDataInchanged() {
+        val dialogContextKey = DialogContextKey<LocalDateTime>("a")
         val dialog =
             Dialog(
                 emptySet(),
-                state = ai.tock.bot.engine.dialog.DialogState(context = mutableMapOf("a" to LocalDateTime.now())),
+                state = ai.tock.bot.engine.dialog.DialogState(context = DialogContextMap(dialogContextKey to LocalDateTime.now())),
             )
         val playerId = PlayerId("a", PlayerType.user)
         val s =

--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -23,6 +23,7 @@ import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorMessageProvider
 import ai.tock.bot.connector.ConnectorType
 import ai.tock.bot.definition.BotDefinition
+import ai.tock.bot.definition.DialogContextKey
 import ai.tock.bot.definition.IntentAware
 import ai.tock.bot.engine.BotBus
 import ai.tock.bot.engine.action.Action
@@ -380,25 +381,33 @@ open class BotBusMock(
         userPreferences.locale = locale
     }
 
-    /**
-     * Returns the non persistent current value.
-     */
-    override fun <T> getBusContextValue(name: String): T? {
-        @Suppress("UNCHECKED_CAST")
-        return mockData.contextMap[name] as T
+    override fun <T : Any> getBusContextValue(key: DialogContextKey<T>): T? {
+        return mockData.contextMap[key]
     }
 
-    /**
-     * Update the non persistent current value.
-     */
-    override fun setBusContextValue(
-        key: String,
-        value: Any?,
+    override fun <T : Any> setBusContextValue(
+        key: DialogContextKey<T>,
+        value: T?,
     ) {
         if (value == null) {
             mockData.contextMap.remove(key)
         } else {
             mockData.contextMap[key] = value
+        }
+    }
+
+    /**
+     * Update the non persistent current value.
+     */
+    @Deprecated("This overload makes unsafe assumptions about the type of value", replaceWith = ReplaceWith("setBusContextValue(DialogContextKey(key), value)"))
+    override fun setBusContextValue(
+        key: String,
+        value: Any?,
+    ) {
+        if (value == null) {
+            mockData.contextMap.asMap().keys.removeIf { it.name == key }
+        } else {
+            setBusContextValue(DialogContextKey(value.javaClass.kotlin, key), value)
         }
     }
 

--- a/bot/test-base/src/main/kotlin/BotBusMock.kt
+++ b/bot/test-base/src/main/kotlin/BotBusMock.kt
@@ -405,9 +405,9 @@ open class BotBusMock(
         value: Any?,
     ) {
         if (value == null) {
-            mockData.contextMap.asMap().keys.removeIf { it.name == key }
+            mockData.contextMap.remove(DialogContextKey(key, Any::class))
         } else {
-            setBusContextValue(DialogContextKey(value.javaClass.kotlin, key), value)
+            setBusContextValue(DialogContextKey(key, value.javaClass.kotlin), value)
         }
     }
 

--- a/bot/test-base/src/main/kotlin/BusMockData.kt
+++ b/bot/test-base/src/main/kotlin/BusMockData.kt
@@ -18,6 +18,8 @@ package ai.tock.bot.test
 
 import ai.tock.bot.connector.ConnectorMessage
 import ai.tock.bot.connector.ConnectorType
+import ai.tock.bot.definition.DialogContextMap
+import ai.tock.bot.definition.MutableDialogContext
 import ai.tock.bot.engine.action.ActionNotificationType
 import ai.tock.bot.engine.action.ActionPriority
 import ai.tock.bot.engine.action.ActionQuote
@@ -30,7 +32,7 @@ import ai.tock.bot.engine.action.ActionVisibility
 internal data class BusMockData(
     var currentDelay: Long = 0,
     val connectorMessages: MutableMap<ConnectorType, ConnectorMessage> = mutableMapOf(),
-    val contextMap: MutableMap<String, Any> = mutableMapOf(),
+    val contextMap: MutableDialogContext = DialogContextMap(),
     var priority: ActionPriority = ActionPriority.normal,
     var notificationType: ActionNotificationType? = null,
     var visibility: ActionVisibility = ActionVisibility.UNKNOWN,

--- a/shared/src/main/kotlin/jackson/AnyValueWrapper.kt
+++ b/shared/src/main/kotlin/jackson/AnyValueWrapper.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.KClass
  */
 @JsonDeserialize(using = AnyValueDeserializer::class)
 @JsonSerialize(using = AnyValueSerializer::class)
-data class AnyValueWrapper(val klass: String, val value: Any?) {
+data class AnyValueWrapper(val klass: KClass<*>, val value: Any?) {
     companion object {
         private val logger = KotlinLogging.logger {}
     }
@@ -48,7 +48,7 @@ data class AnyValueWrapper(val klass: String, val value: Any?) {
         ) {
             gen.writeStartObject()
             gen.writeFieldName(AnyValueWrapper::klass.name)
-            gen.writeString(value.klass)
+            gen.writeString(value.klass.java.name)
             serializers.defaultSerializeField(AnyValueWrapper::value.name, value.value, gen)
             gen.writeEndObject()
         }
@@ -63,8 +63,7 @@ data class AnyValueWrapper(val klass: String, val value: Any?) {
             if (fieldName != null) {
                 val classValue: Class<*>? =
                     try {
-                        // TODO remove replace in 20.3
-                        Class.forName(jp.text.replace("fr.vsct.tock", "ai.tock"))
+                        Class.forName(jp.text)
                     } catch (e: Exception) {
                         logger.warn("deserialization error for class ${e.message}")
                         null
@@ -81,18 +80,16 @@ data class AnyValueWrapper(val klass: String, val value: Any?) {
                     } else {
                         val value = jp.readValueAs(classValue)
                         jp.checkEndToken()
-                        return AnyValueWrapper(classValue.name, value)
+                        return AnyValueWrapper(classValue.kotlin, value)
                     }
                 } else {
                     jp.checkEndToken()
-                    return if (classValue == null) null else AnyValueWrapper(classValue.name, null)
+                    return if (classValue == null) null else AnyValueWrapper(classValue.kotlin, null)
                 }
             }
             return null
         }
     }
-
-    constructor(klass: KClass<*>, value: Any?) : this(klass.java.name, value)
 
     constructor(value: Any) : this(value::class, value)
 }

--- a/shared/src/main/kotlin/security/auth/spi/WebSecurityHandler.kt
+++ b/shared/src/main/kotlin/security/auth/spi/WebSecurityHandler.kt
@@ -27,4 +27,11 @@ const val TOCK_USER_ID = "tock_user_id"
  *
  * Custom implementations should store the final user id in the [RoutingContext] using `routingContext.put(TOCK_USER_ID, userId)`.
  */
-interface WebSecurityHandler : Handler<RoutingContext>
+interface WebSecurityHandler : Handler<RoutingContext> {
+    companion object {
+        /**
+         * Can be used as a [RoutingContext] key to store an optional [ai.tock.bot.definition.DialogContext]
+         */
+        const val TRANSIENT_DIALOG_CONTEXT_KEY = "tock_transient_dialog_context"
+    }
+}

--- a/shared/src/test/kotlin/jackson/AnyValueWrapperTest.kt
+++ b/shared/src/test/kotlin/jackson/AnyValueWrapperTest.kt
@@ -65,8 +65,8 @@ class AnyValueWrapperTest {
 
     @Test
     fun deserializeUnknownClass_shouldNotFailAndReturnsNull() {
-        val value = AnyValueWrapper("unknown", null)
-        val s = mapper.writeValueAsString(value)
+        val value = AnyValueWrapper(Nothing::class, null)
+        val s = mapper.writeValueAsString(value).replace("java.lang.Void", "unknown")
         val newValue = mapper.readValue<AnyValueWrapper?>(s, object : TypeReference<AnyValueWrapper?>() {})
         assertNull(newValue)
     }


### PR DESCRIPTION
This PR resolves #2058 by introducing a transientContext parameter to the `pushNotification` method, allowing callers to pass ephemeral values to the context of a triggered story.

Main changes:
- Introduced `DialogContext` and `DialogContextKey` as the public API for typed transient context entries.
- Added `transientContext`: `DialogContext` parameter to the whole chain of calls from `pushNotification` to `BotBus.getBusContextValue`.
- Refactored the internal persistent dialog context storage to use a dedicated container class, replacing the previous raw map approach.