### PR TITLE
fix #2060 [WhatsApp] Update WhatsApp Cloud API webhook model nullability

### DIFF
--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WebhookActionConverter.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WebhookActionConverter.kt
@@ -74,7 +74,7 @@ internal object WebhookActionConverter {
 
             is WhatsAppCloudButtonMessage -> {
                 val messageCopy = getMessageButtonCopy(message)
-                messageCopy.button.payload.let { payload ->
+                messageCopy.button.payload?.let { payload ->
                     SendChoice.decodeChoice(
                         payload,
                         PlayerId(senderId),
@@ -92,7 +92,7 @@ internal object WebhookActionConverter {
                 val payloadListReply = messageCopy.interactive.listReply?.id
 
                 val payload = payloadButtonReply ?: payloadListReply
-                return payload?.let {
+                payload?.let {
                     SendChoice.decodeChoice(
                         it,
                         PlayerId(senderId),
@@ -138,7 +138,7 @@ internal object WebhookActionConverter {
     }
 
     private fun getMessageButtonCopy(message: WhatsAppCloudButtonMessage): WhatsAppCloudButtonMessage {
-        val payload = payloadWhatsApp.getPayloadById(message.button.payload)
+        val payload = message.button.payload?.let(payloadWhatsApp::getPayloadById)
         return if (payload != null) {
             val copyButton =
                 message.button.copy(

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -208,7 +208,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
         requestBody.entry.forEach { entry: Entry ->
             entry.changes
                 .filter {
-                    it.value.metadata.phoneNumberId == phoneNumberId
+                    it.value.metadata?.phoneNumberId == phoneNumberId
                 }.forEach { change: Change ->
                     change.value.messages
                         .filter {

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/WhatsAppConnectorCloudConnector.kt
@@ -208,7 +208,7 @@ class WhatsAppConnectorCloudConnector internal constructor(
         requestBody.entry.forEach { entry: Entry ->
             entry.changes
                 .filter {
-                    it.value.metadata?.phoneNumberId == phoneNumberId
+                    it.value.metadata.phoneNumberId == phoneNumberId
                 }.forEach { change: Change ->
                     change.value.messages
                         .filter {

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Status.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Status.kt
@@ -31,15 +31,15 @@ data class Status(
 
 data class Conversation(
     @JsonProperty("expiration_timestamp") val expirationTimestamp: String?,
-    @JsonProperty("origin") val origin: Origin,
+    @JsonProperty("origin") val origin: Origin?,
     @JsonProperty("id") val id: String,
 )
 
 data class Origin(
-    @JsonProperty("type")val type: String,
+    @JsonProperty("type") val type: String?,
 )
 
 data class Pricing(
-    @JsonProperty("pricing_model") val pricingModel: String,
-    @JsonProperty("category") val category: String,
+    @JsonProperty("pricing_model") val pricingModel: String?,
+    @JsonProperty("category") val category: String?,
 )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Value.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Value.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Value(
     @JsonProperty("messaging_product") val messagingProduct: String,
-    @JsonProperty("metadata") val metadata: Metadata,
+    @JsonProperty("metadata") val metadata: Metadata?,
     @JsonProperty("contacts") val contacts: List<Contact> = emptyList(),
     @JsonProperty("messages") val messages: List<WhatsAppCloudMessage> = emptyList(),
     @JsonProperty("statuses") val statuses: List<Status> = emptyList(),
@@ -29,15 +29,15 @@ data class Value(
 )
 
 data class Metadata(
-    @JsonProperty("display_phone_number") val displayPhoneNumber: String,
-    @JsonProperty("phone_number_id") val phoneNumberId: String,
+    @JsonProperty("display_phone_number") val displayPhoneNumber: String?,
+    @JsonProperty("phone_number_id") val phoneNumberId: String?,
 )
 
 data class Contact(
-    @JsonProperty("profile") val profile: Profile,
+    @JsonProperty("profile") val profile: Profile?,
     @JsonProperty("wa_id") val waId: String,
 )
 
 data class Profile(
-    @JsonProperty("name") val name: String,
+    @JsonProperty("name") val name: String?,
 )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Value.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/Value.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Value(
     @JsonProperty("messaging_product") val messagingProduct: String,
-    @JsonProperty("metadata") val metadata: Metadata?,
+    @JsonProperty("metadata") val metadata: Metadata,
     @JsonProperty("contacts") val contacts: List<Contact> = emptyList(),
     @JsonProperty("messages") val messages: List<WhatsAppCloudMessage> = emptyList(),
     @JsonProperty("statuses") val statuses: List<Status> = emptyList(),
@@ -29,8 +29,8 @@ data class Value(
 )
 
 data class Metadata(
-    @JsonProperty("display_phone_number") val displayPhoneNumber: String?,
-    @JsonProperty("phone_number_id") val phoneNumberId: String?,
+    @JsonProperty("display_phone_number") val displayPhoneNumber: String,
+    @JsonProperty("phone_number_id") val phoneNumberId: String,
 )
 
 data class Contact(

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/ButtonContent.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/ButtonContent.kt
@@ -17,6 +17,6 @@
 package ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content
 
 data class ButtonContent(
-    val payload: String,
-    val text: String,
+    val payload: String?,
+    val text: String?,
 )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/ContextContent.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/ContextContent.kt
@@ -21,12 +21,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 data class ContextContent(
     val forwarded: Boolean?,
     @JsonProperty("frequently_forwarded") val frequentlyForwarded: Boolean?,
-    val from: String,
-    val id: String,
+    val from: String?,
+    val id: String?,
     @JsonProperty("referred_product") val referredProduct: ReferredProduct?,
 )
 
 data class ReferredProduct(
-    @JsonProperty("catalog_id") val catalogId: String,
-    @JsonProperty("product_retailer_id") val productRetailerId: String,
+    @JsonProperty("catalog_id") val catalogId: String?,
+    @JsonProperty("product_retailer_id") val productRetailerId: String?,
 )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/OrderContent.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/OrderContent.kt
@@ -19,14 +19,14 @@ package ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class OrderContent(
-    @JsonProperty("catalog_id") val catalogId: String,
-    val text: String,
-    @JsonProperty("product_items") val productItems: List<ProductItem>,
+    @JsonProperty("catalog_id") val catalogId: String?,
+    val text: String?,
+    @JsonProperty("product_items") val productItems: List<ProductItem> = emptyList(),
 )
 
 data class ProductItem(
-    @JsonProperty("product_retailer_id") val productRetailerId: String,
-    val quantity: String,
-    @JsonProperty("item_price") val itemPrice: String,
-    val currency: String,
+    @JsonProperty("product_retailer_id") val productRetailerId: String?,
+    val quantity: String?,
+    @JsonProperty("item_price") val itemPrice: String?,
+    val currency: String?,
 )

--- a/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/Referral.kt
+++ b/bot/connector-whatsapp-cloud/src/main/kotlin/model/webhook/message/content/Referral.kt
@@ -19,17 +19,17 @@ package ai.tock.bot.connector.whatsapp.cloud.model.webhook.message.content
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Referral(
-    @JsonProperty("source_url") val sourceUrl: String,
-    @JsonProperty("source_type") val sourceType: String,
-    @JsonProperty("source_id") val sourceId: String,
+    @JsonProperty("source_url") val sourceUrl: String?,
+    @JsonProperty("source_type") val sourceType: String?,
+    @JsonProperty("source_id") val sourceId: String?,
     val ref: String = "",
-    val headline: String,
-    val body: String,
-    @JsonProperty("media_type") val mediaType: MediaType,
+    val headline: String?,
+    val body: String?,
+    @JsonProperty("media_type") val mediaType: MediaType?,
     @JsonProperty("image_url") val imageUrl: String?,
     @JsonProperty("video_url") val videoUrl: String?,
     @JsonProperty("thumbnail_url") val thumbnailUrl: String?,
-    @JsonProperty("ctwa_clid") val ctwaClid: String,
+    @JsonProperty("ctwa_clid") val ctwaClid: String?,
 )
 
 enum class MediaType {


### PR DESCRIPTION
fixes #2060 by marking the correct nullability on model classes:


- Made optional fields nullable: metadata, contacts, profile, origin, pricing fields

- Updated Referral fields to be nullable: sourceUrl, sourceType, sourceId, headline, body, mediaType, ctwaClid

- Made ContextContent fields nullable: from, id, catalogId, productRetailerId

- Made ButtonContent and OrderContent fields nullable to match API specification

- Updated consumers to properly handle nullable fields with safe calls