### PR TITLE
feat(studio): add configurable environment banner

### DIFF
--- a/bot/admin/web/README.md
+++ b/bot/admin/web/README.md
@@ -37,6 +37,102 @@ To preview what the hook would replace without modifying any file:
 DRY_RUN=1 bash .git/hooks/pre-commit
 ```
 
+## Environment banner
+
+The Studio can display a banner indicating the current environment (e.g. `REC`,
+`STAGING`), so users can tell at a glance which instance they are working on. It
+is driven by a single runtime file, `src/assets/env-banner.json`, read once at
+application startup.
+
+A **neutral** version of this file is committed to the repository:
+
+```json
+{ "label": null, "_comment": "Set label to display an environment banner, e.g. 'REC'. Optional: color, textColor." }
+```
+
+With `label` unset, no banner is shown. This is the intended state for
+production and for any instance that should look "clean". Because the file is
+present and valid, no `404` request is emitted at startup.
+
+### Displaying a banner
+
+To show a banner on a given environment, serve an `env-banner.json` with a
+non-empty `label`:
+
+| Field       | Required | Description                                             |
+| ----------- | -------- | ------------------------------------------------------- |
+| `label`     | yes      | Text shown in the banner. `null` or absent = no banner. |
+| `color`     | no       | Background color (any CSS color). Defaults to amber.    |
+| `textColor` | no       | Text color. Auto-derived from `color` when omitted.     |
+
+Example:
+
+```json
+{ "label": "REC", "color": "#e2504f" }
+```
+
+A permanent 4px colored strip is also shown along the top of the window whenever
+a label is set. Unlike the diagonal banner, the strip cannot be dismissed — it
+guarantees the environment stays identifiable even after a user hides the
+banner for the current tab.
+
+### Configuring it per environment
+
+The Studio ships as a single, environment-agnostic build: the same artifact runs
+everywhere, and the banner is resolved **at runtime, not at build time**. The
+environment-specific file must therefore be injected **at deployment**, by
+overwriting `assets/env-banner.json` in the served files. The build itself is
+never specialized per environment.
+
+How you inject it depends on your deployment. Two common patterns:
+
+**Mounted file (Kubernetes / Docker volume)** — keep one image for all
+environments and mount a per-environment file over the asset. This preserves
+image promotion (the exact same image moves from one environment to the next):
+
+```yaml
+# ConfigMap, one per environment
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-env-banner
+data:
+  env-banner.json: |
+    { "label": "REC", "color": "#e2504f" }
+---
+# Mounted over the served asset in the Deployment
+volumeMounts:
+  - name: env-banner
+    mountPath: <web-root>/assets/env-banner.json
+    subPath: env-banner.json
+```
+
+**Container entrypoint** — write the file at startup from an environment
+variable. Environments that set nothing keep the committed neutral file:
+
+```sh
+# docker-entrypoint.sh
+if [ -n "$ENV_BANNER_LABEL" ]; then
+  printf '{"label":"%s","color":"%s"}' \
+    "$ENV_BANNER_LABEL" "${ENV_BANNER_COLOR:-#f2a900}" \
+    > <web-root>/assets/env-banner.json
+fi
+```
+
+In both cases, production simply injects nothing and keeps the neutral file.
+
+### Previewing locally
+
+Temporarily edit `src/assets/env-banner.json` to give it a label, or force one
+via the query string without touching the file:
+
+```
+http://localhost:4200/?env-banner=REC
+```
+
+The banner can be dismissed for the current tab using its close button; it
+reappears on the next session (new tab or window).
+
 ## Troubleshooting
 
 ### Windows setup

--- a/bot/admin/web/pom.xml
+++ b/bot/admin/web/pom.xml
@@ -15,7 +15,10 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -31,11 +34,14 @@
 
   <properties>
     <project.build.frontend.directory>${project.build.directory}/frontend</project.build.frontend.directory>
+    <env>UNDEFINED</env>
   </properties>
 
   <build>
     <sourceDirectory>src/main/kotlin</sourceDirectory>
+
     <plugins>
+
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
@@ -49,6 +55,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -67,10 +74,12 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
+
           <execution>
             <id>merge-bot-admin-sources</id>
             <phase>generate-resources</phase>
@@ -95,6 +104,7 @@
               <overwrite>true</overwrite>
             </configuration>
           </execution>
+
           <execution>
             <id>merge-tock-info</id>
             <phase>generate-resources</phase>
@@ -115,6 +125,27 @@
               <overwrite>true</overwrite>
             </configuration>
           </execution>
+
+        </executions>
+      </plugin>
+
+      <!-- Log the selected environment -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>log-build-environment</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <echo message="Build environment: ${env}"/>
+              </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 
@@ -125,6 +156,7 @@
           <workingDirectory>${project.build.frontend.directory}</workingDirectory>
         </configuration>
         <executions>
+
           <execution>
             <id>install node and npm</id>
             <phase>process-resources</phase>
@@ -135,6 +167,7 @@
               <nodeVersion>${node}</nodeVersion>
             </configuration>
           </execution>
+
           <execution>
             <id>npm ci</id>
             <phase>process-resources</phase>
@@ -145,6 +178,7 @@
               <arguments>ci -d --loglevel warn --force</arguments>
             </configuration>
           </execution>
+
           <execution>
             <id>npm run-script mavenbuild</id>
             <phase>compile</phase>
@@ -155,8 +189,10 @@
               <arguments>run-script mavenbuild --loglevel warn --force</arguments>
             </configuration>
           </execution>
+
         </executions>
       </plugin>
+
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
@@ -175,7 +211,58 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
+
+  <profiles>
+
+    <!--
+      REC environment:
+      overwrite the generated env-banner.json after the web sources
+      have been copied to the frontend build directory.
+    -->
+    <profile>
+      <id>rec</id>
+
+      <activation>
+        <property>
+          <name>env</name>
+          <value>REC</value>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>configure-rec-banner</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo message="REC environment detected: overwriting env-banner.json with REC banner"/>
+
+                    <echo
+                      file="${project.build.frontend.directory}/src/assets/env-banner.json"
+                      message='{ "label": "REC", "color": "#e2504f" }'
+                      encoding="UTF-8"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
 
 </project>

--- a/bot/admin/web/src/app/bot-admin-app.component.html
+++ b/bot/admin/web/src/app/bot-admin-app.component.html
@@ -18,3 +18,4 @@
   <nb-menu [items]="menu"></nb-menu>
   <router-outlet></router-outlet>
 </tock-one-column-layout>
+<tock-env-banner></tock-env-banner>

--- a/bot/admin/web/src/app/bot-admin-app.module.ts
+++ b/bot/admin/web/src/app/bot-admin-app.module.ts
@@ -40,33 +40,41 @@ import { BotService } from './bot/bot-service';
 import { BotAdminAppRoutingModule } from './bot-admin-app-routing.module';
 import { NlpService } from './core-nlp/nlp.service';
 import { TranslocoRootModule } from './transloco-root.module';
+import { EnvBannerComponent } from './shared/env-banner/env-banner.component';
 
-@NgModule({ declarations: [BotAdminAppComponent],
-    bootstrap: [BotAdminAppComponent], imports: [BrowserModule,
-        BrowserAnimationsModule,
-        CoreModule,
-        BotSharedModule,
-        BotCoreModule,
-        BotAdminAppRoutingModule,
-        ThemeModule.forRoot(),
-        NbSidebarModule.forRoot(),
-        NbMenuModule.forRoot(),
-        NbDatepickerModule.forRoot(),
-        NbTimepickerModule.forRoot(),
-        NbDialogModule.forRoot(),
-        NbWindowModule.forRoot(),
-        NbToastrModule.forRoot(),
-        NbThemeModule.forRoot({ name: 'default' }),
-        TranslocoRootModule], providers: [
-        {
-            provide: APP_BASE_HREF,
-            useFactory: (s: PlatformLocation) => s.getBaseHrefFromDOM(),
-            deps: [PlatformLocation]
-        },
-        BotService,
-        NlpService,
-        provideHttpClient(withInterceptorsFromDi())
-    ] })
+@NgModule({
+  declarations: [BotAdminAppComponent],
+  bootstrap: [BotAdminAppComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    CoreModule,
+    BotSharedModule,
+    BotCoreModule,
+    BotAdminAppRoutingModule,
+    ThemeModule.forRoot(),
+    NbSidebarModule.forRoot(),
+    NbMenuModule.forRoot(),
+    NbDatepickerModule.forRoot(),
+    NbTimepickerModule.forRoot(),
+    NbDialogModule.forRoot(),
+    NbWindowModule.forRoot(),
+    NbToastrModule.forRoot(),
+    NbThemeModule.forRoot({ name: 'default' }),
+    TranslocoRootModule,
+    EnvBannerComponent
+  ],
+  providers: [
+    {
+      provide: APP_BASE_HREF,
+      useFactory: (s: PlatformLocation) => s.getBaseHrefFromDOM(),
+      deps: [PlatformLocation]
+    },
+    BotService,
+    NlpService,
+    provideHttpClient(withInterceptorsFromDi())
+  ]
+})
 export class BotAdminAppModule {
   constructor(private iconLibraries: NbIconLibraries) {
     this.iconLibraries.registerFontPack('bootstrap-icons', { iconClassPrefix: 'bi' });

--- a/bot/admin/web/src/app/shared/env-banner/env-banner.component.scss
+++ b/bot/admin/web/src/app/shared/env-banner/env-banner.component.scss
@@ -1,0 +1,54 @@
+// src/app/shared/env-banner/env-banner.component.scss
+.env-banner__rule {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  z-index: 1040;
+  pointer-events: none;
+}
+
+.env-banner {
+  position: fixed;
+  left: -3.5rem;
+  bottom: 1.75rem;
+  width: 14rem;
+  z-index: 1030;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  padding: 0.35rem 0;
+  transform: rotate(45deg);
+  transform-origin: center;
+
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+
+  pointer-events: none;
+  user-select: none;
+
+  box-shadow: 0px 2px 7px #00000050;
+}
+
+.env-banner__close {
+  pointer-events: auto;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font-size: 0.7rem;
+  opacity: 0.6;
+
+  &:hover,
+  &:focus-visible {
+    opacity: 1;
+  }
+}

--- a/bot/admin/web/src/app/shared/env-banner/env-banner.component.ts
+++ b/bot/admin/web/src/app/shared/env-banner/env-banner.component.ts
@@ -1,0 +1,42 @@
+// src/app/shared/env-banner/env-banner.component.ts
+import { Component, inject } from '@angular/core';
+import { TranslocoModule } from '@jsverse/transloco';
+import { EnvBannerService } from './env-banner.service';
+
+@Component({
+  selector: 'tock-env-banner',
+  standalone: true,
+  imports: [TranslocoModule],
+  styleUrls: ['./env-banner.component.scss'],
+  template: `
+    @if (envBanner.label) {
+    <div
+      class="env-banner__rule"
+      [style.background]="envBanner.color"
+      aria-hidden="true"
+    ></div>
+
+    @if (envBanner.visible) {
+    <div
+      class="env-banner"
+      role="status"
+      [style.background]="envBanner.color"
+      [style.color]="envBanner.textColor"
+    >
+      <span class="env-banner__label">{{ envBanner.label }}</span>
+      <button
+        type="button"
+        class="env-banner__close"
+        [attr.aria-label]="'env-banner.hide' | transloco"
+        [title]="'env-banner.hide' | transloco"
+        (click)="envBanner.hide()"
+      >
+        <i class="bi bi-x-lg"></i>
+      </button>
+    </div>
+    } }
+  `
+})
+export class EnvBannerComponent {
+  readonly envBanner = inject(EnvBannerService);
+}

--- a/bot/admin/web/src/app/shared/env-banner/env-banner.model.ts
+++ b/bot/admin/web/src/app/shared/env-banner/env-banner.model.ts
@@ -1,0 +1,9 @@
+// src/app/shared/env-banner/env-banner.model.ts
+export interface EnvBannerConfig {
+  /** Free-form label displayed in the banner, e.g. 'REC', 'STAGING', 'QA-2'. */
+  label: string;
+  /** Optional background color. Defaults to amber. */
+  color?: string;
+  /** Optional text color. Auto-derived from `color` when omitted. */
+  textColor?: string;
+}

--- a/bot/admin/web/src/app/shared/env-banner/env-banner.service.ts
+++ b/bot/admin/web/src/app/shared/env-banner/env-banner.service.ts
@@ -1,0 +1,80 @@
+// src/app/shared/env-banner/env-banner.service.ts
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { EnvBannerConfig } from './env-banner.model';
+
+const CONFIG_URL = 'assets/env-banner.json';
+const STORAGE_KEY = 'tock-env-banner-hidden';
+const QUERY_PARAM = 'env-banner';
+const DEFAULT_COLOR = '#f2a900';
+
+@Injectable({ providedIn: 'root' })
+export class EnvBannerService {
+  private config: EnvBannerConfig | null = null;
+  private hidden = false;
+
+  /**
+   * Resolves the banner configuration at runtime.
+   * Order of precedence: query param override > runtime file > build-time default.
+   * A missing file, an empty label, or any fetch failure resolves to no banner.
+   */
+  async load(): Promise<void> {
+    const override = new URLSearchParams(location.search).get(QUERY_PARAM);
+
+    if (override) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      if (override.toLowerCase() !== 'show') {
+        this.config = { label: override.toUpperCase() };
+        return;
+      }
+    }
+
+    this.hidden = sessionStorage.getItem(STORAGE_KEY) === 'true';
+    this.config = (await this.fetchConfig()) ?? environment.envBanner ?? null;
+  }
+
+  private async fetchConfig(): Promise<EnvBannerConfig | null> {
+    try {
+      const response = await fetch(CONFIG_URL, { cache: 'no-store' });
+      if (!response.ok) return null;
+      // A SPA fallback returns index.html with a 200 status, so the status alone is not enough.
+      if (!response.headers.get('content-type')?.includes('json')) return null;
+
+      const config = (await response.json()) as EnvBannerConfig;
+      return config?.label ? config : null;
+    } catch {
+      return null;
+    }
+  }
+
+  get label(): string | null {
+    return this.config?.label ?? null;
+  }
+
+  get color(): string {
+    return this.config?.color ?? DEFAULT_COLOR;
+  }
+
+  get textColor(): string {
+    return this.config?.textColor ?? this.contrastOn(this.color);
+  }
+
+  get visible(): boolean {
+    return !!this.config && !this.hidden;
+  }
+
+  hide(): void {
+    this.hidden = true;
+    sessionStorage.setItem(STORAGE_KEY, 'true');
+  }
+
+  /** Picks a readable foreground color for an arbitrary background, using relative luminance. */
+  private contrastOn(background: string): string {
+    const hex = background.replace('#', '');
+    if (hex.length !== 6) return '#1a1a1a';
+
+    const [r, g, b] = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+    const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return luminance > 0.55 ? '#1a1a1a' : '#ffffff';
+  }
+}

--- a/bot/admin/web/src/assets/env-banner.json
+++ b/bot/admin/web/src/assets/env-banner.json
@@ -1,0 +1,1 @@
+{ "label": null, "_comment": "Set label to display an environment banner, e.g. 'REC'. Optional: color, textColor." }

--- a/bot/admin/web/src/assets/i18n/en.json
+++ b/bot/admin/web/src/assets/i18n/en.json
@@ -98,6 +98,7 @@
     "open-test-dialog": "Open a test dialog",
     "logout": "Logout"
   },
+  "env-banner": { "hide": "Hide environment indicator" },
   "menu": {
     "language-understanding": "Language Understanding",
     "stories-answers": "Stories & Answers",

--- a/bot/admin/web/src/assets/i18n/fr.json
+++ b/bot/admin/web/src/assets/i18n/fr.json
@@ -87,6 +87,7 @@
       "bot": "Bot"
     }
   },
+  "env-banner": { "hide": "Masquer l'indicateur d'environnement" },
   "header": {
     "interface-language": "Langue de l'interface",
     "theme-switch-light": "Passer en mode clair",

--- a/bot/admin/web/src/environments/environment.prod.ts
+++ b/bot/admin/web/src/environments/environment.prod.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+import { EnvBannerConfig } from '../app/shared/env-banner/env-banner.model';
+
 export const environment = {
   production: true,
   autologin: false,
   ssologin: false,
   default_user: '',
   default_password: '',
-  serverUrl: '/rest'
+  serverUrl: '/rest',
+  envBanner: null as EnvBannerConfig | null
 };

--- a/bot/admin/web/src/environments/environment.ts
+++ b/bot/admin/web/src/environments/environment.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { EnvBannerConfig } from '../app/shared/env-banner/env-banner.model';
+
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
@@ -25,5 +27,6 @@ export const environment = {
   ssologin: false,
   default_user: 'techadmin@app.com',
   default_password: 'password',
-  serverUrl: 'http://localhost:7999/rest'
+  serverUrl: 'http://localhost:7999/rest',
+  envBanner: { label: 'LOCAL', color: '#f2a900' } as EnvBannerConfig | null
 };

--- a/bot/admin/web/src/main.ts
+++ b/bot/admin/web/src/main.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
+import { enableProdMode, inject, provideAppInitializer, provideZoneChangeDetection } from '@angular/core';
 
 import { BotAdminAppModule } from './app/bot-admin-app.module';
 import { environment } from './environments/environment';
 import { platformBrowser } from '@angular/platform-browser';
+import { EnvBannerService } from './app/shared/env-banner/env-banner.service';
 
 if (environment.production) {
   enableProdMode();
 }
 
 platformBrowser()
-  .bootstrapModule(BotAdminAppModule, { applicationProviders: [provideZoneChangeDetection()] })
+  .bootstrapModule(BotAdminAppModule, {
+    applicationProviders: [provideZoneChangeDetection(), provideAppInitializer(() => inject(EnvBannerService).load())]
+  })
   .catch((err) => console.log(err));


### PR DESCRIPTION
## ⚠️ Merge order

**Do not merge before #2073 (chore/studio-angular-21).** This branch is stacked
on top of it and depends on the Angular 21 upgrade (notably
`provideAppInitializer`, introduced in Angular 19+).

## What

Adds an optional banner to the Studio indicating the current environment
(e.g. `REC`, `STAGING`), so users can tell at a glance which instance they
are working on. Nothing is shown in production by default.

The banner is made of two parts:
- a **diagonal ribbon** in the bottom-left corner, dismissable per browser tab;
- a permanent **4px colored strip** along the top of the window, which cannot
  be dismissed — so the environment stays identifiable even after the ribbon
  is hidden.

Placement was chosen to avoid overlapping existing UI: the header actions
(top-right), the back-to-top button (bottom-right), and the main menu (top and
left) are all left untouched.

## How

The banner is driven by a single runtime file, `src/assets/env-banner.json`,
read once at application startup via an app initializer. A **neutral** version
(`{ "label": null }`) is committed to the repository, so no `404` is emitted
when no banner is configured.

Resolution order: runtime file > build-time `environment.envBanner` default >
nothing. An empty or missing label resolves to no banner, meaning a
misconfiguration can never accidentally display a banner in production.

The Studio ships as a single, environment-agnostic build: the banner is
resolved **at runtime, not at build time**, so the environment-specific file
is injected at deployment by overwriting the served asset. This preserves
image promotion — the same artifact moves unchanged from one environment to
the next.

For local testing, a label can be forced via `?env-banner=REC` without
touching the file.

## Config

| Field       | Required | Description                                             |
| ----------- | -------- | ------------------------------------------------------- |
| `label`     | yes      | Text shown in the banner. `null` or absent = no banner. |
| `color`     | no       | Background color. Defaults to amber.                    |
| `textColor` | no       | Text color. Auto-derived from `color` when omitted.     |

Full documentation, including per-environment CI/deployment patterns
(Kubernetes ConfigMap, container entrypoint), is added to the Studio README.

## Notes

- New standalone component (`EnvBannerComponent`) + resolver service, mounted
  as a sibling of the layout in the root component.
- i18n keys added for the dismiss control (Transloco).
- No backend change, no new endpoint.

