### PR TITLE
feat(studio): add CSV import/export for datasets

### DIFF
--- a/bot/admin/web/package-lock.json
+++ b/bot/admin/web/package-lock.json
@@ -78,6 +78,7 @@
         "@types/jasminewd2": "^2.0.8",
         "@types/katex": "^0.16.7",
         "@types/node": "^20.0.0",
+        "@types/papaparse": "^5.5.2",
         "@typescript-eslint/eslint-plugin": "^8.66.0",
         "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0",
@@ -7189,6 +7190,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {

--- a/bot/admin/web/package.json
+++ b/bot/admin/web/package.json
@@ -87,6 +87,7 @@
     "@types/jasminewd2": "^2.0.8",
     "@types/katex": "^0.16.7",
     "@types/node": "^20.0.0",
+    "@types/papaparse": "^5.5.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",
     "@typescript-eslint/parser": "^8.66.0",
     "eslint": "^8.57.0",

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.html
@@ -180,20 +180,39 @@
     [ngClass]="{ 'justify-content-between': isEditMode }"
   >
     @if (isEditMode) {
-    <button
-      nbButton
-      ghost="true"
-      status="primary"
-      tabindex="-1"
-      [disabled]="isLoading"
-      (click)="exportDataset()"
-    >
-      <nb-icon
-        icon="download"
-        class="mr-2"
-      ></nb-icon>
-      {{ 'quality.dataset-create.export_dataset_button' | transloco }}
-    </button>
+    <div class="d-flex gap-05">
+      <button
+        nbButton
+        ghost="true"
+        status="primary"
+        tabindex="-1"
+        [disabled]="isLoading"
+        [nbTooltip]="'quality.dataset-create.export_json_tooltip' | transloco"
+        (click)="exportDataset('json')"
+      >
+        <nb-icon
+          icon="download"
+          class="mr-2"
+        ></nb-icon>
+        JSON
+      </button>
+
+      <button
+        nbButton
+        ghost="true"
+        status="primary"
+        tabindex="-1"
+        [disabled]="isLoading"
+        [nbTooltip]="'quality.dataset-create.export_csv_tooltip' | transloco"
+        (click)="exportDataset('csv')"
+      >
+        <nb-icon
+          icon="download"
+          class="mr-2"
+        ></nb-icon>
+        CSV
+      </button>
+    </div>
     }
 
     <div class="d-flex gap-1">

--- a/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-create/dataset-create.component.ts
@@ -8,6 +8,7 @@ import { DatasetsService } from '../services/datasets.service';
 import { getExportFileName } from '../../../shared/utils';
 import { saveAs } from 'file-saver-es';
 import { TranslocoService } from '@jsverse/transloco';
+import { questionsToCsv } from '../dataset-csv';
 
 interface QuestionForm {
   question: FormControl<string>;
@@ -20,15 +21,17 @@ interface DatasetForm {
   questions: FormArray<FormGroup<QuestionForm>>;
 }
 
+export type DatasetExportFormat = 'json' | 'csv';
+
 const question_minLength = 2;
 const question_maxLength = 1500;
 const groundtruth_maxLength = 1500;
 
 @Component({
-    selector: 'tock-dataset-create',
-    templateUrl: './dataset-create.component.html',
-    styleUrl: './dataset-create.component.scss',
-    standalone: false
+  selector: 'tock-dataset-create',
+  templateUrl: './dataset-create.component.html',
+  styleUrl: './dataset-create.component.scss',
+  standalone: false
 })
 export class DatasetCreateComponent implements OnInit, OnDestroy {
   private readonly destroy$: Subject<boolean> = new Subject();
@@ -273,22 +276,32 @@ export class DatasetCreateComponent implements OnInit, OnDestroy {
       });
   }
 
-  exportDataset(): void {
-    const dataStr = JSON.stringify({
-      name: this.form.controls.name.value,
-      description: this.form.controls.description.value,
-      questions: this._getFilledQuestions(true) // Omit question IDs in export since they are only relevant for diffing during updates
-    });
+  /**
+   * JSON exports the whole dataset. CSV exports questions only:
+   * name and description have no place in a flat two-column file.
+   */
+  exportDataset(format: DatasetExportFormat = 'json'): void {
+    // Question IDs are omitted in exports since they are only relevant for diffing during updates
+    const questions = this._getFilledQuestions(true);
+
+    const content =
+      format === 'json'
+        ? JSON.stringify({
+            name: this.form.controls.name.value,
+            description: this.form.controls.description.value,
+            questions
+          })
+        : questionsToCsv(questions);
 
     const exportFileName = getExportFileName(
       this.stateService.currentApplication.namespace,
       this.stateService.currentApplication.name,
       'dataset',
-      'json'
+      format
     );
 
-    const blob = new Blob([dataStr], {
-      type: 'application/json'
+    const blob = new Blob([content], {
+      type: format === 'json' ? 'application/json' : 'text/csv;charset=utf-8'
     });
 
     saveAs(blob, exportFileName);

--- a/bot/admin/web/src/app/quality/datatsets/dataset-csv.ts
+++ b/bot/admin/web/src/app/quality/datatsets/dataset-csv.ts
@@ -1,0 +1,71 @@
+import * as Papa from 'papaparse';
+
+export interface DatasetCsvQuestion {
+  question: string;
+  groundTruth: string;
+}
+
+export const DATASET_CSV_HEADERS = ['question', 'groundTruth'] as const;
+
+const BOM = '\uFEFF';
+const EXPORT_DELIMITER = ';';
+
+export type CsvParseErrorCode = 'EMPTY_FILE' | 'MISSING_QUESTION_COLUMN' | 'NO_VALID_ROW';
+
+export class CsvParseError extends Error {
+  constructor(public readonly code: CsvParseErrorCode) {
+    super(code);
+    // Required for `instanceof` to work when targeting ES5 downlevel output
+    Object.setPrototypeOf(this, CsvParseError.prototype);
+  }
+}
+
+/** Prevents CSV injection when the exported file is reopened in a spreadsheet. */
+function sanitizeCsvField(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
+export function questionsToCsv(questions: Partial<DatasetCsvQuestion>[], delimiter: string = EXPORT_DELIMITER): string {
+  const csv = Papa.unparse(
+    {
+      fields: [...DATASET_CSV_HEADERS],
+      data: questions.map((q) => [sanitizeCsvField(q.question ?? ''), sanitizeCsvField(q.groundTruth ?? '')])
+    },
+    { delimiter, newline: '\r\n', quotes: true }
+  );
+
+  return BOM + csv;
+}
+
+export function buildCsvTemplate(delimiter: string = EXPORT_DELIMITER): string {
+  return questionsToCsv([], delimiter);
+}
+
+export function csvToQuestions(content: string): DatasetCsvQuestion[] {
+  const result = Papa.parse<Record<string, string>>(content.replace(/^\uFEFF/, ''), {
+    header: true,
+    skipEmptyLines: 'greedy',
+    delimiter: '', // auto-detection (; , \t |) handled by Papa
+    transformHeader: (h) =>
+      h
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_-]/g, '')
+  });
+
+  if (!result.data.length && !result.meta.fields?.length) throw new CsvParseError('EMPTY_FILE');
+  if (!result.meta.fields?.includes('question')) throw new CsvParseError('MISSING_QUESTION_COLUMN');
+
+  const hasGroundTruth = result.meta.fields.includes('groundtruth');
+
+  const questions = result.data
+    .map((row) => ({
+      question: (row['question'] ?? '').trim(),
+      groundTruth: hasGroundTruth ? (row['groundtruth'] ?? '').trim() : ''
+    }))
+    .filter((q) => q.question.length);
+
+  if (!questions.length) throw new CsvParseError('NO_VALID_ROW');
+
+  return questions;
+}

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.html
@@ -135,9 +135,62 @@
             [autofocus]="true"
             [fullWidth]="true"
             [multiple]="false"
-            [fileTypeAccepted]="['json']"
+            [fileTypeAccepted]="['json', 'csv']"
           ></tock-file-upload>
         </tock-form-control>
+
+        <div class="d-flex justify-content-end mb-2">
+          <button
+            type="button"
+            nbButton
+            ghost
+            size="tiny"
+            [nbTooltip]="'quality.datasets-board.download_csv_template_tooltip' | transloco"
+            (click)="downloadCsvTemplate()"
+          >
+            <nb-icon
+              icon="filetype-csv"
+              class="mr-2"
+            ></nb-icon>
+            {{ 'quality.datasets-board.download_csv_template' | transloco }}
+          </button>
+        </div>
+
+        @if (isCsvImport) {
+        <tock-form-control
+          name="name"
+          [label]="'quality.datasets-board.dataset_name_label' | transloco"
+          [required]="true"
+          [controls]="importName"
+          [showError]="isImportSubmitted"
+        >
+          <nb-form-field>
+            <input
+              nbInput
+              fullWidth
+              formControlName="name"
+              [placeholder]="'quality.datasets-board.dataset_name_placeholder' | transloco"
+            />
+          </nb-form-field>
+        </tock-form-control>
+
+        <tock-form-control
+          name="description"
+          [label]="'quality.datasets-board.dataset_description_label' | transloco"
+          [controls]="importDescription"
+          [showError]="isImportSubmitted"
+        >
+          <nb-form-field>
+            <textarea
+              nbInput
+              fullWidth
+              rows="2"
+              formControlName="description"
+              [placeholder]="'quality.datasets-board.dataset_description_placeholder' | transloco"
+            ></textarea>
+          </nb-form-field>
+        </tock-form-control>
+        }
       </form>
     </nb-card-body>
 

--- a/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
+++ b/bot/admin/web/src/app/quality/datatsets/datasets-board/datasets-board.component.ts
@@ -11,15 +11,19 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { FileValidators } from '../../../shared/validators';
 import { readFileAsText } from '../../../shared/utils';
 import { TranslocoService } from '@jsverse/transloco';
+import { saveAs } from 'file-saver-es';
+import { buildCsvTemplate, csvToQuestions, CsvParseError } from '../dataset-csv';
 
 export type DatasetSortField = 'name' | 'questions' | 'runs' | 'lastRun';
 export type SortDirection = 'asc' | 'desc';
 
+type ImportableDataset = Parameters<DatasetsService['createDataset']>[0];
+
 @Component({
-    selector: 'tock-datasets-board',
-    templateUrl: './datasets-board.component.html',
-    styleUrl: './datasets-board.component.scss',
-    standalone: false
+  selector: 'tock-datasets-board',
+  templateUrl: './datasets-board.component.html',
+  styleUrl: './datasets-board.component.scss',
+  standalone: false
 })
 export class DatasetsBoardComponent implements OnInit, OnDestroy {
   destroy$: Subject<unknown> = new Subject();
@@ -51,11 +55,14 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
       this.configurations = confs;
       if (confs.length) this.fetchDatasets();
     });
+
+    // CSV files carry no name/description: those become required inputs in the modal.
+    this.fileSource.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this._syncImportMetadataValidators();
+    });
   }
 
   fetchDatasets(): void {
-    const { namespace, applicationId: botId } = this.configurations[0];
-
     this.datasetsService
       .getDatasets()
       .pipe(takeUntil(this.destroy$))
@@ -107,23 +114,17 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
     this.dialogService.openDialog(DatasetCreateComponent);
   }
 
+  // ---------------------------------------------------------------- Import
+
   importModalRef: NbDialogRef<any>;
-
-  importDataset(): void {
-    this.isImportSubmitted = false;
-    this.importForm.reset();
-    this.importModalRef = this.nbDialogService.open(this.importModal);
-  }
-
-  closeImportModal(): void {
-    this.importModalRef.close();
-  }
 
   importForm: FormGroup = new FormGroup({
     fileSource: new FormControl<File[]>([], {
       nonNullable: true,
-      validators: [Validators.required, FileValidators.mimeTypeSupported(['application/json'])]
-    })
+      validators: [Validators.required, FileValidators.extensionSupported(['json', 'csv'])]
+    }),
+    name: new FormControl<string>('', { nonNullable: true }),
+    description: new FormControl<string>('', { nonNullable: true })
   });
 
   isImportSubmitted: boolean = false;
@@ -132,91 +133,154 @@ export class DatasetsBoardComponent implements OnInit, OnDestroy {
     return this.importForm.get('fileSource') as FormControl;
   }
 
+  get importName(): FormControl {
+    return this.importForm.get('name') as FormControl;
+  }
+
+  get importDescription(): FormControl {
+    return this.importForm.get('description') as FormControl;
+  }
+
+  get importedFile(): File | undefined {
+    return this.fileSource.value?.[0];
+  }
+
+  get isCsvImport(): boolean {
+    return !!this.importedFile && /\.csv$/i.test(this.importedFile.name);
+  }
+
   get canSaveImport(): boolean {
     return this.isImportSubmitted ? this.importForm.valid : this.importForm.dirty;
   }
 
+  importDataset(): void {
+    this.isImportSubmitted = false;
+    this.importForm.reset();
+    this._syncImportMetadataValidators();
+    this.importModalRef = this.nbDialogService.open(this.importModal);
+  }
+
+  closeImportModal(): void {
+    this.importModalRef.close();
+  }
+
+  downloadCsvTemplate(): void {
+    const blob = new Blob([buildCsvTemplate()], { type: 'text/csv;charset=utf-8' });
+    saveAs(blob, 'dataset-template.csv');
+  }
+
+  private _syncImportMetadataValidators(): void {
+    if (this.isCsvImport) {
+      this.importName.setValidators([Validators.required, Validators.minLength(5), Validators.maxLength(100)]);
+      this.importDescription.setValidators([Validators.maxLength(750)]);
+
+      if (!this.importName.value) {
+        this.importName.setValue(this.importedFile.name.replace(/\.csv$/i, '').slice(0, 100), { emitEvent: false });
+      }
+    } else {
+      this.importName.clearValidators();
+      this.importDescription.clearValidators();
+    }
+
+    this.importName.updateValueAndValidity({ emitEvent: false });
+    this.importDescription.updateValueAndValidity({ emitEvent: false });
+  }
+
   submitImportDataset(): void {
     this.isImportSubmitted = true;
-    if (this.canSaveImport) {
-      this.loading = true;
+    if (!this.canSaveImport) return;
 
-      const file = this.fileSource.value[0];
+    this.loading = true;
 
-      readFileAsText(file).then((fileContent) => {
-        try {
-          const importedData = JSON.parse(fileContent.data);
+    readFileAsText(this.importedFile).then((fileContent) => {
+      try {
+        const newDataset = this.isCsvImport ? this._parseCsvImport(fileContent.data) : this._parseJsonImport(fileContent.data);
+        this._persistImportedDataset(newDataset);
+      } catch (e) {
+        this._toastImportError(e);
+        this.loading = false;
+      }
+    });
+  }
 
-          // JSON structure validation
-          if (
-            !importedData.name ||
-            typeof importedData.description !== 'string' ||
-            !Array.isArray(importedData.questions) ||
-            !importedData.questions.every(
-              (q: any) => typeof q.question === 'string' && typeof q.groundTruth === 'string' && q.question.trim() !== ''
-            )
-          ) {
-            this.toastrService.show(
-              this.transloco.translate('quality.datasets-board.invalid_dataset_format_message'),
-              this.transloco.translate('quality.datasets-board.invalid_dataset_format_title'),
-              {
-                duration: 8000,
-                status: 'danger'
-              }
-            );
-            this.loading = false;
-            return;
-          }
+  private _parseJsonImport(raw: string): ImportableDataset {
+    const importedData = JSON.parse(raw); // throws SyntaxError on malformed JSON
 
-          const newDataset: Pick<Dataset, 'name' | 'description' | 'questions'> = {
-            name: importedData.name,
-            description: importedData.description,
-            questions: importedData.questions.map((q: { question: string; groundTruth: string }) => ({
-              question: q.question,
-              groundTruth: q.groundTruth
-            }))
-          };
+    if (
+      !importedData.name ||
+      typeof importedData.description !== 'string' ||
+      !Array.isArray(importedData.questions) ||
+      !importedData.questions.every(
+        (q: any) => typeof q.question === 'string' && typeof q.groundTruth === 'string' && q.question.trim() !== ''
+      )
+    ) {
+      throw new TypeError('INVALID_DATASET_FORMAT');
+    }
 
-          this.datasetsService
-            .createDataset(newDataset)
-            .pipe(takeUntil(this.destroy$))
-            .subscribe({
-              next: (createdDataset) => {
-                this.toastrService.show(
-                  this.transloco.translate('quality.datasets-board.dataset_imported_success_message', { name: createdDataset.name }),
-                  this.transloco.translate('quality.datasets-board.success_title'),
-                  {
-                    duration: 4000,
-                    status: 'success'
-                  }
-                );
-                this.closeImportModal();
-                this.loading = false;
-              },
-              error: (err) => {
-                this.toastrService.show(
-                  this.transloco.translate('quality.datasets-board.dataset_import_failed_message', {
-                    error: err.message || this.transloco.translate('quality.datasets-board.unknown_error')
-                  }),
-                  this.transloco.translate('quality.datasets-board.error_title'),
-                  {
-                    duration: 6000,
-                    status: 'danger'
-                  }
-                );
-                this.loading = false;
-              }
-            });
-        } catch (e) {
+    return {
+      name: importedData.name,
+      description: importedData.description,
+      questions: importedData.questions.map((q: { question: string; groundTruth: string }) => ({
+        question: q.question,
+        groundTruth: q.groundTruth
+      }))
+    };
+  }
+
+  private _parseCsvImport(raw: string): ImportableDataset {
+    return {
+      name: this.importName.value.trim(),
+      description: this.importDescription.value?.trim() ?? '',
+      questions: csvToQuestions(raw) // throws CsvParseError
+    };
+  }
+
+  private _persistImportedDataset(newDataset: ImportableDataset): void {
+    this.datasetsService
+      .createDataset(newDataset)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (createdDataset) => {
           this.toastrService.show(
-            this.transloco.translate('quality.datasets-board.invalid_json_message'),
-            this.transloco.translate('quality.datasets-board.invalid_json_title'),
+            this.transloco.translate('quality.datasets-board.dataset_imported_success_message', { name: createdDataset.name }),
+            this.transloco.translate('quality.datasets-board.success_title'),
+            { duration: 4000, status: 'success' }
+          );
+          this.closeImportModal();
+          this.loading = false;
+        },
+        error: (err) => {
+          this.toastrService.show(
+            this.transloco.translate('quality.datasets-board.dataset_import_failed_message', {
+              error: err.message || this.transloco.translate('quality.datasets-board.unknown_error')
+            }),
+            this.transloco.translate('quality.datasets-board.error_title'),
             { duration: 6000, status: 'danger' }
           );
           this.loading = false;
         }
       });
+  }
+
+  private _toastImportError(e: unknown): void {
+    let messageKey: string;
+    let titleKey: string;
+
+    if (e instanceof CsvParseError) {
+      messageKey = `quality.datasets-board.csv_error_${e.code.toLowerCase()}`;
+      titleKey = 'quality.datasets-board.invalid_dataset_format_title';
+    } else if (e instanceof SyntaxError) {
+      messageKey = 'quality.datasets-board.invalid_json_message';
+      titleKey = 'quality.datasets-board.invalid_json_title';
+    } else {
+      messageKey = 'quality.datasets-board.invalid_dataset_format_message';
+      titleKey = 'quality.datasets-board.invalid_dataset_format_title';
     }
+
+    this.toastrService.show(this.transloco.translate(messageKey), this.transloco.translate(titleKey), {
+      duration: 6000,
+      status: 'danger'
+    });
   }
 
   ngOnDestroy(): void {

--- a/bot/admin/web/src/app/shared/validators/file-validators/file-validators.ts
+++ b/bot/admin/web/src/app/shared/validators/file-validators/file-validators.ts
@@ -40,4 +40,31 @@ export class FileValidators {
       return filesNameWithWrongType.length ? { filesNameWithWrongType } : null;
     };
   }
+
+  static extensionSupported(extensions: string[]): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      if (!Array.isArray(extensions) || !Array.isArray(control.value)) {
+        throw new TypeError('invalid argument. The parameter must be an array');
+      }
+
+      if (!extensions.length) {
+        throw new Error('the extensions parameter cannot be empty');
+      }
+
+      const normalized = extensions.map((e) => e.toLowerCase().replace(/^\./, ''));
+      const filesNameWithWrongType: string[] = [];
+
+      control.value.forEach((f: File) => {
+        if (!(f instanceof File)) {
+          throw new TypeError(`invalid arguments. ${f} must be a File object`);
+        }
+        const ext = f.name.split('.').pop()?.toLowerCase() ?? '';
+        if (!normalized.includes(ext)) {
+          filesNameWithWrongType.push(f.name);
+        }
+      });
+
+      return filesNameWithWrongType.length ? { filesNameWithWrongType } : null;
+    };
+  }
 }

--- a/bot/admin/web/src/assets/i18n/quality/en.json
+++ b/bot/admin/web/src/assets/i18n/quality/en.json
@@ -25,7 +25,16 @@
     "error_title": "Error",
     "invalid_json_message": "The file is not a valid JSON.",
     "invalid_json_title": "Invalid JSON",
-    "unknown_error": "Unknown error"
+    "unknown_error": "Unknown error",
+    "download_csv_template": "CSV template",
+    "download_csv_template_tooltip": "Download an empty CSV file with the expected columns",
+    "dataset_name_label": "Dataset name",
+    "dataset_name_placeholder": "Dataset name",
+    "dataset_description_label": "Description",
+    "dataset_description_placeholder": "Dataset description (optional)",
+    "csv_error_empty_file": "The CSV file is empty.",
+    "csv_error_missing_question_column": "No \"question\" column found. Use the CSV template offered in the import dialog.",
+    "csv_error_no_valid_row": "No valid question was found in the file."
   },
   "dataset-board-entry": {
     "show_questions_tooltip": "Show questions",
@@ -99,7 +108,9 @@
     "create_button": "CREATE",
     "at_least_one_question_required": "At least one question is required.",
     "an_error_occurred": "An error occured",
-    "error_title": "Error"
+    "error_title": "Error",
+    "export_json_tooltip": "Export the full dataset as JSON",
+    "export_csv_tooltip": "Export questions as CSV (name and description are not included)"
   },
   "sample-create-from-run": {
     "title": "New evaluation sample",

--- a/bot/admin/web/src/assets/i18n/quality/fr.json
+++ b/bot/admin/web/src/assets/i18n/quality/fr.json
@@ -25,7 +25,16 @@
     "error_title": "Erreur",
     "invalid_json_message": "Le fichier n'est pas un JSON valide.",
     "invalid_json_title": "JSON invalide",
-    "unknown_error": "Erreur inconnue"
+    "unknown_error": "Erreur inconnue",
+    "download_csv_template": "Modèle CSV",
+    "download_csv_template_tooltip": "Télécharger un fichier CSV vide avec les colonnes attendues",
+    "dataset_name_label": "Nom du dataset",
+    "dataset_name_placeholder": "Nom du dataset",
+    "dataset_description_label": "Description",
+    "dataset_description_placeholder": "Description du dataset (optionnelle)",
+    "csv_error_empty_file": "Le fichier CSV est vide.",
+    "csv_error_missing_question_column": "Colonne « question » introuvable. Utilisez le modèle CSV proposé dans la fenêtre d'import.",
+    "csv_error_no_valid_row": "Aucune question valide n'a été trouvée dans le fichier."
   },
   "dataset-board-entry": {
     "show_questions_tooltip": "Afficher les questions",
@@ -99,7 +108,9 @@
     "create_button": "CRÉER",
     "at_least_one_question_required": "Au moins une question est requise.",
     "an_error_occurred": "Une erreur est survenue",
-    "error_title": "Erreur"
+    "error_title": "Erreur",
+    "export_json_tooltip": "Exporter le dataset complet au format JSON",
+    "export_csv_tooltip": "Exporter les questions au format CSV (le nom et la description ne sont pas inclus)"
   },
   "sample-create-from-run": {
     "title": "Nouvel échantillon d'évaluation",


### PR DESCRIPTION
## ⚠️ Merge order
Do not merge before https://github.com/theopenconversationkit/tock/pull/2073 (chore/studio-angular-21). This branch is stacked on top of it and depends on its i18n implementation

## What

Extends the existing JSON import/export mechanism with CSV support, using the papaparse dependency already present in the studio.

## Changes

Export (dataset-create): the export button in edit mode now offers both JSON and CSV. JSON exports the full dataset; CSV exports questions only (question, groundTruth), since name and description have no place in a flat two-column file.

Import (datasets-board): the import dialog accepts .json and .csv. Because a CSV carries no name/description, those become required inputs shown only for CSV imports (name is pre-filled from the filename). A "download CSV template" button provides an empty file with the expected columns.

New dataset-csv.ts: pure, framework-free module wrapping papaparse — questionsToCsv, buildCsvTemplate, csvToQuestions, and a typed CsvParseError. Handles delimiter auto-detection on import (; , tab), UTF-8 BOM + ; on export for Excel FR compatibility, header normalization, and CSV-injection sanitization on export.

FileValidators.extensionSupported: new validator matching on file extension rather than MIME type. Aligns file validation with the upload widget's fileTypeAccepted (which already filters by extension) and avoids the unreliable CSV MIME reported across OSes.

## Notes
Fixed a latent typing issue surfaced by this work: the board's import path previously fed JSON.parse() output (typed any) to createDataset, silently bypassing type checking. The import payload type is now derived from the service signature.
Design choice: fixed CSV structure (question;groundTruth) rather than user-configurable column mapping — deliberate, to avoid overhead disproportionate to the need. The parser is structured to allow custom mapping later if required.
Client-side validators remain UX guards; actual content validation stays in csvToQuestions / JSON.parse and the backend.