### PR TITLE
[DERCBOT-1686] Google Chat Feedback feature

### DIFF
--- a/bot/connector-google-chat/README.md
+++ b/bot/connector-google-chat/README.md
@@ -54,6 +54,8 @@ Authentication Audience → Project Number
 | **Service account to impersonate** (optional) | `bot-sa@project.iam.gserviceaccount.com` |
 | **Use condensed footnotes** | `1` = condensed, `0` = detailed |
 | **Display sources without URL** | `1` = displayed, `0` = hidden |
+| **Enable feedback buttons** | `1` = enabled, `0` = disabled (default) |
+| **Feedback acknowledgement label** | Label displayed after a vote (default: `Feedback recorded`) |
 
 ---
 
@@ -94,6 +96,12 @@ The connector includes a converter that transforms standard Markdown into a simp
 ---
 
 ##  Bot Behavior
+
+### Feedback buttons
+
+When feedback is enabled, final bot answers include thumbs-up and thumbs-down buttons. The first vote is stored on the corresponding Tock action. The two buttons are then replaced with the selected button in a disabled state, preventing further changes from the Google Chat message.
+
+Waiting and introductory messages don't include feedback buttons.
 
 ###  Conversation Management
 

--- a/bot/connector-google-chat/README.md
+++ b/bot/connector-google-chat/README.md
@@ -21,7 +21,7 @@ If you use **service account impersonation**, the *source* service account must 
 
 |  Required Element |  Description |
 |---------------------|-----------------|
-| **Bot project number** | The numeric ID of your project (e.g., `37564789203`) |
+| **Authentication Audience** | The public HTTPS endpoint configured for the Google Chat app |
 | **JSON credentials** | Service account credentials file |
 | **(Optional) GSA to impersonate** | Email of the target service account if using impersonation |
 
@@ -33,7 +33,7 @@ If you use **service account impersonation**, the *source* service account must 
 
 ```
 HTTP endpoint URL       → https://your-ngrok-url.ngrok-free.app/io/app/assistant/google_chat
-Authentication Audience → Project Number
+Authentication Audience → HTTP endpoint URL
 ```
 
 ---
@@ -49,13 +49,12 @@ Authentication Audience → Project Number
 |-----------|-------------|
 | **Connector type** | `google_chat` |
 | **Application base URL** | `https://area-simple-teal.ngrok-free.app` |
-| **Bot project number** | `37564789203` |
+| **Authentication Audience** | `https://area-simple-teal.ngrok-free.app/io/app/assistant/google_chat` |
 | **Service account credential json content** | `{"type": "service_account", ...}` |
 | **Service account to impersonate** (optional) | `bot-sa@project.iam.gserviceaccount.com` |
 | **Use condensed footnotes** | `1` = condensed, `0` = detailed |
 | **Display sources without URL** | `1` = displayed, `0` = hidden |
 | **Enable feedback buttons** | `1` = enabled, `0` = disabled (default) |
-| **Feedback acknowledgement label** | Label displayed after a vote (default: `Feedback recorded`) |
 
 ---
 

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
@@ -34,6 +34,7 @@ import ai.tock.shared.Executor
 import ai.tock.shared.injector
 import com.github.salomonbrys.kodein.instance
 import com.google.api.services.chat.v1.HangoutsChat
+import com.google.api.services.chat.v1.model.Message
 import com.google.gson.Gson
 import com.google.gson.JsonObject
 import mu.KotlinLogging
@@ -50,6 +51,7 @@ class GoogleChatConnector(
     private val useThread: Boolean = false,
     private val sourcesLabel: String,
     private val waitingMessage: String,
+    private val feedback: GoogleChatFeedback? = null,
 ) : ConnectorBase(GoogleChatConnectorProvider.connectorType) {
     private val logger = KotlinLogging.logger {}
     private val executor: Executor by injector.instance()
@@ -75,45 +77,78 @@ class GoogleChatConnector(
                         val chatEvent: JsonObject = messageEvent.getAsJsonObject("chat")
 
                         // https://developers.google.com/workspace/add-ons/concepts/event-objects#chat-payload
-                        if (!chatEvent.has("messagePayload")) {
-                            logger.debug {
-                                "Only messagePayload is handled. Skipped events: " +
-                                    "AddedToSpacePayload, " +
-                                    "RemovedFromSpacePayload, " +
-                                    "ButtonClickedPayload, " +
-                                    "WidgetUpdatedPayload, " +
-                                    "AppCommandPayload."
-                            }
+                        if (chatEvent.has("messagePayload")) {
+                            handleMessage(chatEvent, controller)
+                        } else if (chatEvent.has("buttonClickedPayload") && feedback != null) {
+                            handleFeedback(messageEvent, chatEvent, controller)
                         } else {
-                            val message = chatEvent.getAsJsonObject("messagePayload").getAsJsonObject("message")
-                            val spaceName = message.getAsJsonObject("space").get("name").asString
-                            val threadName = message.getAsJsonObject("thread").get("name").asString
-
-                            val event = GoogleChatRequestConverter.toEvent(chatEvent, connectorId)
-                            executor.executeBlocking {
-                                val callback =
-                                    GoogleChatConnectorCallback(
-                                        connectorId,
-                                        spaceName,
-                                        threadName,
-                                        chatService,
-                                        introMessage,
-                                        useThread,
-                                        waitingMessage,
-                                    )
-
-                                callback.initializeProcessingMessage()
-
-                                controller.handle(
-                                    event,
-                                    ConnectorData(callback),
-                                )
+                            logger.debug {
+                                "Unsupported Google Chat event skipped. " +
+                                    "Feedback button events are handled only when feedback is enabled."
                             }
                         }
                     } catch (e: Throwable) {
                         logger.error(e) { "Error while handling Google Chat event" }
                     }
                 }
+        }
+    }
+
+    private fun handleMessage(
+        chatEvent: JsonObject,
+        controller: ConnectorController,
+    ) {
+        val message = chatEvent.getAsJsonObject("messagePayload").getAsJsonObject("message")
+        val spaceName = message.getAsJsonObject("space").get("name").asString
+        val threadName = message.getAsJsonObject("thread").get("name").asString
+        val event = GoogleChatRequestConverter.toEvent(chatEvent, connectorId)
+        executor.executeBlocking {
+            val callback =
+                GoogleChatConnectorCallback(
+                    connectorId,
+                    spaceName,
+                    threadName,
+                    chatService,
+                    introMessage,
+                    useThread,
+                    waitingMessage,
+                    feedback,
+                )
+
+            callback.initializeProcessingMessage()
+            controller.handle(event, ConnectorData(callback))
+        }
+    }
+
+    private fun handleFeedback(
+        messageEvent: JsonObject,
+        chatEvent: JsonObject,
+        controller: ConnectorController,
+    ) {
+        val request = GoogleChatRequestConverter.toFeedbackRequest(messageEvent, chatEvent, connectorId)
+        if (request == null) {
+            logger.debug { "Ignoring unsupported Google Chat button action" }
+            return
+        }
+
+        executor.executeBlocking {
+            controller.handle(request.event)
+            patchFeedbackAcknowledgement(request)
+        }
+    }
+
+    private fun patchFeedbackAcknowledgement(request: GoogleChatFeedbackRequest) {
+        try {
+            chatService
+                .spaces()
+                .messages()
+                .patch(
+                    request.messageName,
+                    Message().setAccessoryWidgets(feedback?.acknowledgement(request.vote)),
+                ).setUpdateMask("accessoryWidgets")
+                .execute()
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to acknowledge feedback on Google Chat message: ${request.messageName}" }
         }
     }
 
@@ -135,10 +170,10 @@ class GoogleChatConnector(
             val processingMessageName = callback.processingMessageName
 
             if (processingMessageName != null) {
-                callback.patchGoogleMessage(processingMessageName, message)
+                callback.patchGoogleMessage(processingMessageName, message, event.id.toString())
                 callback.processingMessageName = null
             } else {
-                callback.sendGoogleMessageAndGetName(message)
+                callback.sendGoogleMessageAndGetName(message, event.id.toString())
             }
         }
     }

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnector.kt
@@ -144,7 +144,7 @@ class GoogleChatConnector(
                 .messages()
                 .patch(
                     request.messageName,
-                    Message().setAccessoryWidgets(feedback?.acknowledgement(request.vote)),
+                    Message().setAccessoryWidgets(feedback?.acknowledgement(request.vote, request.event.actionId)),
                 ).setUpdateMask("accessoryWidgets")
                 .execute()
         } catch (e: Exception) {

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorCallback.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorCallback.kt
@@ -34,6 +34,7 @@ data class GoogleChatConnectorCallback(
     private val introMessage: String?,
     val useThread: Boolean,
     private val waitingMessage: String,
+    private val feedback: GoogleChatFeedback? = null,
 ) : ConnectorCallbackBase(applicationId, googleChatConnectorType) {
     private val logger = KotlinLogging.logger {}
     var processingMessageName: String? = null
@@ -84,10 +85,13 @@ data class GoogleChatConnectorCallback(
     /**
      * Sends message to the Google Chat space/thread.
      */
-    fun sendGoogleMessageAndGetName(message: GoogleChatConnectorMessage): String? {
+    fun sendGoogleMessageAndGetName(
+        message: GoogleChatConnectorMessage,
+        feedbackActionId: String? = null,
+    ): String? {
         var messageName: String? = null
         try {
-            val googleMessage = message.toGoogleMessage()
+            val googleMessage = message.toGoogleMessage().withFeedback(feedbackActionId)
             logger.debug { "Google Message content: $googleMessage" }
 
             if (useThread) {
@@ -126,15 +130,17 @@ data class GoogleChatConnectorCallback(
     fun patchGoogleMessage(
         messageName: String,
         message: GoogleChatConnectorMessage,
+        feedbackActionId: String? = null,
     ) {
         try {
+            val googleMessage = message.toGoogleMessage().withFeedback(feedbackActionId)
             chatService
                 .spaces()
                 .messages()
                 .patch(
                     messageName,
-                    message.toGoogleMessage(),
-                ).setUpdateMask("text")
+                    googleMessage,
+                ).setUpdateMask(if (googleMessage.accessoryWidgets == null) "text" else "text,accessoryWidgets")
                 .execute()
 
             logger.info {
@@ -146,4 +152,11 @@ data class GoogleChatConnectorCallback(
             }
         }
     }
+
+    private fun com.google.api.services.chat.v1.model.Message.withFeedback(actionId: String?) =
+        if (actionId == null || feedback == null) {
+            this
+        } else {
+            feedback.addButtons(this, actionId)
+        }
 }

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
@@ -49,6 +49,8 @@ private const val INTRO_MESSAGE_PARAMETER = "introMessage"
 private const val USE_THREAD_PARAMETER = "useThread"
 private const val SOURCES_LABEL_PARAMETER = "sourcesLabel"
 private const val WAITING_MESSAGE_PARAMETER = "waitingMessage"
+private const val ENABLE_FEEDBACK_PARAMETER = "enableFeedback"
+private const val FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER = "feedbackAcknowledgementLabel"
 
 // Lifetime (in seconds) of each impersonated access token.
 // This is the TTL of a single token, not a hard limit on the connector:
@@ -120,6 +122,19 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                     ?.takeIf { it.isNotBlank() }
                     ?: "\uD83D\uDCAD Thinking..."
 
+            val feedback =
+                if (connectorConfiguration.parameters[ENABLE_FEEDBACK_PARAMETER] == "1") {
+                    GoogleChatFeedback(
+                        callbackUrl = "${getBaseUrl().trimEnd('/')}/${path.trimStart('/')}",
+                        acknowledgementLabel =
+                            connectorConfiguration.parameters[FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER]
+                                ?.takeIf { it.isNotBlank() }
+                                ?: "Feedback recorded",
+                    )
+                } else {
+                    null
+                }
+
             return GoogleChatConnector(
                 connectorId,
                 path,
@@ -131,6 +146,7 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 useThread,
                 sourcesLabel,
                 waitingMessage,
+                feedback,
             )
         }
     }
@@ -240,6 +256,16 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                 ConnectorTypeConfigurationField(
                     "Waiting message",
                     WAITING_MESSAGE_PARAMETER,
+                    false,
+                ),
+                ConnectorTypeConfigurationField(
+                    "Enable feedback buttons (true = 1, false = 0)",
+                    ENABLE_FEEDBACK_PARAMETER,
+                    false,
+                ),
+                ConnectorTypeConfigurationField(
+                    "Feedback acknowledgement label",
+                    FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER,
                     false,
                 ),
             ),

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatConnectorProvider.kt
@@ -36,6 +36,7 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import mu.KotlinLogging
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.net.URI
 import kotlin.reflect.KClass
 
 private const val CHAT_SCOPE = "https://www.googleapis.com/auth/chat.bot"
@@ -50,7 +51,6 @@ private const val USE_THREAD_PARAMETER = "useThread"
 private const val SOURCES_LABEL_PARAMETER = "sourcesLabel"
 private const val WAITING_MESSAGE_PARAMETER = "waitingMessage"
 private const val ENABLE_FEEDBACK_PARAMETER = "enableFeedback"
-private const val FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER = "feedbackAcknowledgementLabel"
 
 // Lifetime (in seconds) of each impersonated access token.
 // This is the TTL of a single token, not a hard limit on the connector:
@@ -63,8 +63,24 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
 
     override val connectorType: ConnectorType get() = googleChatConnectorType
 
+    override fun check(connectorConfiguration: ConnectorConfiguration): List<String> =
+        super.check(connectorConfiguration) +
+            listOfNotNull(
+                if (
+                    connectorConfiguration.parameters[ENABLE_FEEDBACK_PARAMETER] == "1" &&
+                    !connectorConfiguration.parameters[AUTH_AUDIENCE_PARAMETER].isAbsoluteHttpsUrl()
+                ) {
+                    "Authentication Audience must be an absolute HTTPS URL when feedback buttons are enabled"
+                } else {
+                    null
+                },
+            )
+
     override fun connector(connectorConfiguration: ConnectorConfiguration): Connector {
         with(connectorConfiguration) {
+            val authenticationAudience =
+                connectorConfiguration.parameters[AUTH_AUDIENCE_PARAMETER]
+                    ?: error("Parameter Authentication Audience not present")
             val gsaToImpersonate = connectorConfiguration.parameters[GSA_TO_IMPERSONATE_PARAMETER]
 
             val credentials: GoogleCredentials =
@@ -101,10 +117,7 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                     .build()
 
             val authorisationHandler =
-                GoogleChatAuthorisationHandler(
-                    connectorConfiguration.parameters[AUTH_AUDIENCE_PARAMETER]
-                        ?: error("Parameter Authentication Audience not present"),
-                )
+                GoogleChatAuthorisationHandler(authenticationAudience)
 
             val introMessage =
                 connectorConfiguration.parameters[INTRO_MESSAGE_PARAMETER]?.takeIf { it.isNotBlank() }
@@ -124,13 +137,10 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
 
             val feedback =
                 if (connectorConfiguration.parameters[ENABLE_FEEDBACK_PARAMETER] == "1") {
-                    GoogleChatFeedback(
-                        callbackUrl = "${getBaseUrl().trimEnd('/')}/${path.trimStart('/')}",
-                        acknowledgementLabel =
-                            connectorConfiguration.parameters[FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER]
-                                ?.takeIf { it.isNotBlank() }
-                                ?: "Feedback recorded",
-                    )
+                    require(authenticationAudience.isAbsoluteHttpsUrl()) {
+                        "Authentication Audience must be an absolute HTTPS URL when feedback buttons are enabled"
+                    }
+                    GoogleChatFeedback(callbackUrl = authenticationAudience)
                 } else {
                     null
                 }
@@ -263,17 +273,17 @@ internal object GoogleChatConnectorProvider : ConnectorProvider {
                     ENABLE_FEEDBACK_PARAMETER,
                     false,
                 ),
-                ConnectorTypeConfigurationField(
-                    "Feedback acknowledgement label",
-                    FEEDBACK_ACKNOWLEDGEMENT_LABEL_PARAMETER,
-                    false,
-                ),
             ),
             svgIcon = resourceAsString("/google_chat.svg"),
         )
 
     override val supportedResponseConnectorMessageTypes: Set<KClass<out ConnectorMessage>> =
         setOf(GoogleChatConnectorTextMessageOut::class)
+
+    private fun String?.isAbsoluteHttpsUrl(): Boolean {
+        val uri = runCatching { URI(this ?: return false) }.getOrNull() ?: return false
+        return uri.isAbsolute && uri.scheme.equals("https", ignoreCase = true) && !uri.host.isNullOrBlank()
+    }
 }
 
 internal class GoogleChatConnectorProviderService : ConnectorProvider by GoogleChatConnectorProvider

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatFeedback.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatFeedback.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2017/2026 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.tock.bot.connector.googlechat
+
+import ai.tock.bot.engine.action.FeedbackVote
+import com.google.api.services.chat.v1.model.AccessoryWidget
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1Action
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1ActionParameter
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1Button
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1ButtonList
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1Icon
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1MaterialIcon
+import com.google.api.services.chat.v1.model.GoogleAppsCardV1OnClick
+import com.google.api.services.chat.v1.model.Message
+
+internal const val GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER = "TOCK_ACTION"
+internal const val GOOGLE_CHAT_FEEDBACK_ACTION_VALUE = "FEEDBACK"
+internal const val GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER = "TOCK_ACTION_ID"
+internal const val GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER = "TOCK_FEEDBACK_VOTE"
+
+class GoogleChatFeedback(
+    private val callbackUrl: String,
+    private val acknowledgementLabel: String,
+) {
+    fun addButtons(
+        message: Message,
+        actionId: String,
+    ): Message = message.setAccessoryWidgets(listOf(buttonsWidget(actionId)))
+
+    fun acknowledgement(vote: FeedbackVote): List<AccessoryWidget> =
+        listOf(
+            AccessoryWidget().setButtonList(
+                GoogleAppsCardV1ButtonList().setButtons(
+                    listOf(
+                        feedbackButton(
+                            vote = vote,
+                            actionId = null,
+                            text = acknowledgementLabel,
+                            disabled = true,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private fun buttonsWidget(actionId: String): AccessoryWidget =
+        AccessoryWidget().setButtonList(
+            GoogleAppsCardV1ButtonList().setButtons(
+                FeedbackVote.entries.map { feedbackButton(it, actionId) },
+            ),
+        )
+
+    private fun feedbackButton(
+        vote: FeedbackVote,
+        actionId: String?,
+        text: String? = null,
+        disabled: Boolean = false,
+    ): GoogleAppsCardV1Button {
+        val button =
+            GoogleAppsCardV1Button()
+                .setText(text)
+                .setAltText(vote.altText)
+                .setDisabled(disabled)
+                .setIcon(
+                    GoogleAppsCardV1Icon()
+                        .setAltText(vote.altText)
+                        .setMaterialIcon(GoogleAppsCardV1MaterialIcon().setName(vote.materialIcon)),
+                )
+
+        if (actionId != null) {
+            button.setOnClick(
+                GoogleAppsCardV1OnClick().setAction(
+                    GoogleAppsCardV1Action()
+                        .setFunction(callbackUrl)
+                        .setLoadIndicator("SPINNER")
+                        .setParameters(
+                            listOf(
+                                actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER, GOOGLE_CHAT_FEEDBACK_ACTION_VALUE),
+                                actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER, actionId),
+                                actionParameter(GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER, vote.name),
+                            ),
+                        ),
+                ),
+            )
+        }
+        return button
+    }
+
+    private fun actionParameter(
+        key: String,
+        value: String,
+    ): GoogleAppsCardV1ActionParameter = GoogleAppsCardV1ActionParameter().setKey(key).setValue(value)
+
+    private val FeedbackVote.materialIcon: String
+        get() =
+            when (this) {
+                FeedbackVote.UP -> "thumb_up"
+                FeedbackVote.DOWN -> "thumb_down"
+            }
+
+    private val FeedbackVote.altText: String
+        get() =
+            when (this) {
+                FeedbackVote.UP -> "Helpful answer"
+                FeedbackVote.DOWN -> "Unhelpful answer"
+            }
+}

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatFeedback.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatFeedback.kt
@@ -33,22 +33,23 @@ internal const val GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER = "TOCK_FEEDBACK_VOTE"
 
 class GoogleChatFeedback(
     private val callbackUrl: String,
-    private val acknowledgementLabel: String,
 ) {
     fun addButtons(
         message: Message,
         actionId: String,
     ): Message = message.setAccessoryWidgets(listOf(buttonsWidget(actionId)))
 
-    fun acknowledgement(vote: FeedbackVote): List<AccessoryWidget> =
+    fun acknowledgement(
+        vote: FeedbackVote,
+        actionId: String,
+    ): List<AccessoryWidget> =
         listOf(
             AccessoryWidget().setButtonList(
                 GoogleAppsCardV1ButtonList().setButtons(
                     listOf(
                         feedbackButton(
                             vote = vote,
-                            actionId = null,
-                            text = acknowledgementLabel,
+                            actionId = actionId,
                             disabled = true,
                         ),
                     ),
@@ -65,13 +66,11 @@ class GoogleChatFeedback(
 
     private fun feedbackButton(
         vote: FeedbackVote,
-        actionId: String?,
-        text: String? = null,
+        actionId: String,
         disabled: Boolean = false,
     ): GoogleAppsCardV1Button {
         val button =
             GoogleAppsCardV1Button()
-                .setText(text)
                 .setAltText(vote.altText)
                 .setDisabled(disabled)
                 .setIcon(
@@ -80,23 +79,20 @@ class GoogleChatFeedback(
                         .setMaterialIcon(GoogleAppsCardV1MaterialIcon().setName(vote.materialIcon)),
                 )
 
-        if (actionId != null) {
-            button.setOnClick(
-                GoogleAppsCardV1OnClick().setAction(
-                    GoogleAppsCardV1Action()
-                        .setFunction(callbackUrl)
-                        .setLoadIndicator("SPINNER")
-                        .setParameters(
-                            listOf(
-                                actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER, GOOGLE_CHAT_FEEDBACK_ACTION_VALUE),
-                                actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER, actionId),
-                                actionParameter(GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER, vote.name),
-                            ),
+        return button.setOnClick(
+            GoogleAppsCardV1OnClick().setAction(
+                GoogleAppsCardV1Action()
+                    .setFunction(callbackUrl)
+                    .setLoadIndicator("SPINNER")
+                    .setParameters(
+                        listOf(
+                            actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER, GOOGLE_CHAT_FEEDBACK_ACTION_VALUE),
+                            actionParameter(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER, actionId),
+                            actionParameter(GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER, vote.name),
                         ),
-                ),
-            )
-        }
-        return button
+                    ),
+            ),
+        )
     }
 
     private fun actionParameter(

--- a/bot/connector-google-chat/src/main/kotlin/GoogleChatRequestConverter.kt
+++ b/bot/connector-google-chat/src/main/kotlin/GoogleChatRequestConverter.kt
@@ -15,8 +15,11 @@
  */
 package ai.tock.bot.connector.googlechat
 
+import ai.tock.bot.engine.action.ActionFeedback
+import ai.tock.bot.engine.action.FeedbackVote
 import ai.tock.bot.engine.action.SendSentence
 import ai.tock.bot.engine.event.Event
+import ai.tock.bot.engine.event.FeedbackEvent
 import ai.tock.bot.engine.user.PlayerId
 import ai.tock.bot.engine.user.PlayerType
 import com.google.gson.JsonObject
@@ -38,4 +41,50 @@ internal object GoogleChatRequestConverter {
         val botId = PlayerId(applicationId, PlayerType.bot)
         return SendSentence(playerId, applicationId, botId, text)
     }
+
+    fun toFeedbackRequest(
+        messageEvent: JsonObject,
+        chatEvent: JsonObject,
+        applicationId: String,
+    ): GoogleChatFeedbackRequest? {
+        val parameters =
+            messageEvent
+                .getAsJsonObject("commonEventObject")
+                ?.getAsJsonObject("parameters")
+                ?: return null
+        if (parameters.string(GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER) != GOOGLE_CHAT_FEEDBACK_ACTION_VALUE) return null
+
+        val actionId = parameters.string(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER)?.takeIf { it.isNotBlank() } ?: return null
+        val vote =
+            parameters
+                .string(GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER)
+                ?.let { value -> FeedbackVote.entries.firstOrNull { it.name == value } }
+                ?: return null
+        val userId = chatEvent.getAsJsonObject("user")?.string("name") ?: return null
+        val messageName =
+            chatEvent
+                .getAsJsonObject("buttonClickedPayload")
+                ?.getAsJsonObject("message")
+                ?.string("name")
+                ?: return null
+
+        val event =
+            FeedbackEvent(
+                userId = PlayerId(userId),
+                recipientId = PlayerId(applicationId, PlayerType.bot),
+                applicationId = applicationId,
+                actionId = actionId,
+                feedback = ActionFeedback(vote),
+            ).apply { replaceExisting = false }
+
+        return GoogleChatFeedbackRequest(event, messageName, vote)
+    }
+
+    private fun JsonObject.string(name: String): String? = get(name)?.takeUnless { it.isJsonNull }?.asString
 }
+
+internal data class GoogleChatFeedbackRequest(
+    val event: FeedbackEvent,
+    val messageName: String,
+    val vote: FeedbackVote,
+)

--- a/bot/connector-google-chat/src/test/kotlin/GoogleChatFeedbackTest.kt
+++ b/bot/connector-google-chat/src/test/kotlin/GoogleChatFeedbackTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2017/2026 SNCF Connect & Tech
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ai.tock.bot.connector.googlechat
+
+import ai.tock.bot.engine.action.FeedbackVote
+import com.google.api.services.chat.v1.model.Message
+import com.google.gson.JsonParser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class GoogleChatFeedbackTest {
+    private val feedback = GoogleChatFeedback("https://example.com/google-chat", "Feedback recorded")
+
+    @Test
+    fun `should append up and down feedback buttons to a message`() {
+        val message = feedback.addButtons(Message().setText("Answer"), "action-123")
+
+        assertThat(message.text).isEqualTo("Answer")
+        val buttons =
+            message.accessoryWidgets
+                .single()
+                .buttonList.buttons
+        assertThat(buttons).hasSize(2)
+        assertThat(buttons.map { it.icon.materialIcon.name }).containsExactly("thumb_up", "thumb_down")
+        assertThat(buttons).allSatisfy { button ->
+            assertThat(button.disabled).isFalse()
+            assertThat(button.onClick.action.function).isEqualTo("https://example.com/google-chat")
+            assertThat(button.onClick.action.loadIndicator).isEqualTo("SPINNER")
+            assertThat(
+                button.onClick.action.parameters
+                    .associate { it.key to it.value },
+            ).containsEntry(GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER, GOOGLE_CHAT_FEEDBACK_ACTION_VALUE)
+                .containsEntry(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER, "action-123")
+        }
+        assertThat(
+            buttons.map {
+                it.onClick.action.parameters
+                    .last()
+                    .value
+            },
+        ).containsExactly("UP", "DOWN")
+    }
+
+    @Test
+    fun `should replace feedback buttons with a disabled acknowledgement`() {
+        val button =
+            feedback
+                .acknowledgement(FeedbackVote.DOWN)
+                .single()
+                .buttonList.buttons
+                .single()
+
+        assertThat(button.disabled).isTrue()
+        assertThat(button.text).isEqualTo("Feedback recorded")
+        assertThat(button.icon.materialIcon.name).isEqualTo("thumb_down")
+        assertThat(button.onClick).isNull()
+    }
+
+    @Test
+    fun `should convert a feedback button event`() {
+        val messageEvent =
+            JsonParser
+                .parseString(
+                    """
+                    {
+                      "commonEventObject": {
+                        "parameters": {
+                          "$GOOGLE_CHAT_FEEDBACK_ACTION_PARAMETER": "$GOOGLE_CHAT_FEEDBACK_ACTION_VALUE",
+                          "$GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER": "action-123",
+                          "$GOOGLE_CHAT_FEEDBACK_VOTE_PARAMETER": "UP"
+                        }
+                      },
+                      "chat": {
+                        "user": { "name": "users/user-123" },
+                        "buttonClickedPayload": {
+                          "message": { "name": "spaces/space-123/messages/message-123" }
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ).asJsonObject
+        val request =
+            GoogleChatRequestConverter.toFeedbackRequest(
+                messageEvent,
+                messageEvent.getAsJsonObject("chat"),
+                "connector-id",
+            )
+
+        assertThat(request).isNotNull
+        assertThat(request!!.messageName).isEqualTo("spaces/space-123/messages/message-123")
+        assertThat(request.vote).isEqualTo(FeedbackVote.UP)
+        assertThat(request.event.userId.id).isEqualTo("users/user-123")
+        assertThat(request.event.actionId).isEqualTo("action-123")
+        assertThat(request.event.feedback?.vote).isEqualTo(FeedbackVote.UP)
+        assertThat(request.event.replaceExisting).isFalse()
+    }
+
+    @Test
+    fun `should ignore an unsupported button event`() {
+        val messageEvent =
+            JsonParser
+                .parseString(
+                    """
+                    {
+                      "commonEventObject": { "parameters": { "action": "other" } },
+                      "chat": {
+                        "user": { "name": "users/user-123" },
+                        "buttonClickedPayload": {
+                          "message": { "name": "spaces/space-123/messages/message-123" }
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ).asJsonObject
+
+        assertThat(
+            GoogleChatRequestConverter.toFeedbackRequest(
+                messageEvent,
+                messageEvent.getAsJsonObject("chat"),
+                "connector-id",
+            ),
+        ).isNull()
+    }
+}

--- a/bot/connector-google-chat/src/test/kotlin/GoogleChatFeedbackTest.kt
+++ b/bot/connector-google-chat/src/test/kotlin/GoogleChatFeedbackTest.kt
@@ -15,6 +15,7 @@
  */
 package ai.tock.bot.connector.googlechat
 
+import ai.tock.bot.connector.ConnectorConfiguration
 import ai.tock.bot.engine.action.FeedbackVote
 import com.google.api.services.chat.v1.model.Message
 import com.google.gson.JsonParser
@@ -22,7 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class GoogleChatFeedbackTest {
-    private val feedback = GoogleChatFeedback("https://example.com/google-chat", "Feedback recorded")
+    private val feedback = GoogleChatFeedback("https://example.com/google-chat")
 
     @Test
     fun `should append up and down feedback buttons to a message`() {
@@ -58,15 +59,54 @@ internal class GoogleChatFeedbackTest {
     fun `should replace feedback buttons with a disabled acknowledgement`() {
         val button =
             feedback
-                .acknowledgement(FeedbackVote.DOWN)
+                .acknowledgement(FeedbackVote.DOWN, "action-123")
                 .single()
                 .buttonList.buttons
                 .single()
 
         assertThat(button.disabled).isTrue()
-        assertThat(button.text).isEqualTo("Feedback recorded")
+        assertThat(button.text).isNull()
         assertThat(button.icon.materialIcon.name).isEqualTo("thumb_down")
-        assertThat(button.onClick).isNull()
+        assertThat(button.onClick.action.function).isEqualTo("https://example.com/google-chat")
+        val parameters =
+            button.onClick.action.parameters
+                .associate { it.key to it.value }
+        assertThat(parameters).containsEntry(GOOGLE_CHAT_FEEDBACK_ACTION_ID_PARAMETER, "action-123")
+    }
+
+    @Test
+    fun `should require an HTTPS authentication audience when feedback is enabled`() {
+        val configuration =
+            ConnectorConfiguration(
+                connectorId = "connector-id",
+                path = "/google-chat",
+                type = GoogleChatConnectorProvider.connectorType,
+                parameters =
+                    mapOf(
+                        "authenticationAudience" to "123456789",
+                        "enableFeedback" to "1",
+                    ),
+            )
+
+        assertThat(GoogleChatConnectorProvider.check(configuration))
+            .contains("Authentication Audience must be an absolute HTTPS URL when feedback buttons are enabled")
+    }
+
+    @Test
+    fun `should accept an HTTPS authentication audience when feedback is enabled`() {
+        val configuration =
+            ConnectorConfiguration(
+                connectorId = "connector-id",
+                path = "/google-chat",
+                type = GoogleChatConnectorProvider.connectorType,
+                parameters =
+                    mapOf(
+                        "authenticationAudience" to "https://example.com/google-chat",
+                        "enableFeedback" to "1",
+                    ),
+            )
+
+        assertThat(GoogleChatConnectorProvider.check(configuration)).isEmpty()
     }
 
     @Test

--- a/bot/engine/src/main/kotlin/definition/EventListenerBase.kt
+++ b/bot/engine/src/main/kotlin/definition/EventListenerBase.kt
@@ -108,9 +108,11 @@ open class EventListenerBase : EventListener {
                         ?.allActions()
                         ?.firstOrNull { it.id.toString() == event.actionId && PlayerType.bot == it.playerId.type }
 
-                if (action != null) {
+                if (action != null && (event.replaceExisting || action.metadata.feedback == null)) {
                     action.metadata.feedback = event.feedback
                     userTimelineDAO.save(timeline, controller.botDefinition)
+                } else if (action != null) {
+                    logger.debug("Feedback ignored: action ${event.actionId} already has feedback.")
                 } else {
                     logger.warn("Feedback ignored: no action found with id ${event.actionId} in the current dialog.")
                 }

--- a/bot/engine/src/main/kotlin/definition/EventListenerBase.kt
+++ b/bot/engine/src/main/kotlin/definition/EventListenerBase.kt
@@ -117,7 +117,7 @@ open class EventListenerBase : EventListener {
                     logger.warn("Feedback ignored: no action found with id ${event.actionId} in the current dialog.")
                 }
             }
-            return false
+            return true
         }
     }
 

--- a/bot/engine/src/main/kotlin/engine/event/FeedbackEvent.kt
+++ b/bot/engine/src/main/kotlin/engine/event/FeedbackEvent.kt
@@ -29,5 +29,7 @@ class FeedbackEvent(
     val actionId: String,
     val feedback: ActionFeedback? = null,
 ) : OneToOneEvent(userId, recipientId, applicationId) {
+    /** Whether this event can replace feedback already stored on the action. */
+    var replaceExisting: Boolean = true
     override fun toString(): String = "Feedback=$feedback to $actionId"
 }

--- a/bot/engine/src/main/kotlin/engine/event/FeedbackEvent.kt
+++ b/bot/engine/src/main/kotlin/engine/event/FeedbackEvent.kt
@@ -31,5 +31,6 @@ class FeedbackEvent(
 ) : OneToOneEvent(userId, recipientId, applicationId) {
     /** Whether this event can replace feedback already stored on the action. */
     var replaceExisting: Boolean = true
+
     override fun toString(): String = "Feedback=$feedback to $actionId"
 }


### PR DESCRIPTION
### Goal

Allow users to rate Google Chat bot answers with a thumbs-up or thumbs-down button, without polling or Pub/Sub subscriptions.

### Details

- Add optional thumbs-up and thumbs-down accessory buttons to Google Chat bot answers
- Handle button click events directly through the existing connector endpoint
- Store the selected vote using Tock's existing action feedback mechanism
- Replace both feedback buttons with the selected option in a disabled state after the first vote
- Prevent later clicks from replacing an existing Google Chat feedback
- Keep feedback disabled by default to preserve the current connector behavior
- Exclude waiting and introductory messages from feedback
- Add connector configuration, documentation, and unit tests